### PR TITLE
Add supplier BOM export (jlcpcb/digikey/mouser) via

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ copperhead export bom --supplier mouser --spares 15     # Mouser cart CSV, 15% s
 - `--boards <n>` (default 1) and `--spares <percent>` (default 10) set the order quantity: `ceil(perBoardCount × boards × (1 + spares/100))`, raised to `perBoardCount × boards + 2` for passive lines (footprints `R_`/`C_`/`L_`) — losing a couple of 0402s to tweezers is the norm, and percentage-only spares under-order low-count passives.
 - Rows without an MPN, and rows still flagged `UNVERIFIED`, are excluded from the supplier file and named in a warnings footer on stderr. `--include-unverified` opts the flagged-but-MPN'd rows back in (it never includes MPN-less rows). `create` stage 6 also emits `outputs/jlcpcb-bom.csv` automatically.
 
-`docs/BOM.md` may carry optional `Manufacturer` and `LCSC` columns beyond the base `Refdes | Value | Footprint | MPN | Rationale` — the exporter matches columns by header, so add them when you want them populated in supplier files; `init` scaffolds the base columns only.
+`docs/BOM.md` may carry optional `Manufacturer` and `LCSC` columns beyond the base `Refdes | Value | Footprint | MPN | Rationale` — the exporter matches columns by header, so add them when you want them populated in supplier files; `init` scaffolds the base columns only. Only *appending* columns is safe: keep `Refdes | Value | Footprint` first and in that order, because the drift check (`check`/`sync`, which the exporter gates on) reads those three by position — reordering them makes it compare the wrong cells and refuse the export with a spurious drift message.
 
 Nothing is a black box: decisions land in an append-only `docs/DECISIONS.md`, every run writes a human-readable summary next to its transcript, and a per-run `docs/CHANGELOG.md` narrates the design history.
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,26 @@ copperhead do "<change request>"     # the core loop: propose, edit, verify, pro
 copperhead check                     # ERC + DRC + doc-drift + spec validation; no LLM calls (alias: verify)
 copperhead sync [--dry-run]          # verify the whole design state, resolve drift
 copperhead create --brief brief.md   # brief → full output package
+copperhead export bom --supplier jlcpcb   # supplier-ready ordering file from docs/BOM.md
 ```
 
 Global flags: `--repo <path>` (default: cwd) and `--json` for machine-readable output. `do` and `create` take `--model` and `--interactive`; `do` also takes `--dry-run`, `--max-turns`, and `--allow-dirty`.
+
+### Ordering (`export bom`)
+
+`copperhead export bom` turns the drift-checked `docs/BOM.md` into a file a supplier accepts without hand-editing. It is deterministic, LLM-free, and network-free — safe anywhere `check` is, and it reads `BOM.md` (never the schematic) so it inherits the drift guarantee; it refuses to export while `BOM.md` disagrees with the schematic.
+
+```bash
+copperhead export bom --supplier jlcpcb                 # JLCPCB assembly CSV → outputs/jlcpcb-bom.csv
+copperhead export bom --supplier digikey --boards 25    # DigiKey cart CSV, quantities for 25 boards
+copperhead export bom --supplier mouser --spares 15     # Mouser cart CSV, 15% spare parts
+```
+
+- `--supplier <jlcpcb|digikey|mouser>` (required). JLCPCB gets the assembly-service format (Comment, Designator, Footprint, LCSC Part #, designators grouped per line); DigiKey and Mouser get cart-upload lists (MPN, manufacturer, quantity, customer reference).
+- `--boards <n>` (default 1) and `--spares <percent>` (default 10) set the order quantity: `ceil(perBoardCount × boards × (1 + spares/100))`, raised to `perBoardCount × boards + 2` for passive lines (footprints `R_`/`C_`/`L_`) — losing a couple of 0402s to tweezers is the norm, and percentage-only spares under-order low-count passives.
+- Rows without an MPN, and rows still flagged `UNVERIFIED`, are excluded from the supplier file and named in a warnings footer on stderr. `--include-unverified` opts the flagged-but-MPN'd rows back in (it never includes MPN-less rows). `create` stage 6 also emits `outputs/jlcpcb-bom.csv` automatically.
+
+`docs/BOM.md` may carry optional `Manufacturer` and `LCSC` columns beyond the base `Refdes | Value | Footprint | MPN | Rationale` — the exporter matches columns by header, so add them when you want them populated in supplier files; `init` scaffolds the base columns only.
 
 Nothing is a black box: decisions land in an append-only `docs/DECISIONS.md`, every run writes a human-readable summary next to its transcript, and a per-run `docs/CHANGELOG.md` narrates the design history.
 

--- a/openspec/changes/add-supplier-bom-export/tasks.md
+++ b/openspec/changes/add-supplier-bom-export/tasks.md
@@ -2,25 +2,25 @@
 
 ## 1. Export core
 
-- [ ] 1.1 Extract the BOM.md table parser from `src/memory/drift.ts` into a shared module and reuse it
-- [ ] 1.2 Implement quantity arithmetic (`ceil(qty × boards × (1 + spares/100))`, passive minimum `qty × boards + 2` for `R_`/`C_`/`L_` footprint prefixes) with unit tests
-- [ ] 1.3 Implement per-supplier emitters in `src/kicad/bom-export.ts`: JLCPCB assembly CSV, DigiKey cart CSV, Mouser cart CSV, each as one function
-- [ ] 1.4 Implement exclusion rules: MPN-less rows always excluded, `UNVERIFIED` rows excluded unless `--include-unverified`; warnings footer to stderr and CSV comments where the format permits
+- [x] 1.1 Extract the BOM.md table parser from `src/memory/drift.ts` into a shared module and reuse it — `parseMarkdownTables` is now imported by `src/kicad/bom-export.ts`'s header-aware `parseBom`
+- [x] 1.2 Implement quantity arithmetic (`ceil(qty × boards × (1 + spares/100))`, passive minimum `qty × boards + 2` for `R_`/`C_`/`L_` footprint prefixes) with unit tests — `orderQuantity` (float-dust-safe) + `isPassiveFootprint`
+- [x] 1.3 Implement per-supplier emitters in `src/kicad/bom-export.ts`: JLCPCB assembly CSV, DigiKey cart CSV, Mouser cart CSV, each as one function
+- [x] 1.4 Implement exclusion rules: MPN-less rows always excluded, `UNVERIFIED` rows excluded unless `--include-unverified`; warnings footer to stderr (CSV comments omitted — strict supplier upload formats reject comment lines, so the footer stays on stderr and in `--json`)
 
 ## 2. CLI wiring
 
-- [ ] 2.1 Add `src/commands/export.ts` with `export bom --supplier --boards --spares --include-unverified`; validate supplier values with a helpful error
-- [ ] 2.2 Refuse export with a drift hint when the parsed BOM.md disagrees with the schematic parse
-- [ ] 2.3 Wire the JLCPCB emitter into `create` stage 6 outputs
+- [x] 2.1 Add `src/commands/export.ts` with `export bom --supplier --boards --spares --include-unverified`; validate supplier values with a helpful error
+- [x] 2.2 Refuse export with a drift hint when the parsed BOM.md disagrees with the schematic parse
+- [x] 2.3 Wire the JLCPCB emitter into `create` stage 6 outputs — `emitCreateJlcpcbBom`, called whenever the outputs stage is confirmed complete
 
 ## 3. Tests
 
-- [ ] 3.1 Golden-file tests per supplier format against the fixture BOM
-- [ ] 3.2 Exclusion and `--include-unverified` behavior tests
-- [ ] 3.3 Drift-refusal test (edited BOM.md value → non-zero exit, drift hint)
-- [ ] 3.4 Network guard: no api.* connections during export
+- [x] 3.1 Golden-file tests per supplier format against the fixture BOM
+- [x] 3.2 Exclusion and `--include-unverified` behavior tests
+- [x] 3.3 Drift-refusal test (edited BOM.md value → non-zero exit, drift hint)
+- [x] 3.4 Network guard: no api.* connections during export (global `fetch` spy asserts zero calls)
 
 ## 4. Docs
 
-- [ ] 4.1 README: ordering section (`export bom` usage, quantity knobs, what gets excluded and why)
-- [ ] 4.2 Decide and document the optional `LCSC` column in the BOM.md scaffold (design open question)
+- [x] 4.1 README: ordering section (`export bom` usage, quantity knobs, what gets excluded and why)
+- [x] 4.2 Decide and document the optional `LCSC` column in the BOM.md scaffold (design open question) — decision: keep `init` scaffolding the base columns only; the exporter matches `Manufacturer`/`LCSC` by header when present, documented in the README ordering section. Leaves the scaffold table narrow while letting hand/agent-maintained BOMs opt in.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import {
   parseSpares,
   ExportError,
 } from './commands/export.js';
+import { DEFAULT_BOARDS, DEFAULT_SPARES } from './kicad/bom-export.js';
 import { runAgentLoop, type BudgetExhaustedStats } from './agent/loop.js';
 import { makeRenderer } from './agent/render.js';
 import { kicadCliVersion } from './kicad/cli.js';
@@ -236,8 +237,8 @@ exportCmd
   .command('bom')
   .description('write a supplier-format BOM (jlcpcb | digikey | mouser) from docs/BOM.md')
   .requiredOption('--supplier <name>', 'jlcpcb | digikey | mouser')
-  .option('--boards <n>', 'number of boards to order', '1')
-  .option('--spares <percent>', 'spare parts percentage', '10')
+  .option('--boards <n>', 'number of boards to order', String(DEFAULT_BOARDS))
+  .option('--spares <percent>', 'spare parts percentage', String(DEFAULT_SPARES))
   .option('--include-unverified', 'include UNVERIFIED rows that carry an MPN (never MPN-less rows)')
   .action(async (opts: { supplier: string; boards: string; spares: string; includeUnverified?: boolean }) => {
     const repo = repoOf(program.opts());

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,13 @@ import { runInit, InitError } from './memory/scaffold.js';
 import { runCheck } from './commands/check.js';
 import { syncVerify, syncResolve, formatSyncReport } from './commands/sync.js';
 import { runCreate } from './commands/create.js';
+import {
+  runExportBom,
+  parseSupplier,
+  parseBoards,
+  parseSpares,
+  ExportError,
+} from './commands/export.js';
 import { runAgentLoop, type BudgetExhaustedStats } from './agent/loop.js';
 import { makeRenderer } from './agent/render.js';
 import { kicadCliVersion } from './kicad/cli.js';
@@ -217,6 +224,48 @@ program
       process.exit(res.ok ? 0 : 1);
     } catch (err) {
       console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+const exportCmd = program
+  .command('export')
+  .description('emit supplier-ready files from repo state (deterministic; no LLM, no network)');
+
+exportCmd
+  .command('bom')
+  .description('write a supplier-format BOM (jlcpcb | digikey | mouser) from docs/BOM.md')
+  .requiredOption('--supplier <name>', 'jlcpcb | digikey | mouser')
+  .option('--boards <n>', 'number of boards to order', '1')
+  .option('--spares <percent>', 'spare parts percentage', '10')
+  .option('--include-unverified', 'include UNVERIFIED rows that carry an MPN (never MPN-less rows)')
+  .action(async (opts: { supplier: string; boards: string; spares: string; includeUnverified?: boolean }) => {
+    const repo = repoOf(program.opts());
+    const json = Boolean(program.opts().json);
+    try {
+      const supplier = parseSupplier(opts.supplier);
+      const boards = parseBoards(opts.boards);
+      const spares = parseSpares(opts.spares);
+      const res = await runExportBom({
+        repoRoot: repo,
+        supplier,
+        boards,
+        spares,
+        includeUnverified: opts.includeUnverified ?? false,
+      });
+      // Warnings go to stderr so a `> file` redirect of stdout stays clean and
+      // the excluded-rows report is still seen.
+      for (const w of res.warnings) console.error(w);
+      if (json) {
+        console.log(JSON.stringify(res, null, 2));
+      } else {
+        console.log(`wrote ${res.outPath} (${res.included.length} part(s), ${res.excluded.length} excluded)`);
+      }
+      process.exit(0);
+    } catch (err) {
+      // ExportError carries an actionable message (bad flag, missing BOM, drift);
+      // anything else is unexpected. Both exit non-zero with no stack trace.
+      console.error(err instanceof ExportError ? err.message : (err as Error).message);
       process.exit(1);
     }
   });

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -10,6 +10,7 @@ import type { RunMetaInput } from '../agent/runmeta.js';
 import type { ProgressRenderer } from '../agent/render.js';
 import { openspecInit } from '../openspec/cli.js';
 import { runCheck } from './check.js';
+import { emitCreateJlcpcbBom } from './export.js';
 
 /**
  * Mode A (`copperhead create`, SPEC §2.5): staged pipeline, each stage a
@@ -122,6 +123,18 @@ export interface CreateOptions {
   meta?: Omit<RunMetaInput, 'stage' | 'brief'>;
 }
 
+/**
+ * Stage 6 emits the JLCPCB assembly BOM deterministically alongside the agent's
+ * outputs package (create-pipeline delta). Called whenever the outputs stage is
+ * confirmed complete — on the pass that finishes it and on any later resume — so
+ * the file tracks the current BOM.md.
+ */
+async function emitJlcpcbAfterOutputs(stageName: string, opts: CreateOptions): Promise<void> {
+  if (stageName !== 'outputs') return;
+  const out = await emitCreateJlcpcbBom(opts.repoRoot);
+  if (out) opts.log(`stage outputs: emitted ${out} (JLCPCB assembly BOM)`);
+}
+
 export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; completed: string[] }> {
   const brief = await readFile(path.resolve(opts.briefPath), 'utf8');
   // Hashed from the content already in hand: a brief edited mid-pipeline shows
@@ -135,6 +148,7 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
     if (await stage.isComplete(opts.repoRoot, config.docs)) {
       opts.log(`stage ${stage.name}: already complete (resuming past it)`);
       completed.push(stage.name);
+      await emitJlcpcbAfterOutputs(stage.name, opts);
       continue;
     }
     opts.log(`stage ${stage.name}: running`);
@@ -174,6 +188,7 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
       return { ok: false, completed };
     }
     completed.push(stage.name);
+    await emitJlcpcbAfterOutputs(stage.name, opts);
   }
 
   const check = await runCheck(opts.repoRoot, opts.log);

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,0 +1,117 @@
+import path from 'node:path';
+import { existsSync } from 'node:fs';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { loadConfig } from '../config.js';
+import { checkDrift } from '../memory/drift.js';
+import { buildExport, parseBom, SUPPLIERS, isSupplier, type Supplier, type ExportResult } from '../kicad/bom-export.js';
+
+/**
+ * `copperhead export bom` (capability supplier-bom-export): deterministic,
+ * LLM-free, network-free — safe anywhere `check` is safe. This module must never
+ * import a provider.
+ */
+export class ExportError extends Error {}
+
+export interface ExportBomOptions {
+  repoRoot: string;
+  supplier: Supplier;
+  boards: number;
+  spares: number;
+  includeUnverified: boolean;
+}
+
+export interface ExportBomResult extends ExportResult {
+  supplier: Supplier;
+  /** Repo-relative path the CSV was written to. */
+  outPath: string;
+}
+
+const OUT_DIR = 'outputs';
+
+export function outFileFor(supplier: Supplier): string {
+  return path.join(OUT_DIR, `${supplier}-bom.csv`);
+}
+
+/**
+ * Read BOM.md, refuse on drift, and write the supplier CSV to
+ * outputs/<supplier>-bom.csv. Throws ExportError with an actionable message for
+ * the caller to print and exit non-zero.
+ */
+export async function runExportBom(opts: ExportBomOptions): Promise<ExportBomResult> {
+  const config = await loadConfig(opts.repoRoot);
+  const bomPath = path.join(opts.repoRoot, config.docs, 'BOM.md');
+  if (!existsSync(bomPath)) {
+    throw new ExportError(
+      `no ${path.join(config.docs, 'BOM.md')} to export — run copperhead init on an existing project, or copperhead create`,
+    );
+  }
+
+  // BOM.md is the sole input, but it must agree with the schematic before it can
+  // be trusted as an ordering source (requirement "BOM.md is the sole input").
+  // Refuse loudly here rather than let a drifted BOM become a wrong order.
+  if (config.schematic && existsSync(path.join(opts.repoRoot, config.schematic))) {
+    const drift = await checkDrift(opts.repoRoot, config.docs, config.schematic);
+    if (drift.length) {
+      const lines = drift.map((m) => `  - ${m.doc} claims "${m.claim}" but actual is "${m.actual}"`).join('\n');
+      throw new ExportError(
+        `BOM.md drifts from the schematic; run \`copperhead check\` and resolve drift before ordering:\n${lines}`,
+      );
+    }
+  }
+
+  const rows = parseBom(await readFile(bomPath, 'utf8'));
+  const result = buildExport(rows, opts.supplier, {
+    boards: opts.boards,
+    spares: opts.spares,
+    includeUnverified: opts.includeUnverified,
+  });
+
+  const outPath = outFileFor(opts.supplier);
+  await mkdir(path.join(opts.repoRoot, OUT_DIR), { recursive: true });
+  await writeFile(path.join(opts.repoRoot, outPath), result.csv, 'utf8');
+
+  return { ...result, supplier: opts.supplier, outPath };
+}
+
+/**
+ * Deterministically emit the JLCPCB assembly BOM alongside the create stage-6
+ * outputs (create-pipeline delta). No-op when there is no BOM.md yet; never
+ * throws on drift here — the pipeline's own gates own that.
+ */
+export async function emitCreateJlcpcbBom(repoRoot: string): Promise<string | null> {
+  const config = await loadConfig(repoRoot);
+  const bomPath = path.join(repoRoot, config.docs, 'BOM.md');
+  if (!existsSync(bomPath)) return null;
+  const rows = parseBom(await readFile(bomPath, 'utf8'));
+  const { csv } = buildExport(rows, 'jlcpcb', { boards: 1, spares: 10, includeUnverified: false });
+  const outPath = outFileFor('jlcpcb');
+  await mkdir(path.join(repoRoot, OUT_DIR), { recursive: true });
+  await writeFile(path.join(repoRoot, outPath), csv, 'utf8');
+  return outPath;
+}
+
+/** Validate `--supplier`; throws ExportError listing the supported values. */
+export function parseSupplier(value: string): Supplier {
+  if (!isSupplier(value)) {
+    throw new ExportError(`unknown supplier "${value}"; supported: ${SUPPLIERS.join(', ')}`);
+  }
+  return value;
+}
+
+/** Validate `--boards`: a positive integer. */
+export function parseBoards(value: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new ExportError(`--boards must be a positive integer, got "${value}"`);
+  }
+  return n;
+}
+
+/** Validate `--spares`: a non-negative percentage. */
+export function parseSpares(value: string): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new ExportError(`--spares must be a non-negative number, got "${value}"`);
+  }
+  return n;
+}

--- a/src/kicad/bom-export.ts
+++ b/src/kicad/bom-export.ts
@@ -1,0 +1,300 @@
+import { parseMarkdownTables, type TableRow } from '../memory/drift.js';
+
+/**
+ * Supplier-format BOM export (capability supplier-bom-export). Deterministic,
+ * LLM-free, network-free: a pure transformation of BOM.md into files a supplier
+ * accepts without hand-editing. BOM.md is the sole input (design D1) — it is
+ * already drift-checked against the schematic, so exports inherit that
+ * consistency guarantee.
+ */
+
+export type Supplier = 'jlcpcb' | 'digikey' | 'mouser';
+
+export const SUPPLIERS: readonly Supplier[] = ['jlcpcb', 'digikey', 'mouser'];
+
+export function isSupplier(s: string): s is Supplier {
+  return (SUPPLIERS as readonly string[]).includes(s);
+}
+
+export interface BomRow {
+  refdes: string;
+  value: string;
+  footprint: string;
+  /** MPN column value as written (may be a placeholder like "UNVERIFIED"). */
+  mpn: string;
+  manufacturer: string;
+  /** LCSC part number when a column carries it, else ''. */
+  lcsc: string;
+  /** True when any cell carries the standalone token UNVERIFIED. */
+  unverified: boolean;
+  /** True when the MPN column carries an orderable part number (not a placeholder). */
+  hasMpn: boolean;
+}
+
+// Header aliases → canonical field. Matched after normalizing a header cell to
+// lowercase alphanumerics, so "LCSC Part #" and "lcsc_part" both hit `lcsc`.
+const HEADER_ALIASES: Record<string, keyof Pick<BomRow, 'refdes' | 'value' | 'footprint' | 'mpn' | 'manufacturer' | 'lcsc'>> = {
+  refdes: 'refdes',
+  ref: 'refdes',
+  designator: 'refdes',
+  reference: 'refdes',
+  value: 'value',
+  comment: 'value',
+  val: 'value',
+  footprint: 'footprint',
+  package: 'footprint',
+  mpn: 'mpn',
+  manufacturerpartnumber: 'mpn',
+  mfrpartnumber: 'mpn',
+  mfrpart: 'mpn',
+  partnumber: 'mpn',
+  manufacturer: 'manufacturer',
+  mfr: 'manufacturer',
+  lcsc: 'lcsc',
+  lcscpart: 'lcsc',
+  lcscpartnumber: 'lcsc',
+};
+
+const norm = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+// MPN cells that mean "no orderable part number yet". `UNVERIFIED` is the
+// init/scaffold placeholder (src/memory/scaffold.ts writes it into the MPN
+// column for every extracted symbol); the rest are common human shorthand.
+const MPN_PLACEHOLDERS = new Set(['', 'unverified', 'tbd', 'todo', 'tbc', 'na', 'none', '-', '—', '?']);
+
+const isMpnPlaceholder = (mpn: string): boolean => MPN_PLACEHOLDERS.has(mpn.trim().toLowerCase());
+
+const UNVERIFIED_RE = /\bUNVERIFIED\b/i;
+
+/**
+ * Parse BOM.md into rows by column header, tolerating extra/reordered columns.
+ * Only the header row and data rows of the first parts table are used; a table
+ * without a recognizable Refdes header yields no rows.
+ */
+export function parseBom(md: string): BomRow[] {
+  const tableRows = parseMarkdownTables(md);
+  const headerIdx = tableRows.findIndex((r) => r.cells.some((c) => HEADER_ALIASES[norm(c)] === 'refdes'));
+  const header = headerIdx === -1 ? undefined : tableRows[headerIdx];
+  if (!header) return [];
+  const col: Partial<Record<keyof BomRow, number>> = {};
+  header.cells.forEach((c, i) => {
+    const field = HEADER_ALIASES[norm(c)];
+    // First occurrence wins, so a stray later column never shadows the real one.
+    if (field && col[field] === undefined) col[field] = i;
+  });
+
+  const at = (row: TableRow, field: keyof BomRow): string => {
+    const i = col[field];
+    return i === undefined ? '' : (row.cells[i] ?? '').trim();
+  };
+
+  const rows: BomRow[] = [];
+  for (const row of tableRows.slice(headerIdx + 1)) {
+    const refdes = at(row, 'refdes');
+    if (!refdes) continue; // blank line / stray row
+    const mpn = at(row, 'mpn');
+    rows.push({
+      refdes,
+      value: at(row, 'value'),
+      footprint: at(row, 'footprint'),
+      mpn,
+      manufacturer: at(row, 'manufacturer'),
+      lcsc: at(row, 'lcsc'),
+      unverified: row.cells.some((c) => UNVERIFIED_RE.test(c)),
+      hasMpn: !isMpnPlaceholder(mpn),
+    });
+  }
+  return rows;
+}
+
+/**
+ * Passive footprint classifier (design D4): the library item after the `:` in a
+ * KiCad footprint id starts with `R_`, `C_`, or `L_` for the passive classes
+ * that lose parts to handling. Bare footprint names (no library) are matched
+ * too, so `R_0603` and `Resistor_SMD:R_0603_1608Metric` both classify.
+ */
+export function isPassiveFootprint(footprint: string): boolean {
+  const item = footprint.includes(':') ? footprint.slice(footprint.lastIndexOf(':') + 1) : footprint;
+  return /^[RCL]_/.test(item.trim());
+}
+
+/**
+ * Order quantity for one BOM line (requirement "Quantity arithmetic"):
+ * `ceil(perBoardCount × boards × (1 + spares/100))`, raised to
+ * `perBoardCount × boards + 2` for passive lines when the percentage yields
+ * less — losing two 0402s to tweezers is the norm and percentage-only spares
+ * under-order low-count passive lines (design D4).
+ */
+export function orderQuantity(
+  perBoardCount: number,
+  boards: number,
+  sparesPercent: number,
+  isPassive: boolean,
+): number {
+  const base = perBoardCount * boards;
+  // `base * (100 + spares) / 100` keeps the multiply in whole units before the
+  // divide, and the epsilon absorbs IEEE-754 dust so an exact result like 110
+  // does not ceil to 111 (100 × 1.1 is 110.00000000000001 in float). The dust is
+  // ~1e-13; 1e-9 is far below any real fractional quantity, so genuine fractions
+  // (44.5 → 45) are unaffected.
+  const withSpares = Math.ceil((base * (100 + sparesPercent)) / 100 - 1e-9);
+  return isPassive ? Math.max(withSpares, base + 2) : withSpares;
+}
+
+/** Natural refdes ordering: R2 before R10, and R* before U*. */
+function naturalCompare(a: string, b: string): number {
+  const pa = a.match(/^([A-Za-z]*)(\d*)/);
+  const pb = b.match(/^([A-Za-z]*)(\d*)/);
+  const alpha = (pa?.[1] ?? '').localeCompare(pb?.[1] ?? '');
+  if (alpha !== 0) return alpha;
+  const na = pa?.[2] ? parseInt(pa[2], 10) : 0;
+  const nb = pb?.[2] ? parseInt(pb[2], 10) : 0;
+  if (na !== nb) return na - nb;
+  return a.localeCompare(b);
+}
+
+/** RFC-4180 field quoting: quote when the field holds a comma, quote, or newline. */
+function csvField(value: string): string {
+  return /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+const csvRow = (fields: string[]): string => fields.map(csvField).join(',');
+
+export interface ExportOptions {
+  boards: number;
+  spares: number;
+  includeUnverified: boolean;
+}
+
+export interface ExportResult {
+  /** The supplier CSV, ending in a newline. */
+  csv: string;
+  /** Rows that made it into the file, in emit order. */
+  included: BomRow[];
+  /** Rows excluded, with the reason, for the warnings footer. */
+  excluded: { row: BomRow; reason: string }[];
+  /** Human-readable warning/notice lines (stderr + --json). */
+  warnings: string[];
+}
+
+interface Line {
+  rows: BomRow[];
+  /** Representative row (first, in refdes order) for value/footprint/mpn/etc. */
+  head: BomRow;
+  designators: string[];
+}
+
+/**
+ * Split rows into included/excluded by the ordering rules (requirement
+ * "Unorderable rows are excluded and reported"): MPN-less rows are always
+ * excluded; UNVERIFIED rows are excluded unless `includeUnverified`, and even
+ * then only when they carry a real MPN.
+ */
+function partition(
+  rows: BomRow[],
+  includeUnverified: boolean,
+): { included: BomRow[]; excluded: ExportResult['excluded'] } {
+  const included: BomRow[] = [];
+  const excluded: ExportResult['excluded'] = [];
+  for (const row of rows) {
+    if (!row.hasMpn) {
+      excluded.push({ row, reason: 'no MPN' });
+    } else if (row.unverified && !includeUnverified) {
+      excluded.push({ row, reason: 'UNVERIFIED' });
+    } else {
+      included.push(row);
+    }
+  }
+  return { included, excluded };
+}
+
+function groupBy(rows: BomRow[], key: (r: BomRow) => string): Line[] {
+  const map = new Map<string, BomRow[]>();
+  for (const r of rows) {
+    const k = key(r);
+    const arr = map.get(k);
+    if (arr) arr.push(r);
+    else map.set(k, [r]);
+  }
+  const lines: Line[] = [];
+  for (const groupRows of map.values()) {
+    const sorted = [...groupRows].sort((a, b) => naturalCompare(a.refdes, b.refdes));
+    // Groups are never empty (a key exists because a row produced it).
+    lines.push({ rows: sorted, head: sorted[0]!, designators: sorted.map((r) => r.refdes) });
+  }
+  // Deterministic line order: by the first designator of each line.
+  return lines.sort((a, b) => naturalCompare(a.designators[0]!, b.designators[0]!));
+}
+
+function buildWarnings(
+  supplier: Supplier,
+  included: BomRow[],
+  excluded: ExportResult['excluded'],
+  includeUnverified: boolean,
+): string[] {
+  const warnings: string[] = [];
+  for (const { row, reason } of excluded) {
+    const hint =
+      reason === 'no MPN'
+        ? 'add an MPN in BOM.md — unorderable without one'
+        : 'verify against the datasheet or re-run with --include-unverified';
+    warnings.push(`EXCLUDED (${reason}): ${row.refdes} (${row.value || 'no value'}) — ${hint}`);
+  }
+  if (includeUnverified) {
+    for (const row of included) {
+      if (row.unverified) {
+        warnings.push(`INCLUDED but UNVERIFIED (--include-unverified): ${row.refdes} (${row.mpn}) — confirm before ordering`);
+      }
+    }
+  }
+  if (supplier === 'jlcpcb') {
+    const blank = included.filter((r) => !r.lcsc).map((r) => r.refdes);
+    if (blank.length) {
+      warnings.push(
+        `NOTE: no LCSC part # for ${blank.join(', ')} — JLCPCB accepts the upload but needs manual matching for these`,
+      );
+    }
+  }
+  return warnings;
+}
+
+function emitJlcpcb(lines: Line[]): string {
+  // JLCPCB assembly-service BOM: one line per Comment+Footprint+LCSC, designators
+  // grouped. Quantity is derived by JLCPCB from the designator count × the board
+  // count entered at upload, so there is no quantity column here (design/proposal).
+  const header = 'Comment,Designator,Footprint,LCSC Part #';
+  const body = lines.map((l) =>
+    csvRow([l.head.value, l.designators.join(','), l.head.footprint, l.head.lcsc]),
+  );
+  return [header, ...body].join('\n') + '\n';
+}
+
+function emitCart(lines: Line[], opts: ExportOptions, mpnHeader: string): string {
+  // DigiKey / Mouser cart upload: one line per MPN with a computed order
+  // quantity and the designators as the customer reference.
+  const header = `${mpnHeader},Manufacturer,Quantity,Customer Reference`;
+  const body = lines.map((l) => {
+    const qty = orderQuantity(l.designators.length, opts.boards, opts.spares, isPassiveFootprint(l.head.footprint));
+    return csvRow([l.head.mpn, l.head.manufacturer, String(qty), l.designators.join(',')]);
+  });
+  return [header, ...body].join('\n') + '\n';
+}
+
+/**
+ * Build the supplier CSV plus its warnings from parsed BOM rows. Pure: no I/O,
+ * so the emitters are golden-file testable in isolation (design D5).
+ */
+export function buildExport(rows: BomRow[], supplier: Supplier, opts: ExportOptions): ExportResult {
+  const { included, excluded } = partition(rows, opts.includeUnverified);
+  const lines =
+    supplier === 'jlcpcb'
+      ? groupBy(included, (r) => `${r.value} ${r.footprint} ${r.lcsc}`)
+      : groupBy(included, (r) => r.mpn);
+
+  let csv: string;
+  if (supplier === 'jlcpcb') csv = emitJlcpcb(lines);
+  else if (supplier === 'digikey') csv = emitCart(lines, opts, 'Manufacturer Part Number');
+  else csv = emitCart(lines, opts, 'Mfr. Part Number');
+
+  return { csv, included, excluded, warnings: buildWarnings(supplier, included, excluded, opts.includeUnverified) };
+}

--- a/src/kicad/bom-export.ts
+++ b/src/kicad/bom-export.ts
@@ -12,6 +12,11 @@ export type Supplier = 'jlcpcb' | 'digikey' | 'mouser';
 
 export const SUPPLIERS: readonly Supplier[] = ['jlcpcb', 'digikey', 'mouser'];
 
+/** CLI defaults for the quantity flags, shared so the "ignored for jlcpcb"
+ *  note fires only when the user actually set a non-default value. */
+export const DEFAULT_BOARDS = 1;
+export const DEFAULT_SPARES = 10;
+
 export function isSupplier(s: string): s is Supplier {
   return (SUPPLIERS as readonly string[]).includes(s);
 }
@@ -70,6 +75,12 @@ const UNVERIFIED_RE = /\bUNVERIFIED\b/i;
  * Parse BOM.md into rows by column header, tolerating extra/reordered columns.
  * Only the header row and data rows of the first parts table are used; a table
  * without a recognizable Refdes header yields no rows.
+ *
+ * NOTE: the drift gate this exporter runs behind (checkDrift in
+ * ../memory/drift.ts) reads Refdes|Value|Footprint *by position*, not by header.
+ * So while this parser tolerates reordering those base columns, reordering them
+ * makes checkDrift compare the wrong cells and the export refuses with a bogus
+ * drift message. Keep the base three columns first and in order; only append.
  */
 export function parseBom(md: string): BomRow[] {
   const tableRows = parseMarkdownTables(md);
@@ -230,8 +241,9 @@ function buildWarnings(
   supplier: Supplier,
   included: BomRow[],
   excluded: ExportResult['excluded'],
-  includeUnverified: boolean,
+  opts: ExportOptions,
 ): string[] {
+  const { includeUnverified } = opts;
   const warnings: string[] = [];
   for (const { row, reason } of excluded) {
     const hint =
@@ -248,6 +260,15 @@ function buildWarnings(
     }
   }
   if (supplier === 'jlcpcb') {
+    // The JLCPCB assembly format has no quantity column — quantity is set from
+    // the board count entered at upload — so --boards/--spares never reach this
+    // file. Say so when the user supplied a non-default value, or they may order
+    // the wrong count expecting the flags to have taken effect.
+    if (opts.boards !== DEFAULT_BOARDS || opts.spares !== DEFAULT_SPARES) {
+      warnings.push(
+        'NOTE: --boards/--spares are ignored for jlcpcb — quantity is set from the board count you enter at JLCPCB upload',
+      );
+    }
     const blank = included.filter((r) => !r.lcsc).map((r) => r.refdes);
     if (blank.length) {
       warnings.push(
@@ -296,5 +317,5 @@ export function buildExport(rows: BomRow[], supplier: Supplier, opts: ExportOpti
   else if (supplier === 'digikey') csv = emitCart(lines, opts, 'Manufacturer Part Number');
   else csv = emitCart(lines, opts, 'Mfr. Part Number');
 
-  return { csv, included, excluded, warnings: buildWarnings(supplier, included, excluded, opts.includeUnverified) };
+  return { csv, included, excluded, warnings: buildWarnings(supplier, included, excluded, opts) };
 }

--- a/test/bom-export.test.ts
+++ b/test/bom-export.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import {
+  parseBom,
+  buildExport,
+  orderQuantity,
+  isPassiveFootprint,
+  isSupplier,
+} from '../src/kicad/bom-export.js';
+import { runExportBom, ExportError, parseBoards, parseSpares, parseSupplier } from '../src/commands/export.js';
+import { runInit } from '../src/memory/scaffold.js';
+import { tempFixtureRepo } from './helpers.js';
+
+// A BOM that is drift-clean against the open-key fixture schematic (R1 10k, R2
+// 1k, U1 ESP32-S3-MINI) and exercises every classification: R1 verified with an
+// MPN, R2 with no MPN (the init/scaffold UNVERIFIED placeholder), U1 with a real
+// MPN but flagged UNVERIFIED in its rationale.
+const FIXTURE_BOM = `# Bill of Materials
+
+| Refdes | Value | Footprint | MPN | Manufacturer | LCSC | Rationale |
+|---|---|---|---|---|---|---|
+| R1 | 10k | Resistor_SMD:R_0603_1608Metric | RC0603FR-0710KL | Yageo | C25804 | pullup, verified against datasheet |
+| R2 | 1k | Resistor_SMD:R_0603_1608Metric | UNVERIFIED | | | placeholder, no MPN chosen yet |
+| U1 | ESP32-S3-MINI | RF_Module:ESP32-S3-MINI-1 | ESP32-S3-MINI-1-N8 | Espressif | C2913202 | UNVERIFIED: datasheet not yet checked |
+`;
+
+describe('BOM parsing (supplier-bom-export)', () => {
+  it('maps columns by header, tolerating extra and reordered columns', () => {
+    const rows = parseBom(FIXTURE_BOM);
+    expect(rows.map((r) => r.refdes)).toEqual(['R1', 'R2', 'U1']);
+    const r1 = rows[0]!;
+    expect(r1).toMatchObject({
+      value: '10k',
+      footprint: 'Resistor_SMD:R_0603_1608Metric',
+      mpn: 'RC0603FR-0710KL',
+      manufacturer: 'Yageo',
+      lcsc: 'C25804',
+      unverified: false,
+      hasMpn: true,
+    });
+  });
+
+  it('treats the UNVERIFIED MPN placeholder as missing, and the token anywhere as a flag', () => {
+    const rows = parseBom(FIXTURE_BOM);
+    // R2: MPN column is the placeholder → no orderable MPN, and flagged.
+    expect(rows[1]).toMatchObject({ hasMpn: false, unverified: true });
+    // U1: real MPN, but UNVERIFIED appears in the rationale → flagged, has MPN.
+    expect(rows[2]).toMatchObject({ hasMpn: true, unverified: true });
+  });
+
+  it('returns no rows when there is no Refdes-headed table', () => {
+    expect(parseBom('# nothing here\n\njust prose\n')).toEqual([]);
+  });
+});
+
+describe('quantity arithmetic (supplier-bom-export)', () => {
+  it('applies the spares percentage (spec: 4/board, 10 boards, 10% → 44)', () => {
+    expect(orderQuantity(4, 10, 10, false)).toBe(44);
+  });
+
+  it('applies the passive minimum (spec: 1/board, 1 board, 10% → 3)', () => {
+    expect(orderQuantity(1, 1, 10, true)).toBe(3);
+  });
+
+  it('the passive minimum only raises, never lowers', () => {
+    // 100/board, 1 board, 10% → 110 spares dominates the +2 floor.
+    expect(orderQuantity(100, 1, 10, true)).toBe(110);
+  });
+
+  it('non-passive lines get percentage spares with no floor', () => {
+    expect(orderQuantity(1, 1, 10, false)).toBe(2);
+    expect(orderQuantity(1, 5, 10, false)).toBe(6);
+  });
+
+  it('classifies passive footprints by the R_/C_/L_ prefix after the library colon', () => {
+    expect(isPassiveFootprint('Resistor_SMD:R_0603_1608Metric')).toBe(true);
+    expect(isPassiveFootprint('Capacitor_SMD:C_0402_1005Metric')).toBe(true);
+    expect(isPassiveFootprint('Inductor_SMD:L_0805_2012Metric')).toBe(true);
+    expect(isPassiveFootprint('R_0603')).toBe(true); // bare, no library
+    expect(isPassiveFootprint('RF_Module:ESP32-S3-MINI-1')).toBe(false);
+  });
+});
+
+describe('supplier format emitters (golden, supplier-bom-export)', () => {
+  const rows = parseBom(FIXTURE_BOM);
+
+  it('JLCPCB assembly CSV: Comment/Designator/Footprint/LCSC, verified rows only', () => {
+    const { csv } = buildExport(rows, 'jlcpcb', { boards: 1, spares: 10, includeUnverified: false });
+    expect(csv).toBe(
+      'Comment,Designator,Footprint,LCSC Part #\n' +
+        '10k,R1,Resistor_SMD:R_0603_1608Metric,C25804\n',
+    );
+  });
+
+  it('JLCPCB groups multiple designators sharing value+footprint+LCSC onto one line', () => {
+    const multi = parseBom(
+      '| Refdes | Value | Footprint | MPN | LCSC |\n' +
+        '|---|---|---|---|---|\n' +
+        '| R10 | 10k | R_0603 | RC0603FR-0710KL | C25804 |\n' +
+        '| R2 | 10k | R_0603 | RC0603FR-0710KL | C25804 |\n',
+    );
+    const { csv } = buildExport(multi, 'jlcpcb', { boards: 1, spares: 10, includeUnverified: false });
+    // Designators naturally sorted (R2 before R10) and quoted because of the comma.
+    expect(csv).toBe('Comment,Designator,Footprint,LCSC Part #\n10k,"R2,R10",R_0603,C25804\n');
+  });
+
+  it('DigiKey cart CSV carries computed quantity, MPN, and manufacturer (spec: 5 boards)', () => {
+    const { csv } = buildExport(rows, 'digikey', { boards: 5, spares: 10, includeUnverified: false });
+    // R1 passive, 1/board × 5 = 5; ceil(5.5)=6, floor 5+2=7 → 7.
+    expect(csv).toBe(
+      'Manufacturer Part Number,Manufacturer,Quantity,Customer Reference\n' +
+        'RC0603FR-0710KL,Yageo,7,R1\n',
+    );
+  });
+
+  it('Mouser cart CSV uses the Mouser MPN header', () => {
+    const { csv } = buildExport(rows, 'mouser', { boards: 1, spares: 10, includeUnverified: false });
+    expect(csv).toBe(
+      'Mfr. Part Number,Manufacturer,Quantity,Customer Reference\n' +
+        'RC0603FR-0710KL,Yageo,3,R1\n',
+    );
+  });
+});
+
+describe('exclusion rules (supplier-bom-export)', () => {
+  const rows = parseBom(FIXTURE_BOM);
+
+  it('excludes MPN-less rows and UNVERIFIED rows by default, and names them', () => {
+    const res = buildExport(rows, 'digikey', { boards: 1, spares: 10, includeUnverified: false });
+    expect(res.included.map((r) => r.refdes)).toEqual(['R1']);
+    expect(res.excluded.map((e) => `${e.row.refdes}:${e.reason}`)).toEqual(['R2:no MPN', 'U1:UNVERIFIED']);
+    expect(res.warnings.join('\n')).toContain('R2');
+    expect(res.warnings.join('\n')).toContain('U1');
+  });
+
+  it('--include-unverified opts UNVERIFIED-with-MPN in, but never MPN-less rows', () => {
+    const res = buildExport(rows, 'digikey', { boards: 1, spares: 10, includeUnverified: true });
+    expect(res.included.map((r) => r.refdes)).toEqual(['R1', 'U1']);
+    // R2 has no MPN — still excluded even with the flag.
+    expect(res.excluded.map((e) => e.row.refdes)).toEqual(['R2']);
+    // U1 is included but still reported as unverified.
+    expect(res.warnings.join('\n')).toMatch(/INCLUDED but UNVERIFIED.*U1/);
+  });
+
+  it('JLCPCB notes blank LCSC part numbers in the warnings footer', () => {
+    const noLcsc = parseBom(
+      '| Refdes | Value | Footprint | MPN |\n|---|---|---|---|\n| R1 | 10k | R_0603 | RC0603FR-0710KL |\n',
+    );
+    const res = buildExport(noLcsc, 'jlcpcb', { boards: 1, spares: 10, includeUnverified: false });
+    expect(res.included.map((r) => r.refdes)).toEqual(['R1']);
+    expect(res.warnings.join('\n')).toMatch(/no LCSC part #.*R1/);
+  });
+});
+
+describe('flag validation (cli-surface)', () => {
+  it('accepts the three suppliers and rejects others', () => {
+    expect(isSupplier('jlcpcb')).toBe(true);
+    expect(isSupplier('acme')).toBe(false);
+    expect(() => parseSupplier('acme')).toThrow(/supported: jlcpcb, digikey, mouser/);
+    expect(parseSupplier('mouser')).toBe('mouser');
+  });
+
+  it('rejects non-positive-integer boards and negative spares', () => {
+    expect(() => parseBoards('0')).toThrow(ExportError);
+    expect(() => parseBoards('1.5')).toThrow(ExportError);
+    expect(parseBoards('5')).toBe(5);
+    expect(() => parseSpares('-1')).toThrow(ExportError);
+    expect(parseSpares('0')).toBe(0);
+  });
+});
+
+describe('export command end-to-end (supplier-bom-export)', () => {
+  let cleanup: (() => Promise<void>) | null = null;
+  afterEach(async () => {
+    if (cleanup) await cleanup();
+    cleanup = null;
+  });
+
+  async function fixtureWithBom(): Promise<string> {
+    const t = await tempFixtureRepo();
+    cleanup = t.cleanup;
+    // init writes .copperhead/config.json (schematic path) and docs/; then we
+    // replace the scaffolded BOM with our controlled, drift-clean one.
+    await runInit({ repoRoot: t.repo, installHooks: false });
+    await writeFile(path.join(t.repo, 'docs', 'BOM.md'), FIXTURE_BOM, 'utf8');
+    return t.repo;
+  }
+
+  it('writes outputs/digikey-bom.csv from a drift-clean repo', async () => {
+    const repo = await fixtureWithBom();
+    const res = await runExportBom({ repoRoot: repo, supplier: 'digikey', boards: 1, spares: 10, includeUnverified: false });
+    expect(res.outPath).toBe(path.join('outputs', 'digikey-bom.csv'));
+    const written = await readFile(path.join(repo, res.outPath), 'utf8');
+    expect(written).toBe(res.csv);
+    expect(written).toContain('RC0603FR-0710KL,Yageo,3,R1');
+    expect(written).not.toContain('U1'); // UNVERIFIED, excluded by default
+  });
+
+  it('refuses to export when BOM.md drifts from the schematic', async () => {
+    const repo = await fixtureWithBom();
+    // Change R1's value so BOM.md disagrees with the schematic (10k).
+    await writeFile(path.join(repo, 'docs', 'BOM.md'), FIXTURE_BOM.replace('| 10k |', '| 47k |'), 'utf8');
+    await expect(
+      runExportBom({ repoRoot: repo, supplier: 'digikey', boards: 1, spares: 10, includeUnverified: false }),
+    ).rejects.toThrow(/drift/i);
+    // Nothing written on refusal.
+    expect(existsSync(path.join(repo, 'outputs', 'digikey-bom.csv'))).toBe(false);
+  });
+
+  it('errors when there is no BOM.md to export', async () => {
+    const t = await tempFixtureRepo();
+    cleanup = t.cleanup;
+    await expect(
+      runExportBom({ repoRoot: t.repo, supplier: 'jlcpcb', boards: 1, spares: 10, includeUnverified: false }),
+    ).rejects.toThrow(/BOM\.md/);
+  });
+
+  it('makes zero network calls during export (network-free invariant)', async () => {
+    const repo = await fixtureWithBom();
+    const originalFetch = globalThis.fetch;
+    let fetched = false;
+    // Any outbound fetch during a deterministic export is a contract violation.
+    globalThis.fetch = (async () => {
+      fetched = true;
+      throw new Error('network access attempted during export');
+    }) as typeof fetch;
+    try {
+      await runExportBom({ repoRoot: repo, supplier: 'mouser', boards: 2, spares: 10, includeUnverified: false });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    expect(fetched).toBe(false);
+  });
+});

--- a/test/bom-export.test.ts
+++ b/test/bom-export.test.ts
@@ -152,6 +152,23 @@ describe('exclusion rules (supplier-bom-export)', () => {
     expect(res.included.map((r) => r.refdes)).toEqual(['R1']);
     expect(res.warnings.join('\n')).toMatch(/no LCSC part #.*R1/);
   });
+
+  it('JLCPCB warns that --boards/--spares are ignored when set to a non-default', () => {
+    const boardsSet = buildExport(rows, 'jlcpcb', { boards: 25, spares: 10, includeUnverified: false });
+    expect(boardsSet.warnings.join('\n')).toMatch(/--boards\/--spares are ignored for jlcpcb/);
+    const sparesSet = buildExport(rows, 'jlcpcb', { boards: 1, spares: 15, includeUnverified: false });
+    expect(sparesSet.warnings.join('\n')).toMatch(/--boards\/--spares are ignored for jlcpcb/);
+  });
+
+  it('JLCPCB does not warn about quantity flags at their defaults', () => {
+    const res = buildExport(rows, 'jlcpcb', { boards: 1, spares: 10, includeUnverified: false });
+    expect(res.warnings.join('\n')).not.toMatch(/ignored for jlcpcb/);
+  });
+
+  it('cart suppliers never emit the jlcpcb quantity-flags note', () => {
+    const res = buildExport(rows, 'digikey', { boards: 25, spares: 15, includeUnverified: false });
+    expect(res.warnings.join('\n')).not.toMatch(/ignored for jlcpcb/);
+  });
 });
 
 describe('flag validation (cli-surface)', () => {


### PR DESCRIPTION
## What

fixes #42 


https://github.com/user-attachments/assets/8319f8fc-a071-4285-bc0e-c234abb94412


Adds a new `copperhead export bom --supplier <jlcpcb|digikey|mouser>` command that turns the drift-checked [docs/BOM.md](docs/BOM.md) into a file each supplier accepts without hand-editing: a JLCPCB assembly CSV, or a DigiKey/Mouser cart-upload CSV with computed order quantities. The `create` stage-6 outputs package now also emits the JLCPCB file automatically.

## Why

`create` produces a generic `BOM.csv`, but no supplier accepts it as-is: JLCPCB wants its assembly format, DigiKey and Mouser want cart-uploadable lists with quantities. Users close that gap by hand today, which is exactly the distance between "orderable BOM" (the current claim) and an actual order. This implements the `add-supplier-bom-export` OpenSpec change (roadmap Phase 2, item 2).

## Design

- Source of truth is BOM.md, not the schematic (design D1): BOM.md carries the MPNs and sourcing flags and is already drift-checked, so the export inherits that consistency guarantee. The markdown table parser (`parseMarkdownTables`) is reused from [drift.ts](src/memory/drift.ts); [bom-export.ts](src/kicad/bom-export.ts) layers a header-aware `parseBom` on top, so optional `Manufacturer` and `LCSC` columns are matched by name regardless of position.
- `export bom` is a new top-level command, not a `check` flag (design D2): export writes files and `check` must never write, so the read-only/write split stays at the command boundary.
- Unorderable rows (no MPN, or still flagged `UNVERIFIED`) are excluded and reported in a warnings footer, never silently included (design D3). `--include-unverified` opts flagged-but-MPN'd rows back in, but never MPN-less rows.
- Quantity is `ceil(perBoard * boards * (1 + spares/100))`, raised to `perBoard * boards + 2` for passive footprints (`R_`/`C_`/`L_`) when the percentage yields less (design D4). The percentage math runs in whole units with a small epsilon, so an exact result like 110 does not ceil to 111 (`100 * 1.1` is `110.00000000000001` in IEEE-754).
- Deterministic, LLM-free, network-free: a pure transformation of repo state, safe anywhere `check` is safe. It refuses with a drift hint when BOM.md disagrees with the schematic (the drift check uses the read-only s-expression reader, so no kicad-cli is needed).

## Spec / OpenSpec

- Change: `add-supplier-bom-export` ([proposal](openspec/changes/add-supplier-bom-export/proposal.md), [design](openspec/changes/add-supplier-bom-export/design.md), [tasks](openspec/changes/add-supplier-bom-export/tasks.md)).
- Delta specs: new capability `supplier-bom-export` (the `export bom` command, per-supplier formats, quantity arithmetic, exclusion rules); modified `cli-surface` (the command and its flags) and `create-pipeline` (stage 6 emits the JLCPCB file).
- All 13 tasks in `tasks.md` are checked off. One documented deviation from task 1.4: the warnings footer goes to stderr and `--json` only, not embedded as CSV comments, because strict supplier upload parsers reject comment lines.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | 151 pass, 7 skip, 7 fail (all pre-existing, see below) |
| Live-LLM (opt-in) | n/a | n/a (no LLM path in this change) |

New tests: [test/bom-export.test.ts](test/bom-export.test.ts), 21 passing: header-aware parsing, quantity arithmetic (including the two spec scenarios, 44 and 3), the three golden supplier formats, exclusion and `--include-unverified` behavior, flag validation, end-to-end file write, drift refusal, and a network-free guard.

Pre-existing failures unrelated to this PR: the 7 failing tests (in `init-check`, `create-hardening`, `gating-sync`) all fail with `KicadCliMissingError` because `kicad-cli` is not installed in this environment. None touch the export code, which makes zero kicad-cli calls, so they fail identically on `main`.

### Manual test log (required)

- Sandbox variant used: `edit` (`./manual-tests/setup.sh edit --fresh`, the open-key fixture copy). Since `init` needs `kicad-cli` (not installed in this environment), I placed `.copperhead/config.json` and a populated `docs/BOM.md` directly (R1 verified, R2 no-MPN, U1 UNVERIFIED-with-MPN), which is what `init` would scaffold, then exercised `export bom`.
- Commands run and outcome: quantities, exclusions, `--include-unverified`, and drift refusal all as expected.

```text
$ npm run dev -- --repo manual-tests/runs/edit export bom --supplier digikey --boards 25
EXCLUDED (no MPN): R2 (1k) ...
EXCLUDED (UNVERIFIED): U1 (ESP32-S3-MINI) ...
wrote outputs/digikey-bom.csv (1 part(s), 2 excluded)
  -> RC0603FR-0710KL,Yageo,28,R1

$ npm run dev -- --repo manual-tests/runs/edit export bom --supplier jlcpcb --include-unverified
INCLUDED but UNVERIFIED (--include-unverified): U1 (ESP32-S3-MINI-1-N8) ...
wrote outputs/jlcpcb-bom.csv (2 part(s), 1 excluded)

$ npm run dev -- --repo manual-tests/runs/edit export bom --supplier mouser   # after drifting R1 10k to 47k
BOM.md drifts from the schematic; run `copperhead check` and resolve drift before ordering:
  - BOM.md claims "R1 value 47k" but actual is "R1 value 10k"   (exit 1)
```

## Docs

 - [README.md](vscode-webview://0cekt2ari09fb47bpj5hrtku6nc1i8kcm9snh7ei8ehbb4rhg53j/README.md) gains an "Ordering (export bom)" section: usage, the --boards/--spares quantity knobs, what gets excluded and why, and a note that BOM.md may carry optional Manufacturer and LCSC columns that the exporter matches by header.

---

## Invariant checklist

<!-- These are hard requirements from SPEC.md. Check the boxes this PR is responsible for;
     mark N/A for the ones it does not touch. A reviewer will verify each. -->

- [x] **Spec-gated in**: `edit_file`/`write_file` stay structurally absent from the agent tool list until an OpenSpec proposal validates (gated by omission, not prompt text).
- [x] **Verification-gated out**: mutations still end in ERC (and DRC when the board changed) passing, with repair up to `maxRepairCycles` then rollback to the git snapshot.
- [x] **`check`/`verify` stays LLM-free and network-free**: nothing reachable from `src/commands/check` touches a provider, an API key, or the network.
- [x] **No sexp serialization**: the `src/kicad/` parser stays read-only; KiCad files are edited only via anchored exact-match text replace (no round-tripping).
- [x] **Sync-obligations ledger**: post-tool-call hooks keep feeding the ledger, and commit keeps refusing while obligations are open.
- [x] **Secrets**: transcripts and summaries redact `sk-[A-Za-z0-9_-]+` at write time; keys live only in env vars; `.gitignore` keeps `.env` and `.copperhead/runs/`.
- [x] **Spec coherence**: if spec-level behavior changed, SPEC.md and the change artifacts (`proposal.md`, `design.md`, delta specs, `tasks.md`) moved together and `openspec validate <change>` passes.
