### PR TITLE
fix: preserve failed-run audit trails during rollback

### DIFF
--- a/src/agent/transcript.ts
+++ b/src/agent/transcript.ts
@@ -38,6 +38,7 @@ export class Transcript {
 
   async event(type: string, data: unknown): Promise<void> {
     const line = redactSecrets(JSON.stringify({ ts: new Date().toISOString(), type, data }));
+    await mkdir(this.dir, { recursive: true });
     await appendFile(this.jsonlPath, line + '\n', 'utf8');
   }
 
@@ -72,6 +73,7 @@ export class Transcript {
     }
     if (s.detail) lines.push('', '## Detail', '', s.detail);
     const out = path.join(this.dir, 'summary.md');
+    await mkdir(this.dir, { recursive: true });
     await writeFile(out, redactSecrets(lines.join('\n') + '\n'), 'utf8');
     return out;
   }

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -1,4 +1,8 @@
 import { execa } from 'execa';
+import { cp, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 export interface GitSnapshot {
   head: string;
@@ -43,10 +47,49 @@ export async function snapshot(repo: string): Promise<GitSnapshot> {
  * (.copperhead/runs/) survives rollback: it is the evidence of what failed.
  */
 export async function restore(repo: string, snap: GitSnapshot): Promise<void> {
-  await git(repo, ['reset', '--hard', snap.head]);
-  await git(repo, ['clean', '-fd', '-e', '.copperhead/runs']);
-  if (snap.stash) {
-    await git(repo, ['stash', 'apply', snap.stash]);
+  // `git clean -e` only protects untracked paths. A run directory can become
+  // staged (for example while preserving failed work), and `reset --hard`
+  // deletes such paths before clean runs. Copy it outside the repository so
+  // the audit trail survives regardless of its index state.
+  const runs = path.join(repo, '.copperhead', 'runs');
+  let backupRoot: string | null = null;
+  let backup: string | null = null;
+  try {
+    try {
+      backupRoot = await mkdtemp(path.join(tmpdir(), 'copperhead-runs-'));
+      backup = path.join(backupRoot, 'runs');
+      if (existsSync(runs)) await cp(runs, backup, { recursive: true });
+    } catch (err) {
+      backup = null;
+      console.warn(`warning: could not preserve failed-run audit trail before rollback: ${(err as Error).message}`);
+    }
+
+    try {
+      await git(repo, ['reset', '--hard', snap.head]);
+      await git(repo, ['clean', '-fd', '-e', '.copperhead/runs']);
+      if (snap.stash) {
+        await git(repo, ['stash', 'apply', snap.stash]);
+      }
+    } finally {
+      if (backup && existsSync(backup)) {
+        try {
+          await mkdir(path.dirname(runs), { recursive: true });
+          // Restored runs are intentionally untracked; their audit contents
+          // are ignored by the target-repository convention.
+          await cp(backup, runs, { recursive: true, force: true });
+        } catch (err) {
+          console.warn(`warning: could not restore failed-run audit trail: ${(err as Error).message}`);
+        }
+      }
+    }
+  } finally {
+    if (backupRoot) {
+      try {
+        await rm(backupRoot, { recursive: true, force: true });
+      } catch (err) {
+        console.warn(`warning: could not clean failed-run audit backup: ${(err as Error).message}`);
+      }
+    }
   }
 }
 

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { resolveInRepo, SandboxError, isKicadFile } from '../src/util/paths.js';
@@ -9,6 +9,7 @@ import { toolWriteFile, toolEditFile, toolSearch } from '../src/agent/filetools.
 import { Transcript } from '../src/agent/transcript.js';
 import { isDirty, snapshot, restore } from '../src/util/git.js';
 import { tempFixtureRepo } from './helpers.js';
+import { execa } from 'execa';
 
 describe('path sandbox (AC-4.2)', () => {
   it('rejects traversal outside the repo root', () => {
@@ -70,6 +71,31 @@ describe('secret redaction (AC-4.1)', () => {
     const summary = await readFile(summaryPath, 'utf8');
     expect(jsonl).not.toMatch(/sk-[A-Za-z0-9_-]{20,}/);
     expect(summary).not.toMatch(/sk-[A-Za-z0-9_-]{20,}/);
+  });
+
+  it('recreates its audit directory when rollback removed it', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'ch-'));
+    const t = new Transcript(dir);
+    await t.init();
+    await rm(t.dir, { recursive: true, force: true });
+
+    await t.event('run-failed', { reason: 'repair budget exhausted' });
+    const summaryPath = await t.writeSummary({
+      request: 'test rollback recovery',
+      changeId: null,
+      plan: null,
+      filesTouched: [],
+      ercResult: null,
+      drcResult: null,
+      decisions: [],
+      tokensIn: 0,
+      tokensOut: 0,
+      outcome: 'failure',
+      openObligations: null,
+    });
+
+    expect(await readFile(t.jsonlPath, 'utf8')).toContain('run-failed');
+    expect(await readFile(summaryPath, 'utf8')).toContain('# Run summary');
   });
 });
 
@@ -153,6 +179,59 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
       expect(await isDirty(repo)).toBe(false);
       expect(await readFile(sch, 'utf8')).toBe(before);
     } finally {
+      await cleanup();
+    }
+  });
+
+  it('preserves a staged in-flight audit trail during rollback', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const snap = await snapshot(repo);
+      const runFile = path.join(repo, '.copperhead', 'runs', 'in-flight', 'transcript.jsonl');
+      await mkdir(path.dirname(runFile), { recursive: true });
+      await writeFile(runFile, '{"type":"run-start"}\n', 'utf8');
+      await execa('git', ['add', '-f', '.copperhead/runs/in-flight/transcript.jsonl'], { cwd: repo });
+
+      await restore(repo, snap);
+
+      expect(await readFile(runFile, 'utf8')).toBe('{"type":"run-start"}\n');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('preserves the audit trail even when rollback fails', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const snap = await snapshot(repo);
+      const runFile = path.join(repo, '.copperhead', 'runs', 'in-flight', 'transcript.jsonl');
+      await mkdir(path.dirname(runFile), { recursive: true });
+      await writeFile(runFile, '{"type":"run-start"}\n', 'utf8');
+      await execa('git', ['add', '-f', '.copperhead/runs/in-flight/transcript.jsonl'], { cwd: repo });
+
+      await expect(restore(repo, { ...snap, stash: 'not-a-stash' })).rejects.toThrow();
+
+      expect(await readFile(runFile, 'utf8')).toBe('{"type":"run-start"}\n');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('still rolls back when temporary audit backup storage is unavailable', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    const originalTmpDir = process.env.TMPDIR;
+    try {
+      const snap = await snapshot(repo);
+      const sch = path.join(repo, 'hardware', 'open-key.kicad_sch');
+      const before = await readFile(sch, 'utf8');
+      await writeFile(sch, before.replace('KEY_DAH', 'KEY_RUINED'), 'utf8');
+      process.env.TMPDIR = path.join(repo, 'missing-temp-directory');
+
+      await expect(restore(repo, snap)).resolves.toBeUndefined();
+
+      expect(await readFile(sch, 'utf8')).toBe(before);
+    } finally {
+      process.env.TMPDIR = originalTmpDir;
       await cleanup();
     }
   });


### PR DESCRIPTION
## What changes

This fixes #25: a failed agent run could delete its own audit directory, then crash while attempting to write its failure summary.

## How rollback preserves the audit trail

`restore()` now treats `.copperhead/runs/` as protected evidence rather than ordinary working-tree content:

1. Before calling Git, it copies the complete runs directory to a temporary directory outside the repository.
2. It runs the normal rollback sequence: `git reset --hard <snapshot>`, `git clean`, then applies the saved dirty-tree stash when present.
3. In a nested `finally` block, it copies the saved runs directory back into `.copperhead/runs/`. This executes even if reset, clean, or stash application throws, so Git can never remove the evidence before it is restored.
4. A final cleanup removes the temporary backup.

This covers the staged-path failure mode: `git clean -e .copperhead/runs` only protects untracked paths, while `git reset --hard` deletes a staged, not-in-HEAD run directory before `clean` gets a chance.

`Transcript.event()` and `Transcript.writeSummary()` also create their parent run directory immediately before writing. If an earlier failure or an external cleanup removed it, reporting the failure no longer raises `ENOENT`.

## Tests

- rollback retains a staged in-flight `transcript.jsonl`
- rollback still restores the audit trail when stash application fails
- transcript event and summary writes recover after the run directory is removed

Closes #25.

## Verification

- `npx vitest run test/safety.test.ts` — 16 passed
- `npm run typecheck` — passed
- `PATH="/Applications/KiCad/KiCad.app/Contents/MacOS:$PATH" npm test` — 73 passed, 7 skipped, 2 existing failures outside this change:
  - `test/gating-sync.test.ts`: fixture ERC does not reach the expected clean state
  - `test/init-check.test.ts`: clean fixture check returns `ok: false` under KiCad 10.0.4
