### PR TITLE
Preflight hardening: unborn-HEAD gate, deferred affects-revisit, and why/remedy failure messages

### DIFF
--- a/openspec/changes/build-copperhead-phase-1/specs/agent-core/spec.md
+++ b/openspec/changes/build-copperhead-phase-1/specs/agent-core/spec.md
@@ -47,7 +47,7 @@ The system prompt SHALL include the verbatim rules of SPEC.md §4.3, the `budget
 - **THEN** the agent refuses or proposes an alternative, citing the budget from SPEC.md, and does not silently comply
 
 ### Requirement: Sync obligations block commit
-The loop SHALL maintain an obligations ledger fed by deterministic post-tool-call hooks: editing a KiCad file records ERC/DRC, drift-check, and changelog obligations; recording a constraint records dual-write verification and a revisit obligation for every item in its `affects[]`; a non-trivial decision records a `docs/DECISIONS.md` append obligation. The commit step SHALL refuse to run while any obligation is open, and the ledger's final state SHALL be written into the run's `summary.md`.
+The loop SHALL maintain an obligations ledger fed by deterministic post-tool-call hooks: editing a KiCad file records ERC/DRC, drift-check, and changelog obligations; recording a constraint records dual-write verification and a revisit obligation for every item in its `affects[]` whose target artifact exists — an item targeting a not-yet-built artifact (schematic, board, BOM before their pipeline stage) is marked `deferred` in the registry instead and re-opens at the start of the first run where the artifact exists; a non-trivial decision records a `docs/DECISIONS.md` append obligation. The commit step SHALL refuse to run while any obligation is open, and the ledger's final state SHALL be written into the run's `summary.md`.
 
 #### Scenario: Stale doc blocks commit
 - **WHEN** a run edits a schematic value referenced by BOM.md but has not yet updated the doc
@@ -56,6 +56,10 @@ The loop SHALL maintain an obligations ledger fed by deterministic post-tool-cal
 #### Scenario: Constraint change forces affects revisit
 - **WHEN** a constraint with `affects: ["U2", "R7-absent"]` is modified during a run
 - **THEN** the run cannot commit until each affected item is explicitly resolved as changed or "no change needed" with a reason
+
+#### Scenario: Deferred revisit for unbuilt artifacts
+- **WHEN** a docs-only stage records a constraint with `affects: ["layout", "R1"]` before any board exists
+- **THEN** only the R1 revisit obligation opens now; the layout item is marked deferred and its obligation re-opens automatically at the start of the first run where a board is configured
 
 #### Scenario: Aborted run shows open obligations
 - **WHEN** a run fails or is aborted with obligations open

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -208,6 +208,8 @@ The agent maintains `.copperhead/constraints.json` — a live, machine-readable 
 
 Loaded into every run's system prompt; `check` validates the design against it mechanically where possible (leakage sums, keepout geometry, forbidden pins). The `affects` field is what makes propagation reliable — change a constraint and the agent knows exactly which parts to revisit.
 
+An `affects` item that targets an artifact that does not exist yet (schematic, board, or BOM recorded before their pipeline stage) opens no revisit obligation at record time — it is marked `deferred` in the registry instead, and the obligation re-opens automatically at the start of the first run where the artifact exists. This keeps early docs-only stages from burning turns on ceremonial "not yet created" resolutions without losing the reconciliation guarantee: the revisit still happens, at the moment it can actually change the design.
+
 ### Change workflow (OpenSpec propose → apply → archive)
 
 - `copperhead do "<request>"` first generates `openspec/changes/<id>/` (proposal.md, spec deltas, tasks.md), then implements against it; the ERC/DRC-clean commit archives the change. Every hardware change gets a paper trail: *why → what spec changed → what files changed → verification result*

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -8,7 +8,7 @@ import { loadConstraints, reopenDeferredAffects } from '../memory/constraints.js
 import { loadConfig, type CopperheadConfig } from '../config.js';
 import { Transcript } from './transcript.js';
 import { ObligationsLedger } from './ledger.js';
-import { isDirty, isGitRepo, hasCommits, snapshot, restore, commitAll, changedFiles } from '../util/git.js';
+import { gitPreflight, isDirty, snapshot, restore, commitAll, changedFiles } from '../util/git.js';
 import { withRetry, isRateLimit } from '../util/retry.js';
 import { openspecArchive } from '../openspec/cli.js';
 import { existsSync } from 'node:fs';
@@ -105,17 +105,7 @@ async function runWithMemory(opts: RunOptions, memory: SynapMemory | null): Prom
   const config = await loadConfig(repoRoot);
   const maxTurns = opts.maxTurns ?? config.maxTurns;
 
-  if (!(await isGitRepo(repoRoot))) {
-    throw new Error('not a git repository; copperhead requires git for snapshots and rollback');
-  }
-  if (!(await hasCommits(repoRoot))) {
-    throw new Error(
-      'repository has no commits; copperhead requires at least one commit for snapshots and rollback — run "git add -A && git commit -m \'initial commit\'" first',
-    );
-  }
-  if ((await isDirty(repoRoot)) && !opts.allowDirty) {
-    throw new Error('working tree is dirty; commit your changes or pass --allow-dirty (snapshots via git stash create)');
-  }
+  await gitPreflight(repoRoot, { allowDirty: opts.allowDirty ?? false });
   const snap = await snapshot(repoRoot);
 
   const transcript = new Transcript(repoRoot);

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -8,7 +8,7 @@ import { loadConstraints } from '../memory/constraints.js';
 import { loadConfig, type CopperheadConfig } from '../config.js';
 import { Transcript } from './transcript.js';
 import { ObligationsLedger } from './ledger.js';
-import { isDirty, isGitRepo, snapshot, restore, commitAll, changedFiles } from '../util/git.js';
+import { isDirty, isGitRepo, hasCommits, snapshot, restore, commitAll, changedFiles } from '../util/git.js';
 import { withRetry, isRateLimit } from '../util/retry.js';
 import { openspecArchive } from '../openspec/cli.js';
 import { existsSync } from 'node:fs';
@@ -107,6 +107,11 @@ async function runWithMemory(opts: RunOptions, memory: SynapMemory | null): Prom
 
   if (!(await isGitRepo(repoRoot))) {
     throw new Error('not a git repository; copperhead requires git for snapshots and rollback');
+  }
+  if (!(await hasCommits(repoRoot))) {
+    throw new Error(
+      'repository has no commits; copperhead requires at least one commit for snapshots and rollback — run "git add -A && git commit -m \'initial commit\'" first',
+    );
   }
   if ((await isDirty(repoRoot)) && !opts.allowDirty) {
     throw new Error('working tree is dirty; commit your changes or pass --allow-dirty (snapshots via git stash create)');

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -4,7 +4,7 @@ import { execa } from 'execa';
 import type { Msg, Provider, Turn } from './types.js';
 import { availableTools, dispatchTool, type RunContext } from './tools.js';
 import { buildSystemPrompt } from './prompts.js';
-import { loadConstraints } from '../memory/constraints.js';
+import { loadConstraints, reopenDeferredAffects } from '../memory/constraints.js';
 import { loadConfig, type CopperheadConfig } from '../config.js';
 import { Transcript } from './transcript.js';
 import { ObligationsLedger } from './ledger.js';
@@ -140,8 +140,29 @@ async function runWithMemory(opts: RunOptions, memory: SynapMemory | null): Prom
   };
 
   let provider = makeProvider(opts.model);
+  // Revisit obligations deferred while their artifact didn't exist re-open now
+  // if it does (must run before loadConstraints so the prompt sees the updated
+  // registry). They land in this run's fresh ledger, so finish gates on them.
+  const reopened = await reopenDeferredAffects(repoRoot, config, (key, item) =>
+    ctx.ledger.add('affects-revisit', `${key} affects ${item}`, key),
+  );
+  if (reopened.length) {
+    await transcript.event('deferred-affects-reopened', { reopened });
+    log(`re-opened ${reopened.length} deferred constraint revisit obligation(s)`);
+  }
   const constraints = await loadConstraints(repoRoot);
-  const basePrompt = await buildSystemPrompt(repoRoot, config, constraints);
+  let basePrompt = await buildSystemPrompt(repoRoot, config, constraints);
+  if (reopened.length) {
+    basePrompt += [
+      '',
+      '',
+      '## Reopened constraint revisits',
+      '',
+      'These constraints were recorded before their target artifact existed; the artifact now exists.',
+      'Revisit each against the design and close it with resolve_affected (batch the calls):',
+      ...reopened.map((r) => `- ${r.key} affects ${r.item}`),
+    ].join('\n');
+  }
   // Cross-run memory is appended after the repo's own docs and constraints so
   // that the in-repo sources of truth are what the model reads first.
   const recalled = memory ? await memory.recall(opts.request) : null;

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -21,7 +21,9 @@ const WORKFLOW = `Workflow for every run:
 4. Run run_erc after schematic edits (and run_drc after board edits). If violations: read them, fix, re-run.
 5. Run check_drift; update any doc that references a changed value/part/pin in the same run.
 6. Record every non-trivial decision with record_decision, and every stated/assumed/discovered constraint with record_constraint.
-7. Call finish with outcome "done" when everything is verified, or outcome "refuse" (citing the violated budget/constraint) if the request should not be done. finish will list any unmet obligations; resolve them and call it again.`;
+7. Call finish with outcome "done" when everything is verified, or outcome "refuse" (citing the violated budget/constraint) if the request should not be done. finish will list any unmet obligations; resolve them and call it again.
+
+Turns are the scarce resource, not tool calls: the run has a hard turn budget, and every tool call in one reply executes in the same turn. When calls are independent — multiple record_constraint or resolve_affected calls, several read_file calls — issue them together in a single reply instead of one per turn.`;
 
 export async function buildSystemPrompt(
   repoRoot: string,

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -7,7 +7,7 @@ import { runErc, runDrc, exportSvg, exportFab } from '../kicad/cli.js';
 import { formatViolations, type CheckReport } from '../kicad/report.js';
 import { listSymbols, listNets } from '../kicad/sexp.js';
 import { checkDrift } from '../memory/drift.js';
-import { saveConstraint } from '../memory/constraints.js';
+import { saveConstraint, classifyAffectsTarget, affectsTargetExists } from '../memory/constraints.js';
 import { openspecValidate } from '../openspec/cli.js';
 import { existsSync } from 'node:fs';
 import type { CopperheadConfig } from '../config.js';
@@ -99,7 +99,11 @@ export const TOOLS: ToolDef[] = [
     },
     requiresUnlock: false,
     handler: async (ctx, args) => {
-      const matches = await toolSearch(ctx.repoRoot, str(args, 'pattern'), args.glob as string | undefined);
+      const pattern = args.pattern;
+      if (typeof pattern !== 'string' || pattern.trim() === '') {
+        return 'error: search requires a non-empty regex in "pattern" (narrow by file with "glob", e.g. {"pattern": "GPIO", "glob": "**/*.md"}); to list files, use a broad pattern like "." with a glob';
+      }
+      const matches = await toolSearch(ctx.repoRoot, pattern, args.glob as string | undefined);
       if (!matches.length) return 'no matches';
       return matches.map((m) => `${m.file}:${m.line}: ${m.text}`).join('\n');
     },
@@ -250,7 +254,8 @@ export const TOOLS: ToolDef[] = [
     },
     requiresUnlock: false,
     handler: async (ctx) => {
-      if (!ctx.config.schematic) return 'no schematic configured';
+      if (!ctx.config.schematic)
+        return 'no schematic configured; ERC does not apply yet — skip it until a schematic exists and is set in .copperhead/config.json';
       const report = await runErc(path.join(ctx.repoRoot, ctx.config.schematic));
       ctx.lastErc = report;
       if (report.ok) ctx.ledger.clear('erc');
@@ -266,7 +271,8 @@ export const TOOLS: ToolDef[] = [
     },
     requiresUnlock: false,
     handler: async (ctx) => {
-      if (!ctx.config.board) return 'no board configured';
+      if (!ctx.config.board)
+        return 'no board configured; DRC does not apply yet — skip it until a board exists and is set in .copperhead/config.json';
       const report = await runDrc(path.join(ctx.repoRoot, ctx.config.board));
       ctx.lastDrc = report;
       if (report.ok) ctx.ledger.clear('drc');
@@ -366,6 +372,19 @@ export const TOOLS: ToolDef[] = [
     handler: async (ctx, args) => {
       const key = str(args, 'key');
       const affects = (args.affects as string[]) ?? [];
+      // An affects item whose target artifact is not built yet (no schematic or
+      // board configured, no BOM.md) has nothing to revisit; opening an
+      // obligation now only forces a ceremonial "not yet created" resolution.
+      // Defer it in the registry instead — reopenDeferredAffects re-opens it at
+      // the start of the first run where the artifact exists, which is when the
+      // revisit actually means something.
+      const deferred: string[] = [];
+      const openNow: string[] = [];
+      for (const item of affects) {
+        const target = classifyAffectsTarget(item);
+        if (target && !affectsTargetExists(target, ctx.repoRoot, ctx.config)) deferred.push(item);
+        else openNow.push(item);
+      }
       await saveConstraint(ctx.repoRoot, key, {
         ...(args.min !== undefined ? { min: args.min as number } : {}),
         ...(args.max !== undefined ? { max: args.max as number } : {}),
@@ -373,10 +392,18 @@ export const TOOLS: ToolDef[] = [
         ...(args.value !== undefined ? { value: args.value as string } : {}),
         source: str(args, 'source'),
         affects,
+        ...(deferred.length ? { deferred } : {}),
       });
-      ctx.ledger.onConstraintChange(key, affects);
+      ctx.ledger.onConstraintChange(key, openNow);
       ctx.ledger.clear('constraint-dual-write', key);
-      return `constraint ${key} recorded; revisit obligations opened for: ${affects.join(', ') || '(none)'}`;
+      const parts = [`constraint ${key} recorded`];
+      parts.push(`revisit obligations opened for: ${openNow.join(', ') || '(none)'}`);
+      if (deferred.length) {
+        parts.push(
+          `deferred until the target artifact exists (no resolve_affected needed now): ${deferred.join(', ')}`,
+        );
+      }
+      return parts.join('; ');
     },
   },
   {

--- a/src/kicad/cli.ts
+++ b/src/kicad/cli.ts
@@ -3,11 +3,18 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { normalizeReport, type CheckReport } from './report.js';
+import { PreflightError } from '../util/preflight.js';
 
-export class KicadCliMissingError extends Error {
+export class KicadCliMissingError extends PreflightError {
   constructor() {
     super(
-      'kicad-cli not found on PATH. Install KiCad ≥ 8 (https://www.kicad.org/download/) and ensure kicad-cli is available.',
+      'kicad-cli not found on PATH',
+      'copperhead verifies every mutation with kicad-cli ERC/DRC; without it no edit can be checked, so no run can start',
+      [
+        'install KiCad ≥ 8: https://www.kicad.org/download/',
+        'ensure the kicad-cli binary is on PATH (on macOS it ships inside KiCad.app/Contents/MacOS)',
+        'confirm with "kicad-cli version", then rerun',
+      ],
     );
     this.name = 'KicadCliMissingError';
   }

--- a/src/memory/constraints.ts
+++ b/src/memory/constraints.ts
@@ -14,6 +14,13 @@ export interface Constraint {
   value?: string | number;
   source: string;
   affects: string[];
+  /**
+   * Subset of `affects` whose target artifact (schematic/board/BOM) did not
+   * exist when the constraint was recorded. No revisit obligation is open for
+   * these; they re-open at the start of the first run where the artifact
+   * exists (reopenDeferredAffects), then the marker is removed.
+   */
+  deferred?: string[];
 }
 
 export type ConstraintRegistry = Record<string, Constraint>;
@@ -28,6 +35,12 @@ export async function loadConstraints(repoRoot: string): Promise<ConstraintRegis
   return JSON.parse(await readFile(p, 'utf8')) as ConstraintRegistry;
 }
 
+export async function saveConstraints(repoRoot: string, registry: ConstraintRegistry): Promise<void> {
+  const p = constraintsPath(repoRoot);
+  await mkdir(path.dirname(p), { recursive: true });
+  await writeFile(p, JSON.stringify(registry, null, 2) + '\n', 'utf8');
+}
+
 export async function saveConstraint(
   repoRoot: string,
   key: string,
@@ -35,10 +48,84 @@ export async function saveConstraint(
 ): Promise<ConstraintRegistry> {
   const registry = await loadConstraints(repoRoot);
   registry[key] = constraint;
-  const p = constraintsPath(repoRoot);
-  await mkdir(path.dirname(p), { recursive: true });
-  await writeFile(p, JSON.stringify(registry, null, 2) + '\n', 'utf8');
+  await saveConstraints(repoRoot, registry);
   return registry;
+}
+
+/** The build artifact an `affects` item names, when it clearly names one. */
+export type AffectsTarget = 'schematic' | 'board' | 'bom';
+
+/**
+ * Items that name a not-yet-built artifact are deferrable; items that name a
+ * specific refdes, net, or doc fact return null and open a revisit obligation
+ * immediately. Misclassification is cheap in both directions: an unmatched
+ * artifact item just costs one ceremonial resolve_affected call (the old
+ * behavior for everything), and a deferred item still re-opens later.
+ */
+export function classifyAffectsTarget(item: string): AffectsTarget | null {
+  if (/\b(bom|part[-\s]?selection|mpn)\b/i.test(item)) return 'bom';
+  if (/\b(schematic|pinout|pin[-\s]?assign\w*|strapping|netlist)\b/i.test(item)) return 'schematic';
+  if (
+    /\b(layout|stackup|rout(?:e|es|ing)?|vias?|pours?|keepouts?|zones?|copper|traces?|board|pcb|mounting|thermal|silkscreen|assembly|current[-\s]?carrying)\b/i.test(
+      item,
+    )
+  )
+    return 'board';
+  return null;
+}
+
+interface ArtifactConfig {
+  schematic: string | null;
+  board: string | null;
+  docs: string;
+}
+
+export function affectsTargetExists(target: AffectsTarget, repoRoot: string, config: ArtifactConfig): boolean {
+  switch (target) {
+    case 'schematic':
+      return !!config.schematic;
+    case 'board':
+      return !!config.board;
+    case 'bom':
+      return existsSync(path.join(repoRoot, config.docs, 'BOM.md'));
+  }
+}
+
+export interface ReopenedAffects {
+  key: string;
+  item: string;
+}
+
+/**
+ * Run-start hook: re-open the revisit obligations that were deferred while
+ * their target artifact did not exist. Each re-opened item is removed from the
+ * registry's `deferred` marker in the same pass, so it re-opens exactly once —
+ * from then on it lives in the run's ledger like any other obligation.
+ */
+export async function reopenDeferredAffects(
+  repoRoot: string,
+  config: ArtifactConfig,
+  openObligation: (key: string, item: string) => void,
+): Promise<ReopenedAffects[]> {
+  const registry = await loadConstraints(repoRoot);
+  const reopened: ReopenedAffects[] = [];
+  for (const [key, c] of Object.entries(registry)) {
+    if (!c.deferred?.length) continue;
+    const stillDeferred: string[] = [];
+    for (const item of c.deferred) {
+      const target = classifyAffectsTarget(item);
+      if (target && !affectsTargetExists(target, repoRoot, config)) {
+        stillDeferred.push(item);
+        continue;
+      }
+      openObligation(key, item);
+      reopened.push({ key, item });
+    }
+    if (stillDeferred.length) c.deferred = stillDeferred;
+    else delete c.deferred;
+  }
+  if (reopened.length) await saveConstraints(repoRoot, registry);
+  return reopened;
 }
 
 export interface ConstraintViolation {

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -1,4 +1,5 @@
 import { execa } from 'execa';
+import { PreflightError } from './preflight.js';
 
 export interface GitSnapshot {
   head: string;
@@ -32,6 +33,39 @@ export async function hasCommits(repo: string): Promise<boolean> {
 export async function isDirty(repo: string): Promise<boolean> {
   const status = await git(repo, ['status', '--porcelain']);
   return status.length > 0;
+}
+
+/**
+ * The run-blocking git gates, in order: repo -> commits -> dirty (AC-3.8).
+ * Throws a PreflightError whose message explains why the run is refused and
+ * how to fix it; a caller that catches only needs err.message.
+ */
+export async function gitPreflight(repo: string, opts: { allowDirty?: boolean } = {}): Promise<void> {
+  if (!(await isGitRepo(repo))) {
+    throw new PreflightError(
+      'not a git repository; copperhead requires git for snapshots and rollback',
+      'every run snapshots HEAD before editing so a failed run can be rolled back losslessly; without git there is no snapshot and no undo',
+      ['git init', 'git add -A && git commit -m "initial commit"', 'rerun the same copperhead command'],
+    );
+  }
+  if (!(await hasCommits(repo))) {
+    throw new PreflightError(
+      'repository has no commits; copperhead requires at least one commit for snapshots and rollback',
+      'the pre-run snapshot is the current HEAD commit; with an unborn HEAD there is nothing to roll back to if verification fails',
+      ['git add -A && git commit -m "initial commit"', 'rerun the same copperhead command'],
+    );
+  }
+  if ((await isDirty(repo)) && !opts.allowDirty) {
+    throw new PreflightError(
+      'working tree is dirty; copperhead refuses to run on uncommitted changes by default',
+      'a rollback hard-resets to the pre-run snapshot, which would silently destroy your uncommitted work',
+      [
+        'git add -A && git commit — to keep your changes (recommended)',
+        'git stash — to set them aside for now',
+        'or rerun with --allow-dirty to let copperhead preserve them via "git stash create"',
+      ],
+    );
+  }
 }
 
 /**

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -19,6 +19,16 @@ export async function isGitRepo(repo: string): Promise<boolean> {
   }
 }
 
+/** False on an unborn HEAD (fresh `git init` with no commits yet). */
+export async function hasCommits(repo: string): Promise<boolean> {
+  try {
+    await git(repo, ['rev-parse', '--quiet', '--verify', 'HEAD']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function isDirty(repo: string): Promise<boolean> {
   const status = await git(repo, ['status', '--porcelain']);
   return status.length > 0;

--- a/src/util/preflight.ts
+++ b/src/util/preflight.ts
@@ -1,0 +1,22 @@
+/**
+ * A run-blocking environment failure. Distinct from a mid-run error: nothing
+ * has been written yet, so the message alone is the whole user experience.
+ * The formatted message carries the reason, why copperhead refuses to run,
+ * and concrete remedy steps — every CLI catch path prints err.message, so
+ * embedding the explanation here means no call site needs special rendering.
+ */
+export class PreflightError extends Error {
+  constructor(
+    readonly reason: string,
+    readonly why: string,
+    readonly remedy: string[],
+  ) {
+    super(formatPreflightFailure(reason, why, remedy));
+    this.name = 'PreflightError';
+  }
+}
+
+export function formatPreflightFailure(reason: string, why: string, remedy: string[]): string {
+  const steps = remedy.map((step, i) => `  ${i + 1}. ${step}`);
+  return [reason, '', `why it failed: ${why}`, 'to fix:', ...steps].join('\n');
+}

--- a/test/gating-sync.test.ts
+++ b/test/gating-sync.test.ts
@@ -6,7 +6,12 @@ import { loadConfig } from '../src/config.js';
 import { availableTools, dispatchTool, type RunContext } from '../src/agent/tools.js';
 import { ObligationsLedger } from '../src/agent/ledger.js';
 import { Transcript } from '../src/agent/transcript.js';
-import { saveConstraint } from '../src/memory/constraints.js';
+import {
+  saveConstraint,
+  loadConstraints,
+  classifyAffectsTarget,
+  reopenDeferredAffects,
+} from '../src/memory/constraints.js';
 import { syncVerify } from '../src/commands/sync.js';
 import { tempFixtureRepo } from './helpers.js';
 
@@ -183,6 +188,115 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       // The obligations stay open, and no decision is logged for a failed resolve.
       expect(ctx.ledger.openOfKind('affects-revisit')).toHaveLength(2);
       expect(ctx.decisions.some((d) => d.includes('CC1/CC2'))).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('record_constraint defers affects items whose artifact does not exist yet', async () => {
+    // Regression: during the docs-only create stages every affects item that
+    // targets the future schematic/board opened an obligation the model could
+    // only close with a ceremonial "no change needed: not yet created" call —
+    // 13 of them burned ~25 turns in a live spec-seed run.
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      ctx.editsUnlocked = true;
+      ctx.config = { ...ctx.config, schematic: null, board: null };
+      const res = await dispatchTool(ctx, 'record_constraint', {
+        key: 'manufacturing.copper_weight_oz',
+        value: '1',
+        source: 'brief',
+        affects: ['layout', 'stackup', 'R1'],
+      });
+      // R1 names a concrete part: opens now. layout/stackup wait for the board.
+      const open = ctx.ledger.openOfKind('affects-revisit').map((o) => o.detail);
+      expect(open).toEqual(['manufacturing.copper_weight_oz affects R1']);
+      expect(res).toContain('deferred until the target artifact exists');
+      expect(res).toContain('layout, stackup');
+      const registry = await loadConstraints(repo);
+      expect(registry['manufacturing.copper_weight_oz']!.deferred).toEqual(['layout', 'stackup']);
+      // the full affects list is preserved for propagation regardless
+      expect(registry['manufacturing.copper_weight_oz']!.affects).toEqual(['layout', 'stackup', 'R1']);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('deferred revisits re-open once their artifact exists, exactly once', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      ctx.editsUnlocked = true;
+      ctx.config = { ...ctx.config, schematic: null, board: null };
+      await dispatchTool(ctx, 'record_constraint', {
+        key: 'mechanical.mounting_holes',
+        value: '24mm pitch',
+        source: 'brief',
+        affects: ['layout'],
+      });
+      expect(ctx.ledger.openOfKind('affects-revisit')).toHaveLength(0);
+
+      // board still absent: nothing re-opens, marker stays
+      const none = await reopenDeferredAffects(repo, ctx.config, () => {
+        throw new Error('should not open anything');
+      });
+      expect(none).toEqual([]);
+
+      // a later run has the board configured: the revisit re-opens in its ledger
+      const laterConfig = { ...ctx.config, board: 'hardware/x.kicad_pcb' };
+      const ledger = new ObligationsLedger();
+      const reopened = await reopenDeferredAffects(repo, laterConfig, (key, item) =>
+        ledger.add('affects-revisit', `${key} affects ${item}`, key),
+      );
+      expect(reopened).toEqual([{ key: 'mechanical.mounting_holes', item: 'layout' }]);
+      expect(ledger.openOfKind('affects-revisit').map((o) => o.detail)).toEqual([
+        'mechanical.mounting_holes affects layout',
+      ]);
+      // the marker is consumed: a third run re-opens nothing
+      expect((await loadConstraints(repo))['mechanical.mounting_holes']!.deferred).toBeUndefined();
+      expect(await reopenDeferredAffects(repo, laterConfig, () => {})).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('classifies affects items by target artifact', () => {
+    expect(classifyAffectsTarget('layout')).toBe('board');
+    expect(classifyAffectsTarget('stackup')).toBe('board');
+    expect(classifyAffectsTarget('current-carrying traces')).toBe('board');
+    expect(classifyAffectsTarget('thermal')).toBe('board');
+    expect(classifyAffectsTarget('schematic')).toBe('schematic');
+    expect(classifyAffectsTarget('pin assignment')).toBe('schematic');
+    expect(classifyAffectsTarget('BOM')).toBe('bom');
+    // concrete refdes/nets are never deferrable
+    expect(classifyAffectsTarget('R1')).toBeNull();
+    expect(classifyAffectsTarget('U2 EN pullup')).toBeNull();
+  });
+
+  it('search rejects an empty pattern with a corrective message', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const res = await dispatchTool(ctx, 'search', { pattern: '' });
+      expect(res).toMatch(/^error:/);
+      expect(res).toContain('non-empty regex');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('run_erc without a schematic says ERC does not apply yet', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      ctx.config = { ...ctx.config, schematic: null, board: null };
+      expect(await dispatchTool(ctx, 'run_erc', {})).toContain('does not apply yet');
+      expect(await dispatchTool(ctx, 'run_drc', {})).toContain('does not apply yet');
     } finally {
       await cleanup();
     }

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -6,6 +6,9 @@ import path from 'node:path';
 import { execa } from 'execa';
 import { runAgentLoop } from '../src/agent/loop.js';
 import { runCreate } from '../src/commands/create.js';
+import { gitPreflight } from '../src/util/git.js';
+import { PreflightError } from '../src/util/preflight.js';
+import { KicadCliMissingError } from '../src/kicad/cli.js';
 import { tempFixtureRepo } from './helpers.js';
 
 // The git preflight throws before the provider is constructed and before
@@ -122,6 +125,92 @@ describe('copperhead create without a git setup (bug-report path)', () => {
     try {
       await writeFile(path.join(dir, 'brief.md'), 'A tiny USB macro keypad', 'utf8');
       await expect(runCreate(createOpts(dir))).rejects.toThrow(/not a git repository/);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+describe('preflight failures explain why and how to fix', () => {
+  async function preflightError(dir: string, allowDirty = false): Promise<PreflightError> {
+    const err = await gitPreflight(dir, { allowDirty }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(PreflightError);
+    return err as PreflightError;
+  }
+
+  it('non-git directory: why line plus numbered remedy steps ending in a rerun', async () => {
+    const { dir, cleanup } = await tempDir();
+    try {
+      const err = await preflightError(dir);
+      expect(err.message).toMatch(/why it failed: .*snapshot/);
+      expect(err.message).toMatch(/to fix:\n  1\. git init\n  2\. git add -A && git commit/);
+      expect(err.message).toMatch(/rerun the same copperhead command/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('unborn HEAD: explains there is nothing to roll back to, remedy is the first commit', async () => {
+    const { dir, cleanup } = await tempDir();
+    try {
+      await execa('git', ['init', '-q'], { cwd: dir });
+      const err = await preflightError(dir);
+      expect(err.message).toMatch(/why it failed: .*nothing to roll back to/);
+      expect(err.message).toMatch(/1\. git add -A && git commit/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('dirty tree: explains rollback would destroy uncommitted work, offers commit/stash/--allow-dirty', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await writeFile(path.join(repo, 'junk.txt'), 'dirty', 'utf8');
+      const err = await preflightError(repo);
+      expect(err.message).toMatch(/why it failed: .*destroy your uncommitted work/);
+      expect(err.message).toMatch(/git add -A && git commit/);
+      expect(err.message).toMatch(/git stash/);
+      expect(err.message).toMatch(/--allow-dirty/);
+      // the offered flag actually works
+      await expect(gitPreflight(repo, { allowDirty: true })).resolves.toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('exposes reason/why/remedy as structured fields for programmatic callers', async () => {
+    const { dir, cleanup } = await tempDir();
+    try {
+      const err = await preflightError(dir);
+      expect(err.reason).toMatch(/not a git repository/);
+      expect(err.why).toBeTruthy();
+      expect(err.remedy.length).toBeGreaterThan(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('missing kicad-cli is a PreflightError with install steps', () => {
+    const err = new KicadCliMissingError();
+    expect(err).toBeInstanceOf(PreflightError);
+    expect(err.message).toMatch(/why it failed: .*ERC\/DRC/);
+    expect(err.message).toMatch(/1\. install KiCad/);
+    expect(err.message).toMatch(/kicad-cli version/);
+  });
+
+  it('the loop surfaces the full explanation, not just the reason line', async () => {
+    const { dir, cleanup } = await tempDir();
+    try {
+      await execa('git', ['init', '-q'], { cwd: dir });
+      const err = await runAgentLoop(loopOpts(dir)).then(
+        () => null,
+        (e: Error) => e,
+      );
+      expect(err!.message).toMatch(/why it failed:/);
+      expect(err!.message).toMatch(/to fix:/);
     } finally {
       await cleanup();
     }

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execa } from 'execa';
+import { runAgentLoop } from '../src/agent/loop.js';
+import { runCreate } from '../src/commands/create.js';
+import { tempFixtureRepo } from './helpers.js';
+
+// The git preflight throws before the provider is constructed and before
+// transcript.init(), so these run the real loop offline: no API key is read,
+// no network is touched, no run dir is written.
+
+const loopOpts = (repoRoot: string) => ({
+  repoRoot,
+  model: 'gpt-5',
+  request: 'test request',
+  log: () => {},
+});
+
+async function tempDir(): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ch-preflight-'));
+  return { dir, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+describe('git preflight (unborn HEAD, AC-3.8)', () => {
+  it('non-git directory: friendly error, not raw git output', async () => {
+    const { dir, cleanup } = await tempDir();
+    try {
+      await expect(runAgentLoop(loopOpts(dir))).rejects.toThrow(
+        /not a git repository; copperhead requires git/,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('unborn HEAD: friendly error with the fix spelled out, no exit-128 noise', async () => {
+    const { dir, cleanup } = await tempDir();
+    try {
+      await execa('git', ['init', '-q'], { cwd: dir });
+      const err = await runAgentLoop(loopOpts(dir)).then(
+        () => null,
+        (e: Error) => e,
+      );
+      expect(err).not.toBeNull();
+      expect(err!.message).toMatch(/repository has no commits/);
+      expect(err!.message).toMatch(/git add -A && git commit/);
+      expect(err!.message).not.toMatch(/exit code 128|ambiguous argument/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('staged-but-uncommitted files still count as no commits', async () => {
+    const { dir, cleanup } = await tempDir();
+    try {
+      await execa('git', ['init', '-q'], { cwd: dir });
+      await writeFile(path.join(dir, 'brief.md'), 'a brief', 'utf8');
+      await execa('git', ['add', '-A'], { cwd: dir });
+      await expect(runAgentLoop(loopOpts(dir))).rejects.toThrow(/repository has no commits/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('detection is independent of the default branch name', async () => {
+    const { dir, cleanup } = await tempDir();
+    try {
+      await execa('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+      await expect(runAgentLoop(loopOpts(dir))).rejects.toThrow(/repository has no commits/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a failed preflight leaves no .copperhead footprint', async () => {
+    const { dir, cleanup } = await tempDir();
+    try {
+      await execa('git', ['init', '-q'], { cwd: dir });
+      await runAgentLoop(loopOpts(dir)).catch(() => {});
+      expect(existsSync(path.join(dir, '.copperhead'))).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('checks run in order repo -> commits -> dirty: a committed repo passes the commit gate', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await writeFile(path.join(repo, 'junk.txt'), 'dirty', 'utf8');
+      // reaching the dirty-tree error proves both git gates before it passed
+      await expect(runAgentLoop(loopOpts(repo))).rejects.toThrow(/working tree is dirty/);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+describe('copperhead create without a git setup (bug-report path)', () => {
+  const createOpts = (repoRoot: string) => ({
+    repoRoot,
+    briefPath: path.join(repoRoot, 'brief.md'),
+    model: 'gpt-5',
+    log: () => {},
+  });
+
+  it('unborn HEAD: create fails with the no-commits message instead of crashing in spec-seed', async () => {
+    const { dir, cleanup } = await tempDir();
+    try {
+      await writeFile(path.join(dir, 'brief.md'), 'A tiny USB macro keypad', 'utf8');
+      await execa('git', ['init', '-q'], { cwd: dir });
+      await expect(runCreate(createOpts(dir))).rejects.toThrow(/repository has no commits/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('non-git directory: create fails with the not-a-repository message', async () => {
+    const { dir, cleanup } = await tempDir();
+    try {
+      await writeFile(path.join(dir, 'brief.md'), 'A tiny USB macro keypad', 'utf8');
+      await expect(runCreate(createOpts(dir))).rejects.toThrow(/not a git repository/);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -7,8 +7,9 @@ import { redactSecrets } from '../src/util/redact.js';
 import { withRetry } from '../src/util/retry.js';
 import { toolWriteFile, toolEditFile, toolSearch } from '../src/agent/filetools.js';
 import { Transcript } from '../src/agent/transcript.js';
-import { isDirty, snapshot, restore } from '../src/util/git.js';
+import { isDirty, hasCommits, snapshot, restore } from '../src/util/git.js';
 import { tempFixtureRepo } from './helpers.js';
+import { execa } from 'execa';
 
 describe('path sandbox (AC-4.2)', () => {
   it('rejects traversal outside the repo root', () => {
@@ -139,6 +140,19 @@ describe('retry', () => {
 });
 
 describe('git guard (AC-3.8, AC-3.6)', () => {
+  it('hasCommits distinguishes an unborn HEAD from a committed repo', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'ch-'));
+    expect(await hasCommits(dir)).toBe(false); // not a repo at all
+    await execa('git', ['init', '-q'], { cwd: dir });
+    expect(await hasCommits(dir)).toBe(false); // repo, but no commits yet
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      expect(await hasCommits(repo)).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('snapshot and restore leave the tree byte-identical', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {


### PR DESCRIPTION
Three pieces of preflight/loop hardening, developed and merged as a stack on the fork (animesh-chouhan#1, animesh-chouhan#2):

## 1. Fail preflight cleanly on an unborn HEAD

`copperhead create` in a fresh `git init` repo (zero commits) crashed in the `spec-seed` stage with raw git output (`exit code 128: fatal: ambiguous argument 'HEAD'`). The preflight only checked `isGitRepo`, which passes on an unborn HEAD, and then `snapshot()` ran `git rev-parse HEAD` unguarded. Adds `hasCommits()` and a preflight gate that fails up front with a friendly message, plus offline scenario tests covering non-git dirs, unborn HEAD, staged-but-uncommitted state, branch-name independence, and no `.copperhead` footprint on a failed preflight (AC-3.8).

## 2. Defer affects-revisit obligations until the target artifact exists

Affects-revisit obligations no longer open against artifacts that don't exist yet; they're deferred and re-opened at the start of the first run where the target artifact does exist (landing in that run's fresh ledger, so `finish` gates on them).

## 3. Explain why preflight failed and how to fix it

Every run-blocking failure — non-git directory, unborn HEAD, dirty tree, missing `kicad-cli` — now throws a structured `PreflightError` carrying the reason, a "why it failed" line, and numbered remedy steps:

```
repository has no commits; copperhead requires at least one commit for snapshots and rollback

why it failed: the pre-run snapshot is the current HEAD commit; with an unborn HEAD there is nothing to roll back to if verification fails
to fix:
  1. git add -A && git commit -m "initial commit"
  2. rerun the same copperhead command
```

The explanation is embedded in `err.message`, so every CLI catch path surfaces it with no rendering changes; `reason`/`why`/`remedy` remain available as structured fields. The three inline git gates are consolidated into `gitPreflight()` in `src/util/git.ts`, and `KicadCliMissingError` joins the same format.

## Verification

Full offline suite green: 92 passed, 7 skipped (LLM integration tests skip without an API key). The branch is behind `main` by the three docs-site commits but touches none of the same files — merges clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)