### PR TITLE
Add PR template, body-lint check, contributor docs, and the pr-review skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: pr-review
+description: Review a copperhead pull request against the repo's invariants and spec workflow. Use when the user asks to review a PR, e.g. /pr-review 28 or /pr-review <url>.
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(openspec:*), Bash(npm:*)
+compatibility: Requires the gh CLI, authenticated against chouhanindustries/copperhead.
+metadata:
+  author: copperhead
+  version: "1.0"
+---
+
+Review a pull request for this repository. Present the findings report to the user, and also post it to the PR automatically as a comment (`gh pr comment <n>`) so the review is recorded on GitHub. Do NOT submit a formal review (`gh pr review --approve` / `--request-changes`) unless the user explicitly asks: those affect merge gating, whereas a plain comment does not.
+
+**Input**: a PR number or URL. If omitted, run `gh pr list --json number,title,author,headRefName` and either auto-select the single open PR or use the AskUserQuestion tool to let the user pick. Always announce which PR is being reviewed.
+
+**Steps**
+
+1. **Gather the change**
+   - `gh pr view <n> --json title,body,author,baseRefName,headRefName,files,additions,deletions`
+   - `gh pr diff <n>` for the full diff. For large PRs, read the diff per file.
+   - Read the surrounding context of every changed hunk in the working tree (or via `gh api`) so findings are grounded in real code, not diff fragments.
+
+2. **General review**: correctness, edge cases, error handling, test coverage for new behavior, and whether the PR does what its description claims. Flag scope creep (changes unrelated to the stated purpose).
+
+3. **Repo invariant checks** (each is a hard requirement from SPEC.md; violations are high severity):
+   - **Spec-gated in**: `edit_file`/`write_file` must remain structurally absent from the agent tool list until an OpenSpec proposal validates. Reject any change that exposes mutation tools unconditionally or gates them by prompt text instead of by omission.
+   - **Verification-gated out**: mutations must still end in ERC (and DRC when the board changed) passing, with repair up to `maxRepairCycles` then rollback to the git snapshot. Watch for paths that skip verification or mark a run done early.
+   - **`check`/`verify` stays LLM-free and network-free**: no change may make `src/commands/check` (or anything it imports) touch a provider, an API key, or the network.
+   - **No sexp serialization**: the parser in `src/kicad/` is read-only; KiCad files are edited only via anchored exact-match text replace. Reject any round-tripping.
+   - **Sync-obligations ledger**: post-tool-call hooks must keep feeding the ledger, and commit must keep refusing while obligations are open.
+   - **Secrets**: transcripts and summaries redact `sk-[A-Za-z0-9_-]+` at write time; keys live only in env vars; `.gitignore` keeps `.env` and `.copperhead/runs/`.
+
+4. **Spec coherence**: if the PR changes spec-level behavior, `openspec/specs/SPEC.md` and the active change artifacts (`proposal.md`, `design.md`, delta specs, `tasks.md`) must move together. Run `openspec validate build-copperhead-phase-1` when planning artifacts changed. A code-only PR that silently diverges from SPEC.md is a finding.
+
+5. **Verify before reporting**: for each candidate finding, re-read the code and try to refute it. Drop anything speculative or already handled elsewhere. If the PR touches build or tests, run `npm test` locally on the PR branch when feasible and report actual results, never assumed ones.
+
+**Output**
+
+A short verdict first (approve / approve with nits / request changes), then findings ranked by severity. Each finding: one-sentence claim, the file and line, and a concrete failure scenario. Note explicitly which invariant checks were performed and passed, so a clean report is distinguishable from an unexamined one.
+
+After presenting the report to the user, post the same report to the PR automatically with `gh pr comment <n> --body <report>`, opening it with a line that marks it as an automated pr-review pass (so a human review is not implied). Announce that you posted it and link the comment. Only if the user then explicitly asks to submit a formal review, use `gh pr review <n>` with the appropriate `--approve` / `--request-changes` / `--comment` flag and the findings as body.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,52 @@
+<!--
+Fill in the sections that apply and delete the rest, including this comment.
+Keep prose em-dash-free (use colons, commas, or parentheses).
+Reference files as clickable relative links, e.g. [loop.ts](src/agent/loop.ts).
+-->
+
+## What
+
+<!-- One or two sentences: what this PR changes, from the user's point of view. -->
+
+## Why
+
+<!-- The gap or problem this closes. Link the issue if there is one. -->
+
+## Design
+
+<!-- Only if the change is non-trivial. How it works and the load-bearing decisions.
+     If it touches the agent loop, safety gates, providers, or the KiCad layer, say how the
+     invariants below are preserved. Link to design.md decisions where relevant. -->
+
+## Spec / OpenSpec
+
+<!-- If this changes spec-level behavior, SPEC.md and the active change artifacts must move together.
+     List the OpenSpec change, the affected acceptance criteria (AC-x.y), and any delta specs.
+     Delete this section for a pure refactor or docs-only PR. -->
+
+## Testing
+
+<!-- What you ran and what it produced (real results, not assumed):
+     - new or changed tests, and pass/skip counts
+     - `npm run typecheck` / `npm run build` / `npm test` status
+     - any live-LLM verification, and how it was keyed
+     - known pre-existing failures unrelated to this PR -->
+
+## Docs
+
+<!-- README, configuration reference, .env.example, doc comments, or CHANGELOG/DECISIONS entries touched. -->
+
+---
+
+## Invariant checklist
+
+<!-- These are hard requirements from SPEC.md. Check the boxes this PR is responsible for;
+     mark N/A for the ones it does not touch. A reviewer will verify each. -->
+
+- [ ] **Spec-gated in**: `edit_file`/`write_file` stay structurally absent from the agent tool list until an OpenSpec proposal validates (gated by omission, not prompt text).
+- [ ] **Verification-gated out**: mutations still end in ERC (and DRC when the board changed) passing, with repair up to `maxRepairCycles` then rollback to the git snapshot.
+- [ ] **`check`/`verify` stays LLM-free and network-free**: nothing reachable from `src/commands/check` touches a provider, an API key, or the network.
+- [ ] **No sexp serialization**: the `src/kicad/` parser stays read-only; KiCad files are edited only via anchored exact-match text replace (no round-tripping).
+- [ ] **Sync-obligations ledger**: post-tool-call hooks keep feeding the ledger, and commit keeps refusing while obligations are open.
+- [ ] **Secrets**: transcripts and summaries redact `sk-[A-Za-z0-9_-]+` at write time; keys live only in env vars; `.gitignore` keeps `.env` and `.copperhead/runs/`.
+- [ ] **Spec coherence**: if spec-level behavior changed, SPEC.md and the change artifacts (`proposal.md`, `design.md`, delta specs, `tasks.md`) moved together and `openspec validate <change>` passes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,11 +26,35 @@ Reference files as clickable relative links, e.g. [loop.ts](src/agent/loop.ts).
 
 ## Testing
 
-<!-- What you ran and what it produced (real results, not assumed):
-     - new or changed tests, and pass/skip counts
-     - `npm run typecheck` / `npm run build` / `npm test` status
-     - any live-LLM verification, and how it was keyed
-     - known pre-existing failures unrelated to this PR -->
+<!-- Real results only, never assumed. Fill in the status table and the manual-test log below. -->
+
+### Automated test status
+
+<!-- Report what you actually ran. Use pass / fail / skip / n/a, with counts where it helps. -->
+
+| Check | Command | Status |
+| --- | --- | --- |
+| Typecheck | `npm run typecheck` | |
+| Build | `npm run build` | |
+| Unit + offline | `npm test` | |
+| Live-LLM (opt-in) | keyed on `<ENV_VAR>` | |
+
+<!-- New or changed tests, and known pre-existing failures unrelated to this PR: -->
+
+### Manual test log (required)
+
+<!-- Required for any change to CLI behavior, the agent loop, providers, or the KiCad layer.
+     Exercise the CLI by hand against the manual-tests sandbox (see manual-tests/README.md),
+     and paste the commands you ran with their outcome. Write "n/a" with a reason only for
+     changes that cannot be exercised at runtime (e.g. docs-only or CI-config-only). -->
+
+- Sandbox variant used (`create` / `edit`):
+- Commands run and outcome:
+
+```text
+$ <command>
+<result>
+```
 
 ## Docs
 

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,59 @@
+name: PR lint
+
+# Checks that a PR description still follows .github/pull_request_template.md:
+# the required sections and the invariant checklist must be present and non-empty.
+# It verifies presence, not truth. A reviewer (see the pr-review skill) still confirms
+# the content is honest and the ticked invariants actually hold.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  template:
+    runs-on: ubuntu-latest
+    # Drafts are works in progress; Dependabot does not use our template.
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    steps:
+      - name: Check PR description
+        env:
+          # Passed via env, never interpolated into the script, so a crafted body cannot inject shell.
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          node <<'EOF'
+          const body = process.env.PR_BODY || "";
+          // Drop HTML comments so the template's placeholder guidance never counts as content.
+          const stripped = body.replace(/<!--[\s\S]*?-->/g, "");
+
+          // Bucket lines under their nearest "## Heading".
+          const sections = {};
+          let current = null;
+          for (const line of stripped.split(/\r?\n/)) {
+            const h = line.match(/^\s*##\s+(.+?)\s*$/);
+            if (h) { current = h[1].toLowerCase(); sections[current] = sections[current] || []; continue; }
+            if (current) sections[current].push(line);
+          }
+          const hasContent = (name) => {
+            const key = Object.keys(sections).find((k) => k.startsWith(name));
+            return key !== undefined && sections[key].some((l) => l.trim().length > 0);
+          };
+
+          const problems = [];
+          for (const req of ["what", "why", "testing"]) {
+            if (!hasContent(req)) problems.push(`Section "## ${req[0].toUpperCase() + req.slice(1)}" is missing or empty.`);
+          }
+          // The invariant checklist must survive (checkboxes may be unchecked or marked N/A).
+          if (!/^\s*-\s*\[[ xX]\]/m.test(stripped)) {
+            problems.push('The invariant checklist is missing (no "- [ ]" items found).');
+          }
+
+          if (problems.length) {
+            console.error("PR description does not follow the template:\n");
+            for (const p of problems) console.error("  - " + p);
+            console.error("\nSee .github/pull_request_template.md. Fill in the sections and keep the invariant checklist.");
+            process.exit(1);
+          }
+          console.log("PR description follows the template.");
+          EOF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,24 @@ The offline test suite runs without any credentials. Integration tests that call
 
 For exercising the CLI by hand against a real repository, see [manual-tests/README.md](manual-tests/README.md). It provides two sandbox variants: `create` (full pipeline from a product brief) and `edit` (`init`, `check`, and the `do` loop on an existing KiCad project).
 
+Any change to CLI behavior, the agent loop, providers, or the KiCad layer must be exercised by hand in this sandbox before you open a PR, and the commands you ran plus their outcome go in the PR's manual-test log (see below).
+
 ## Making changes
 
 - This repo uses spec-driven development with OpenSpec. Behavior changes should stay consistent with `openspec/specs/SPEC.md`; if your change alters spec-level behavior, update the spec alongside the code.
 - Keep pull requests focused: one logical change per PR.
 - Add or update tests for anything you change. The offline suite must stay green.
+
+## Opening a pull request
+
+Opening a PR fills the description with [our template](.github/pull_request_template.md). Keep its sections and fill them in:
+
+- **What / Why**: what the change does and the gap it closes.
+- **Design / Spec**: for non-trivial or spec-level changes, how it works and which acceptance criteria or OpenSpec artifacts move with it.
+- **Testing**: the automated status table (typecheck, build, `npm test`, live-LLM if keyed) with real results, plus the required manual-test log. Report actual outcomes, never assumed ones. Write "n/a" with a reason only for changes that cannot be exercised at runtime, such as docs-only or CI-config-only PRs.
+- **Invariant checklist**: tick the invariants your change is responsible for and mark the rest n/a. A reviewer verifies each.
+
+A `PR lint` check runs on every PR and fails if a required section or the invariant checklist is missing or empty, so do not delete them. The lint verifies presence, not truth; a reviewer still confirms the manual log is real and the ticked invariants hold. Keep prose em-dash-free (use colons, commas, or parentheses).
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
## What

Adds a pull-request template, a `PR lint` workflow that enforces it, the matching contributor docs, and the `pr-review` skill (previously untracked) that reviews a PR against the repo invariants. Opening a PR now pre-fills What/Why/Design/Spec/Testing/Docs plus an invariant checklist; a CI check fails any PR whose description drops a required section or the checklist; and the pr-review skill posts its findings back to the PR as a comment.

## Why

Nothing recorded what a PR should contain, and the SPEC.md invariants (spec-gating, verification-gating, secrets, etc.) were only checked ad hoc at review time. Surfacing them at authoring time, blocking a stripped-out description, and tracking the review skill in-repo makes reviews faster and keeps the invariants visible to contributors.

## Design

Enforcement is layered:

- [.github/pull_request_template.md](.github/pull_request_template.md): the prompt. Sections plus an invariant checklist mapped 1:1 onto the pr-review skill's hard requirements. HTML-comment guidance stays invisible in the rendered PR.
- [.github/workflows/pr-lint.yml](.github/workflows/pr-lint.yml): the gate for presence. Runs on `opened`/`edited`/`synchronize`/`reopened`/`ready_for_review`, strips HTML comments so placeholders do not count as content, and fails if `## What`, `## Why`, `## Testing`, or the checklist are missing or empty. The PR body is passed via an env var, never interpolated into the script, so a crafted body cannot inject shell. Drafts and Dependabot are skipped.
- [.claude/skills/pr-review/SKILL.md](.claude/skills/pr-review/SKILL.md): the review-time check for truth. It verifies the invariants the lint cannot, and now posts its findings report to the PR as a comment automatically. The merge-gating `gh pr review` (approve / request-changes) stays behind an explicit ask.
- [CONTRIBUTING.md](CONTRIBUTING.md): documents the template, the lint, and the required manual-test log.

The lint verifies presence, not truth; the skill and a human reviewer confirm the manual log is real and the ticked invariants hold. Turning `PR lint` and `test` into required checks is tracked separately in #38 (branch protection).

## Spec / OpenSpec

No spec-level behavior changes. Tooling, skill, and docs only; SPEC.md and the OpenSpec artifacts are untouched.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | n/a (no source changed) |
| Build | `npm run build` | n/a (no source changed) |
| Unit + offline | `npm test` | n/a (no source changed) |
| Live-LLM (opt-in) | keyed on `<ENV_VAR>` | n/a |

This PR touches only Markdown and a GitHub Actions workflow; no application code is changed, so the suites above are not affected.

### Manual test log (required)

n/a for the CLI sandbox: docs, CI-config, and skill only, nothing runtime-exercisable in manual-tests. Both artifacts were exercised in place instead:
- `pr-lint` ran live against this PR's own description and passed (the `template` check).
- The `pr-review` skill was run against this PR; it produced the invariant-checked findings report and auto-posted it as a comment.

## Docs

[CONTRIBUTING.md](CONTRIBUTING.md): new "Opening a pull request" section and a manual-testing note that runtime-affecting changes must be exercised in the sandbox before a PR.

---

## Invariant checklist

- [ ] **Spec-gated in**: n/a (no agent tooling changed).
- [ ] **Verification-gated out**: n/a (no mutation path changed).
- [ ] **`check`/`verify` stays LLM-free and network-free**: n/a (no source changed).
- [ ] **No sexp serialization**: n/a (parser untouched).
- [ ] **Sync-obligations ledger**: n/a (loop untouched).
- [ ] **Secrets**: n/a (no transcript/summary code changed).
- [ ] **Spec coherence**: n/a (no spec-level behavior changed).

🤖 Generated with Claude Code