### PR TITLE
Post PR-lint results as a comment

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -4,12 +4,18 @@ name: PR lint
 # the required sections and the invariant checklist must be present and non-empty.
 # It verifies presence, not truth. A reviewer (see the pr-review skill) still confirms
 # the content is honest and the ticked invariants actually hold.
+#
+# Uses pull_request_target so the job holds a writable token and can post its result
+# as a comment on fork PRs (a plain pull_request run gets a read-only token on forks).
+# This is safe here only because the workflow never checks out or runs PR code: it reads
+# the PR body from an env var and parses it. Do not add a checkout of the PR head.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   template:
@@ -18,11 +24,13 @@ jobs:
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       - name: Check PR description
+        id: check
         env:
           # Passed via env, never interpolated into the script, so a crafted body cannot inject shell.
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           node <<'EOF'
+          const fs = require("fs");
           const body = process.env.PR_BODY || "";
           // Drop HTML comments so the template's placeholder guidance never counts as content.
           const stripped = body.replace(/<!--[\s\S]*?-->/g, "");
@@ -49,11 +57,53 @@ jobs:
             problems.push('The invariant checklist is missing (no "- [ ]" items found).');
           }
 
+          // Build a PR comment. The marker line lets a later run find and update this
+          // same comment instead of posting a new one on every edit.
+          const marker = "<!-- pr-lint-report -->";
+          let report;
+          if (problems.length) {
+            report = [
+              marker,
+              "**PR lint failed: the description does not follow the template.**",
+              "",
+              ...problems.map((p) => "- " + p),
+              "",
+              "See `.github/pull_request_template.md`. Fill in the sections and keep the invariant checklist.",
+              "This check verifies presence, not truth: a reviewer still confirms the content is honest.",
+            ].join("\n");
+          } else {
+            report = marker + "\n**PR lint passed: the description follows the template.**";
+          }
+
+          const out = process.env.GITHUB_OUTPUT;
+          fs.appendFileSync(out, `status=${problems.length ? "fail" : "pass"}\n`);
+          fs.appendFileSync(out, `report<<PR_LINT_EOF\n${report}\nPR_LINT_EOF\n`);
+
           if (problems.length) {
             console.error("PR description does not follow the template:\n");
             for (const p of problems) console.error("  - " + p);
-            console.error("\nSee .github/pull_request_template.md. Fill in the sections and keep the invariant checklist.");
-            process.exit(1);
+          } else {
+            console.log("PR description follows the template.");
           }
-          console.log("PR description follows the template.");
           EOF
+
+      - name: Post result as a comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          REPORT: ${{ steps.check.outputs.report }}
+        run: |
+          marker='<!-- pr-lint-report -->'
+          # Reuse our own prior comment (found by the hidden marker) so edits update in place.
+          id=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                 --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1)
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$id" -f body="$REPORT" >/dev/null
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$REPORT" >/dev/null
+          fi
+
+      - name: Fail if the description is incomplete
+        if: ${{ steps.check.outputs.status == 'fail' }}
+        run: exit 1


### PR DESCRIPTION
## What

The PR-lint check now posts its result as a comment on the PR, listing exactly which template sections or the invariant checklist are missing, instead of only writing to the Actions job log.

## Why

The findings were only visible by opening the failed check's Details in the Actions tab, so authors rarely saw what was wrong. A comment puts the specific gaps in front of them. Every open PR is currently from a fork, and a plain `pull_request` run gets a read-only token on forks, so it could not comment at all.

## Design

The trigger moves from `pull_request` to `pull_request_target` so the job holds a writable token in the base-repo context. This stays safe because the workflow never checks out or runs PR code: it reads the body from the `PR_BODY` env var and parses it, same as before. A file comment warns against adding a PR-head checkout. The comment carries a hidden `<!-- pr-lint-report -->` marker so later runs (on edit or synchronize) update the same comment in place rather than piling on new ones. The check still exits non-zero on an incomplete description, so merge gating is unchanged. See [pr-lint.yml](.github/workflows/pr-lint.yml).

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | n/a |
| Build | `npm run build` | n/a |
| Unit + offline | `npm test` | n/a |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY` | n/a |

CI-config-only change: no application code is touched. The YAML was validated as parseable and the node parsing/output logic was dry-run locally against sample bodies to confirm it detects missing sections and emits the comment payload.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a
- Commands run and outcome: n/a, CI-config-only. The workflow cannot be exercised from the CLI sandbox; `pull_request_target` runs the default-branch version, so it will be observable on PRs once merged.

```text
n/a
```

## Docs

None.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, no agent tooling touched.
- [ ] **Verification-gated out**: N/A, no mutation path touched.
- [ ] **`check`/`verify` stays LLM-free and network-free**: N/A, CI workflow only.
- [ ] **No sexp serialization**: N/A, KiCad layer untouched.
- [ ] **Sync-obligations ledger**: N/A, loop untouched.
- [ ] **Secrets**: N/A, no transcript or key handling touched.
- [ ] **Spec coherence**: N/A, no spec-level behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)