### PR TITLE
fix: enforce create stage completion contracts

### DIFF
--- a/openspec/changes/build-copperhead-phase-1/specs/create-pipeline/spec.md
+++ b/openspec/changes/build-copperhead-phase-1/specs/create-pipeline/spec.md
@@ -27,6 +27,13 @@ Pipeline state SHALL live in the repo (docs + files + gate results), so a killed
 - **WHEN** `create` is killed after the BOM stage and re-run
 - **THEN** it skips spec/architecture/BOM and resumes at the schematic stage
 
+### Requirement: Stage contract acceptance
+Each stage SHALL define a repo-state completion contract. `create` SHALL check that contract before skipping a stage during resume and again after a successful stage run. If the contract remains unmet, `create` SHALL preserve the partial committed work, report the unmet clause, and stop without advancing to a downstream stage.
+
+#### Scenario: Agent success without complete work
+- **WHEN** an agent reports success for a stage but the stage's repo-state contract remains unmet
+- **THEN** `create` does not start the next stage, reports the failed contract clause, and a later `create` invocation resumes the same stage
+
 ### Requirement: First-draft layout with honesty gate
 The layout stage SHALL produce rule-driven placement (real coordinates in the `.kicad_pcb`) and rule-based routing of power/critical nets, with every routed net passing DRC, and SHALL auto-write a `## Draft quality` section in LAYOUT.md listing what is done and what a human or specialist tool should redo.
 

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -155,7 +155,7 @@ Firmware scope: scaffold + pin definitions + driver stubs + one working happy-pa
 
 ### The pipeline (Mode A internally)
 
-**Run-to-completion guarantee:** once `create` starts, it always finishes with the complete output package. Gates are *quality checks the agent must satisfy*, not stops that wait for a human. By default the pipeline is fully autonomous: unstated decisions get `ASSUMED` flags, imperfect layout gets the `Draft quality` label, and the run ends with gerbers, firmware, renders, and DEVPLAN.md on disk — an end product, reviewable as a whole. `--interactive` turns the two human gates (spec approval, pre-export review) back on for users who want them.
+**Run-to-completion guarantee:** once `create` starts, it autonomously works toward the complete output package. Gates are *quality checks the agent must satisfy*, not stops that wait for a human. Each stage has a repo-state completion contract; Copperhead skips a stage only when its contract is met and re-checks it after an agent reports success. If a contract remains unmet, Copperhead preserves the partial committed work, reports the unmet clause, and exits so the next `create` run resumes that stage rather than silently advancing. By default unstated decisions get `ASSUMED` flags, imperfect layout gets the `Draft quality` label, and a successful run ends with gerbers, firmware, renders, and DEVPLAN.md on disk — an end product, reviewable as a whole. `--interactive` turns the two human gates (spec approval, pre-export review) back on for users who want them.
 
 ```
 brief.md
@@ -169,7 +169,7 @@ brief.md
   → DEVPLAN.md
 ```
 
-Each stage is a `do`-loop run with a stage-specific prompt. State lives in the repo (docs + files), so `create` is resumable: kill it at any stage, re-run, it continues from the docs.
+Each stage is a `do`-loop run with a stage-specific prompt and completion contract. State lives in the repo (docs + files), so `create` is resumable: kill it at any stage, or leave a stage contract unmet, re-run, and it continues from that stage.
 
 ### First-draft layout (explicitly non-optimal, explicitly useful)
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -5,7 +5,7 @@ import { createHash } from 'node:crypto';
 import { loadConfig } from '../config.js';
 import { bootstrapKicadProject } from '../kicad/bootstrap.js';
 import { exportSvg, runErc } from '../kicad/cli.js';
-import { listSymbols } from '../kicad/sexp.js';
+import { children, isList, listSymbols, parseSexp } from '../kicad/sexp.js';
 import { isDirty, commitAll, changedFiles } from '../util/git.js';
 import type { CopperheadConfig } from '../config.js';
 import { checkDrift } from '../memory/drift.js';
@@ -29,111 +29,123 @@ import { emitCreateJlcpcbBom } from './export.js';
  */
 interface Stage {
   name: string;
-  /** true when repo state shows the stage is already done (resume support). */
+  /** true when repo state satisfies the stage contract (resume and acceptance). */
   isComplete: (repoRoot: string, docs: string) => Promise<boolean> | boolean;
+  /** Included in recovery logs when an agent reports success without the artifact. */
+  contract: string;
   prompt: (brief: string) => string;
 }
 
 const docExists = (repoRoot: string, rel: string) => existsSync(path.join(repoRoot, rel));
 
-async function docHasContent(repoRoot: string, rel: string, marker: string): Promise<boolean> {
+async function docHasFilledSection(repoRoot: string, rel: string, heading: string): Promise<boolean> {
   const p = path.join(repoRoot, rel);
   if (!existsSync(p)) return false;
-  return (await readFile(p, 'utf8')).includes(marker);
-}
-
-// Heading-aware variant of docHasContent: matches any Markdown heading whose
-// text contains `word`, ignoring heading level, leading numbering ("3."), and
-// trailing decoration ("Budgets and constraints (...)"). Stage prompts don't
-// dictate exact heading text, so a literal `.includes('## Budgets')` produces
-// false negatives against valid docs titled e.g. "## 3. Budgets and constraints".
-async function docHasHeading(repoRoot: string, rel: string, word: string): Promise<boolean> {
-  const p = path.join(repoRoot, rel);
-  if (!existsSync(p)) return false;
-  const re = new RegExp(`^#{1,6}\\s.*\\b${word}\\b`, 'im');
-  return re.test(await readFile(p, 'utf8'));
+  const lines = (await readFile(p, 'utf8')).split('\n');
+  const headingAt = lines.findIndex((line) => line.trim() === heading);
+  if (headingAt < 0) return false;
+  const nextHeading = lines.slice(headingAt + 1).findIndex((line) => /^##\s/.test(line));
+  const section = lines.slice(headingAt + 1, nextHeading < 0 ? undefined : headingAt + 1 + nextHeading).join('\n');
+  return section.replace(/<!--[\s\S]*?-->/g, '').trim().length > 0;
 }
 
 export const STAGES: Stage[] = [
   {
     name: 'spec-seed',
-    isComplete: (root, docs) => docHasHeading(root, path.join(docs, 'SPEC.md'), 'Budgets?'),
+    isComplete: (root, docs) => docHasFilledSection(root, path.join(docs, 'SPEC.md'), '## Budgets'),
+    contract: 'docs/SPEC.md must contain a filled ## Budgets section',
     prompt: (brief) =>
       `Stage 1 of the create pipeline: seed the requirements. From the product brief below, write docs/SPEC.md (what the device is, top-level constraints and budgets). Every budget you state must also be recorded with record_constraint. Anything the brief does not state: propose a sensible default and flag it ASSUMED. If an openspec/ workspace exists, also seed openspec/specs/ with per-capability requirements using Given/When/Then scenarios.\n\nBrief:\n${brief}`,
   },
   {
     name: 'architecture',
     isComplete: (root, docs) => docExists(root, path.join(docs, 'SUBSYSTEMS.md')),
+    contract: 'docs/SUBSYSTEMS.md must exist',
     prompt: () =>
       'Stage 2: architecture. Write docs/SUBSYSTEMS.md: the block diagram in prose, one section per subsystem (power, MCU, connectivity, UI, ...), with the reasoning and key values for each. Respect every budget in SPEC.md.',
   },
   {
     name: 'part-selection',
     isComplete: (root, docs) => docExists(root, path.join(docs, 'BOM.md')),
+    contract: 'docs/BOM.md must exist',
     prompt: () =>
       'Stage 3: part selection. Write docs/BOM.md with the fixed table format (| Refdes | Value | Footprint | MPN | Rationale |). Every MPN you introduce is flagged UNVERIFIED with a datasheet-verifiable justification. Check leakage/quiescent current of every part against the power budget. Run check_drift before finishing.',
   },
   {
     name: 'schematic',
     isComplete: async (root) => {
-      const config = await loadConfig(root);
-      if (!config.schematic) return false;
-      const p = path.join(root, config.schematic);
-      if (!existsSync(p)) return false;
-      // Mere file existence is not completion: bootstrapping leaves a blank
-      // sheet on disk (a hand-scaffolded project, or the future fix for #19),
-      // and skipping this stage over a blank sheet cascades — layout and
-      // outputs then run against nothing. The stage's contract is "build the
-      // schematic from BOM.md", so completion means symbols exist AND the
-      // BOM/PINOUT tables agree with them (drift-clean); anything less keeps
-      // the stage active on the next resume so partial capture continues.
-      if (!(await listSymbols(p)).length) return false;
-      if ((await checkDrift(root, config.docs, config.schematic)).length !== 0) return false;
-      // ERC-clean is part of "done" (F2 / verification-gated-out on the resume
-      // path). Symbols + drift-clean can still hold on a schematic with
-      // unconnected pins — e.g. a run hard-killed mid-capture after BOM/PINOUT
-      // went clean but before ERC passed. Without this check, resume would treat
-      // it as complete and commitResumedStage would commit an ERC-failing
-      // schematic, advancing the pipeline against unverified work. Returning
-      // false here keeps the stage active so it re-runs, fixes ERC, and commits
-      // through the normal finish gate.
-      return (await runErc(p)).ok;
+      try {
+        const config = await loadConfig(root);
+        if (!config.schematic) return false;
+        const p = path.join(root, config.schematic);
+        if (!existsSync(p)) return false;
+        // Mere file existence is not completion: bootstrapping leaves a blank
+        // sheet on disk (a hand-scaffolded project, or the future fix for #19),
+        // and skipping this stage over a blank sheet cascades — layout and
+        // outputs then run against nothing. The stage's contract is "build the
+        // schematic from BOM.md", so completion means symbols exist AND the
+        // BOM/PINOUT tables agree with them (drift-clean); anything less keeps
+        // the stage active on the next resume so partial capture continues.
+        if (!(await listSymbols(p)).length) return false;
+        if ((await checkDrift(root, config.docs, config.schematic)).length !== 0) return false;
+        // ERC-clean is part of "done" (F2 / verification-gated-out on the resume
+        // path). Symbols + drift-clean can still hold on a schematic with
+        // unconnected pins — e.g. a run hard-killed mid-capture after BOM/PINOUT
+        // went clean but before ERC passed. Without this check, resume would treat
+        // it as complete and commitResumedStage would commit an ERC-failing
+        // schematic, advancing the pipeline against unverified work. Returning
+        // false here keeps the stage active so it re-runs, fixes ERC, and commits
+        // through the normal finish gate.
+        return (await runErc(p)).ok;
+      } catch {
+        return false;
+      }
     },
+    contract: 'the schematic must contain symbols, be drift-clean, and pass ERC',
     prompt: () =>
       'Stage 4: schematic. An empty KiCad project has already been scaffolded and wired into .copperhead/config.json (an empty schematic and a blank board with a default outline). Populate the existing schematic with edit_file — write_file refuses KiCad files, so add lib_symbols, symbols, and connectivity by anchored edits into the file that already exists. Work ONE part at a time, not in large blocks: add a symbol (its lib_symbols entry if new, then its placement), run run_erc, fix any violation, then move to the next part — small incremental edits keep a geometry or grid slip local instead of forcing a full-block rewrite. When you add a lib_symbols entry, use the exact canonical KiCad lib_id (e.g. Device:R, Connector:USB_C_Receptacle_USB2.0_16P) and reproduce the real part\'s pins faithfully — never invent pin numbers, names, or electrical types. Once symbols are placed, run verify_symbols and reconcile every divergence it reports (a wrong lib_id or pin set passes ERC but is still wrong); if it flags a renamed symbol, adopt the real name it suggests. Build subsystem by subsystem from BOM.md and SUBSYSTEMS.md. Same net names and refdes everywhere. Two KiCad rules the pipeline has repeatedly tripped on: (1) a net label placed on a pin only NAMES the net — it is NOT an electrical connection unless a wire actually reaches the pin; ERC will report the pin unconnected until you draw the wire. (2) Place every symbol origin and every wire endpoint on the 1.27mm (50mil) grid; an off-grid pin silently fails to connect and costs turns to diagnose. Update PINOUT.md as you assign pins; check the strapping table first.',
   },
   {
     name: 'layout-draft',
     isComplete: async (root, docs) => {
-      // The LAYOUT.md marker alone is not enough: `copperhead init` scaffolds
-      // LAYOUT.md with the literal "## Draft quality" heading, so an init-ed
-      // repo would skip this stage without a single footprint placed. Require
-      // a board with at least one footprint on it as well.
-      const config = await loadConfig(root);
-      if (!config.board) return false;
-      const p = path.join(root, config.board);
-      if (!existsSync(p)) return false;
-      if (!(await readFile(p, 'utf8')).includes('(footprint')) return false;
-      return docHasContent(root, path.join(docs, 'LAYOUT.md'), '## Draft quality');
+      try {
+        // The LAYOUT.md marker alone is not enough: `copperhead init` scaffolds
+        // LAYOUT.md with the literal "## Draft quality" heading, so an init-ed
+        // repo would skip this stage without a single footprint placed. Require
+        // a board with at least one footprint on it as well.
+        const config = await loadConfig(root);
+        if (!config.board) return false;
+        const p = path.join(root, config.board);
+        if (!existsSync(p)) return false;
+        const board = parseSexp(await readFile(p, 'utf8'))[0];
+        if (!board || !isList(board) || children(board, 'footprint').length === 0) return false;
+        return docHasFilledSection(root, path.join(docs, 'LAYOUT.md'), '## Draft quality');
+      } catch {
+        return false;
+      }
     },
+    contract: 'the board must contain a footprint and LAYOUT.md must contain a filled ## Draft quality section',
     prompt: () =>
       'Stage 5: first-draft layout. Rule-driven placement written as real coordinates: connectors on edges, decoupling at IC pins, ESD at connectors, keepouts honored. Route power and short critical nets; leave the rest as ratsnest. Every routed net must pass run_drc. Then write the "## Draft quality" section in LAYOUT.md: exactly what is fine and what a human or specialist tool should redo. Non-optimal is acceptable; unlabeled non-optimal is not.',
   },
   {
     name: 'outputs',
     isComplete: (root) => existsSync(path.join(root, 'outputs')),
+    contract: 'the outputs/ directory must exist',
     prompt: () =>
       'Stage 6: outputs package. Export into outputs/: gerbers+drill (JLC profile), DXF and STEP outline, SVG renders (export_svg), and an ordering BOM.csv generated from BOM.md (refdes, MPN, qty). Every export must succeed.',
   },
   {
     name: 'firmware',
     isComplete: (root) => existsSync(path.join(root, 'firmware')),
+    contract: 'the firmware/ directory must exist',
     prompt: () =>
       'Stage 7: firmware scaffold. Generate firmware/ for the chosen MCU HAL: pins.h generated from PINOUT.md (single source of truth), driver stubs, and one working happy path. If the vendor toolchain is available, the build must pass; if not, note "not compiled here" explicitly in DEVPLAN.md.',
   },
   {
     name: 'devplan',
     isComplete: (root, docs) => docExists(root, path.join(docs, 'DEVPLAN.md')),
+    contract: 'docs/DEVPLAN.md must exist',
     prompt: () =>
       'Stage 8: DEVPLAN.md. Write docs/DEVPLAN.md: bring-up steps in order, test points and what to meter first, risk list, and the prototype order plan.',
   },
@@ -626,7 +638,7 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
         res.outcome !== 'success'
           ? `the run ended as "${res.outcome}" (${res.exitPath})`
           : !(await stage.isComplete(opts.repoRoot, config.docs))
-            ? 'the run finished but the stage completion contract is not met — no usable artifact was produced'
+            ? `the run finished but the stage completion contract is not met: ${stage.contract}`
             : null;
       if (!failure) {
         stageDone = true;

--- a/test/create-resilience.test.ts
+++ b/test/create-resilience.test.ts
@@ -54,7 +54,7 @@ function ok(): RunResult {
 async function writeStageDoc(repoRoot: string, request: string): Promise<void> {
   const docs = path.join(repoRoot, 'docs');
   await mkdir(docs, { recursive: true });
-  if (request.includes('spec-seed')) await writeFile(path.join(docs, 'SPEC.md'), '# s\n\n## Budgets\n', 'utf8');
+  if (request.includes('spec-seed')) await writeFile(path.join(docs, 'SPEC.md'), '# s\n\n## Budgets\n\n- sleep_current_uA: 25\n', 'utf8');
   else if (request.includes('architecture')) await writeFile(path.join(docs, 'SUBSYSTEMS.md'), '# s\n', 'utf8');
   else if (request.includes('part-selection')) await writeFile(path.join(docs, 'BOM.md'), '# b\n', 'utf8');
 }
@@ -145,7 +145,7 @@ describe('create pipeline resilience (review F3)', () => {
       // (managed paths) — the resume-after-hard-kill situation.
       const docs = path.join(repo, 'docs');
       await mkdir(docs, { recursive: true });
-      await writeFile(path.join(docs, 'SPEC.md'), '# s\n\n## Budgets\n', 'utf8');
+      await writeFile(path.join(docs, 'SPEC.md'), '# s\n\n## Budgets\n\n- sleep_current_uA: 25\n', 'utf8');
       await writeFile(path.join(docs, 'SUBSYSTEMS.md'), '# s\n', 'utf8');
       await writeFile(path.join(docs, 'BOM.md'), '# b\n', 'utf8');
 
@@ -171,7 +171,7 @@ describe('create pipeline resilience (review F3)', () => {
 
       const docs = path.join(repo, 'docs');
       await mkdir(docs, { recursive: true });
-      await writeFile(path.join(docs, 'SPEC.md'), '# s\n\n## Budgets\n', 'utf8');
+      await writeFile(path.join(docs, 'SPEC.md'), '# s\n\n## Budgets\n\n- sleep_current_uA: 25\n', 'utf8');
       // A user's own uncommitted file, unrelated to copperhead's managed paths.
       await writeFile(path.join(repo, 'my-notes.txt'), 'do not touch\n', 'utf8');
 

--- a/test/create-stage-contracts.test.ts
+++ b/test/create-stage-contracts.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { runInit } from '../src/memory/scaffold.js';
+import { STAGES } from '../src/commands/create.js';
+import { tempFixtureRepo } from './helpers.js';
+
+const stage = (name: string) => {
+  const found = STAGES.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`stage ${name} not found`);
+  return found;
+};
+
+describe('create stage completion contracts', () => {
+  it('does not treat init placeholders as a completed spec or layout stage', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo, installHooks: false });
+
+      await expect(stage('spec-seed').isComplete(repo, 'docs/')).resolves.toBe(false);
+      await expect(stage('layout-draft').isComplete(repo, 'docs/')).resolves.toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('recognizes filled spec and layout contracts with a real footprint', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo, installHooks: false });
+      await writeFile(path.join(repo, 'docs', 'SPEC.md'), '# Spec\n\n## Budgets\n\n- sleep_current_uA: 25\n', 'utf8');
+      await writeFile(path.join(repo, 'docs', 'LAYOUT.md'), '# Layout\n\n## Draft quality\n\nHuman-reviewed draft.\n', 'utf8');
+      await writeFile(path.join(repo, 'hardware', 'open-key.kicad_pcb'), '(kicad_pcb (footprint "Test" (layer "F.Cu") (at 0 0)))\n', 'utf8');
+
+      await expect(stage('spec-seed').isComplete(repo, 'docs/')).resolves.toBe(true);
+      await expect(stage('layout-draft').isComplete(repo, 'docs/')).resolves.toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('treats malformed schematic and board files as incomplete rather than throwing', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo, installHooks: false });
+      await writeFile(path.join(repo, 'hardware', 'open-key.kicad_sch'), 'not a schematic', 'utf8');
+      await writeFile(path.join(repo, 'hardware', 'open-key.kicad_pcb'), 'not a board', 'utf8');
+
+      await expect(stage('schematic').isComplete(repo, 'docs/')).resolves.toBe(false);
+      await expect(stage('layout-draft').isComplete(repo, 'docs/')).resolves.toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/test/create-stage-turns.test.ts
+++ b/test/create-stage-turns.test.ts
@@ -13,7 +13,7 @@ const mockRunAgentLoop = vi.hoisted(() =>
     const docs = pathMod.join(opts.repoRoot, 'docs');
     await mkdirFs(docs, { recursive: true });
     if (opts.request.includes('spec-seed'))
-      await writeFileFs(pathMod.join(docs, 'SPEC.md'), '# spec\n\n## Budgets\n', 'utf8');
+      await writeFileFs(pathMod.join(docs, 'SPEC.md'), '# spec\n\n## Budgets\n\n- sleep_current_uA: 25\n', 'utf8');
     if (opts.request.includes('architecture'))
       await writeFileFs(pathMod.join(docs, 'SUBSYSTEMS.md'), '# subsystems\n', 'utf8');
     if (opts.request.includes('part-selection'))
@@ -104,6 +104,7 @@ describe('create pipeline per-stage turn budgets (AC-15.18, AC-15.19)', () => {
       expect(out).toContain('stopped at stage 4/8 (schematic)');
       expect(out).toMatch(/copperhead .*create --brief \S*brief\.md --model gpt-5/);
       expect(out).toContain('resumes at schematic');
+      expect(out).toContain('the schematic must contain symbols, be drift-clean, and pass ERC');
 
       // 5.2: a cost table with a row per stage that ran and a TOTAL.
       expect(out).toContain('Per-stage cost summary');


### PR DESCRIPTION
## What

Strengthens `copperhead create` completion contracts for the spec-seed, schematic, and layout stages. A generated template, empty board, or malformed KiCad file cannot be treated as a usable completed artifact.

## Why

This addresses the stage-contract portion of #23. The previous checks accepted `SPEC.md` with only a `## Budgets` heading and an initialized layout template. It does not close #23: outputs and firmware require their own contract design.

## Design

- `spec-seed` requires non-template content under the exact `## Budgets` section.
- Schematic completion remains symbols plus drift-clean docs plus passing ERC. Read or parse failures safely mean incomplete.
- Layout completion requires a parseable board containing a real top-level footprint and non-template content under `## Draft quality`.
- A stage that reports success but misses its contract now logs the specific required artifact before recovery or stop.
- The boolean `isComplete` signature is unchanged for compatibility with the related PRs.

## Spec / OpenSpec

Updated [SPEC.md](openspec/specs/SPEC.md) and the active [create-pipeline delta](openspec/changes/build-copperhead-phase-1/specs/create-pipeline/spec.md) to define repo-state completion contracts and post-run rechecks. OpenSpec validation could not run because the `openspec` executable is not installed by this repository after `npm ci`.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Markdown lint | `npm run lint:md` | pass |
| Focused contracts | `npx vitest run test/create-stage-contracts.test.ts test/create-stage-turns.test.ts test/create-resilience.test.ts` | pass: 8 tests |
| Unit + offline | `PATH="/Applications/KiCad/KiCad.app/Contents/MacOS:$PATH" npm test` | known baseline: 329 passed, 14 skipped, 2 unrelated KiCad 10.0.4 fixture failures in `gating-sync` and `init-check` |
| Live-LLM (opt-in) | keyed on `OPENAI_API_KEY` | n/a: no live provider run for this deterministic contract change |

New coverage rejects initialized placeholders and malformed schematic/board files, accepts filled positive artifacts, and verifies actionable unmet-contract recovery output.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): create
- Commands run and outcome: n/a. The post-agent acceptance path requires a live keyed provider; it is exercised deterministically through the focused `runCreate` and contract tests above.

```text
$ npm run build
passed
$ npm run lint:md
passed: 109 Markdown files
```

## Docs

Updated the normative SPEC and active OpenSpec delta.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, no tool-list or proposal-gate behavior changed.
- [x] **Verification-gated out**: schematic completion still requires ERC, and an unmet contract stops advancement.
- [ ] **`check`/`verify` stays LLM-free and network-free**: N/A, their module graph is unchanged.
- [x] **No sexp serialization**: the KiCad parser is used read-only to inspect board footprints.
- [ ] **Sync-obligations ledger**: N/A, ledger behavior is unchanged.
- [ ] **Secrets**: N/A, transcript and environment handling are unchanged.
- [ ] **Spec coherence**: SPEC and the active delta changed together; `openspec validate` is unavailable locally because the CLI is not installed after `npm ci`.
