### PR TITLE
fix(export): defuse spreadsheet formulas in supplier CSV fields

### DIFF
--- a/src/kicad/bom-export.ts
+++ b/src/kicad/bom-export.ts
@@ -164,9 +164,17 @@ function naturalCompare(a: string, b: string): number {
   return a.localeCompare(b);
 }
 
-/** RFC-4180 field quoting: quote when the field holds a comma, quote, or newline. */
+/**
+ * RFC-4180 field quoting: quote when the field holds a comma, quote, or newline.
+ *
+ * Fields opening with `=`, `+`, `-`, or `@` are also prefixed with an
+ * apostrophe: BOM.md cells are agent-written, and a spreadsheet opened on the
+ * export before upload would evaluate such a cell as a formula. No real MPN,
+ * manufacturer, or designator starts with one, so nothing orderable is altered.
+ */
 function csvField(value: string): string {
-  return /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+  const v = /^[=+\-@]/.test(value) ? `'${value}` : value;
+  return /[",\n\r]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v;
 }
 
 const csvRow = (fields: string[]): string => fields.map(csvField).join(',');

--- a/test/bom-export.test.ts
+++ b/test/bom-export.test.ts
@@ -122,6 +122,16 @@ describe('supplier format emitters (golden, supplier-bom-export)', () => {
         'RC0603FR-0710KL,Yageo,3,R1\n',
     );
   });
+
+  it('defuses cells a spreadsheet would evaluate as a formula', () => {
+    const hostile = parseBom(
+      '| Refdes | Value | Footprint | MPN | Manufacturer |\n' +
+        '|---|---|---|---|---|\n' +
+        '| R1 | 10k | R_0603 | =cmd\'/c calc\' | -Yageo |\n',
+    );
+    const { csv } = buildExport(hostile, 'mouser', { boards: 1, spares: 10, includeUnverified: false });
+    expect(csv.split('\n')[1]).toBe("'=cmd'/c calc','-Yageo,3,R1");
+  });
 });
 
 describe('exclusion rules (supplier-bom-export)', () => {


### PR DESCRIPTION
## Summary

#45 landed the full `add-supplier-bom-export` change, including the Mouser emitter this PR originally carried, so I have rebased this branch onto main and repointed it at the one review item from #35 that did not make it in: CSV formula injection in the shared `csvField`.

## What changes

BOM.md cells are agent-written, and the exports are routinely opened in a spreadsheet before being uploaded to a supplier. A cell starting with `=`, `+`, `-` or `@` is evaluated as a formula there, so `csvField` now prefixes those fields with an apostrophe on top of the existing RFC 4180 quoting.

The guard sits in the shared helper, so it covers the JLCPCB, DigiKey and Mouser formats at once. No real MPN, manufacturer, value or designator opens with one of those characters, so nothing orderable is altered and every existing golden expectation is untouched.

## Tests

One case added to the golden emitter block: a BOM row with `=cmd'/c calc'` as its MPN and `-Yageo` as its manufacturer comes out apostrophe-prefixed.

## Verification

- `npm run typecheck` passed
- `npx vitest run test/bom-export.test.ts`, 25 passed