### PR TITLE
Add fab documentation-presence check for release gate.

### DIFF
--- a/openspec/changes/add-fab-release-gate/tasks.md
+++ b/openspec/changes/add-fab-release-gate/tasks.md
@@ -6,7 +6,7 @@
 - [ ] 1.2 Implement BOM-readiness check: parse BOM.md rows, flag missing MPN/footprint as failures, `UNVERIFIED` rows as warnings
 - [ ] 1.3 Implement schematic-to-PCB match: refdes + footprint join via `list_symbols` and a board-side footprint enumerator added to `src/kicad/sexp.ts` (read-only)
 - [ ] 1.4 Implement output-freshness check: read the export hash record from `.copperhead/config.json`, recompute SHA-256 of `.kicad_pcb`, compare; distinct messages for missing outputs, missing record, and stale hash
-- [ ] 1.5 Implement documentation-presence check (LAYOUT.md `## Draft quality`, DEVPLAN.md for `create` repos)
+- [x] 1.5 Implement documentation-presence check (LAYOUT.md `## Draft quality`, DEVPLAN.md for `create` repos)
 
 ## 2. Export hash record
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,12 @@ export interface CopperheadConfig {
   budgets: Record<string, number>;
   /** Content hashes of generated docs, for init idempotency (AC-1.4). */
   generatedHashes?: Record<string, string>;
+  /**
+   * How the repo was bootstrapped. `"create"` marks a Mode A pipeline repo
+   * (fab gate requires DEVPLAN.md). Written by `copperhead create`; absent on
+   * init-only / hand-maintained repos.
+   */
+  origin?: 'create' | 'init';
 }
 
 export const CONFIG_DIR = '.copperhead';
@@ -51,6 +57,7 @@ export async function loadConfig(repoRoot: string): Promise<CopperheadConfig> {
     maxRepairCycles: raw.maxRepairCycles ?? DEFAULTS.maxRepairCycles,
     budgets: raw.budgets ?? {},
     ...(raw.generatedHashes ? { generatedHashes: raw.generatedHashes } : {}),
+    ...(raw.origin === 'create' || raw.origin === 'init' ? { origin: raw.origin } : {}),
   };
 }
 

--- a/src/kicad/fab.ts
+++ b/src/kicad/fab.ts
@@ -1,0 +1,121 @@
+/**
+ * Fab release gate checks (OpenSpec: add-fab-release-gate).
+ * Documentation presence is pure over file contents: LLM-free, network-free.
+ */
+
+/** Violation shape shared by the fab JSON report (`claim` / `actual` / optional location). */
+export interface FabViolation {
+  claim: string;
+  actual: string;
+  location?: string;
+}
+
+export interface FabCheckResult {
+  status: 'pass' | 'warn' | 'fail';
+  violations: FabViolation[];
+}
+
+export const DRAFT_QUALITY_HEADING = '## Draft quality';
+
+/** Config marker: repos produced by `copperhead create` set `origin` to `"create"`. */
+export const CREATE_ORIGIN = 'create';
+
+/**
+ * True when `.copperhead/config.json` marks the repo as create-produced.
+ * Accepts the raw parsed object (or a loaded config that retained `origin`).
+ */
+export function isCreateProducedRepo(config: unknown): boolean {
+  if (config === null || typeof config !== 'object') return false;
+  return (config as { origin?: unknown }).origin === CREATE_ORIGIN;
+}
+
+/**
+ * Body of `## Draft quality` through the next `##` heading, or `null` if the
+ * heading is absent. HTML comments and whitespace alone do not count as filled
+ * (init scaffolds the empty heading + a placeholder comment).
+ */
+export function draftQualitySection(layoutMd: string): string | null {
+  const lines = layoutMd.split(/\r?\n/);
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]!.trim() === DRAFT_QUALITY_HEADING) {
+      start = i + 1;
+      break;
+    }
+  }
+  if (start < 0) return null;
+
+  const body: string[] = [];
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (/^##\s/.test(line.trim())) break;
+    body.push(line);
+  }
+  return body.join('\n');
+}
+
+export function isFilledDraftQuality(sectionBody: string): boolean {
+  const withoutComments = sectionBody.replace(/<!--[\s\S]*?-->/g, '');
+  return withoutComments.trim().length > 0;
+}
+
+export interface DocumentationPresenceInput {
+  /** Full LAYOUT.md text, or `null` when the file is missing. */
+  layoutMd: string | null;
+  /** Whether docs/DEVPLAN.md exists on disk. */
+  devplanExists: boolean;
+  /** From {@link isCreateProducedRepo}; only create repos require DEVPLAN.md. */
+  isCreateRepo: boolean;
+  /** Docs directory name used in violation locations (default `docs`). */
+  docsDir?: string;
+}
+
+/**
+ * Documentation-presence check for `check --fab` (task 1.5):
+ * - LAYOUT.md must have a filled `## Draft quality` section
+ * - create-produced repos must also have DEVPLAN.md
+ *
+ * Failures use the drift-report voice: file as location, claim `"release-ready"`.
+ */
+export function checkDocumentationPresence(input: DocumentationPresenceInput): FabCheckResult {
+  const docs = (input.docsDir ?? 'docs').replace(/[/\\]+$/, '');
+  const violations: FabViolation[] = [];
+  const layoutLoc = `${docs}/LAYOUT.md`;
+  const claim = 'release-ready';
+
+  if (input.layoutMd === null) {
+    violations.push({
+      claim,
+      actual: 'LAYOUT.md missing',
+      location: layoutLoc,
+    });
+  } else {
+    const section = draftQualitySection(input.layoutMd);
+    if (section === null) {
+      violations.push({
+        claim,
+        actual: `missing ${DRAFT_QUALITY_HEADING} section`,
+        location: layoutLoc,
+      });
+    } else if (!isFilledDraftQuality(section)) {
+      violations.push({
+        claim,
+        actual: `${DRAFT_QUALITY_HEADING} section is empty`,
+        location: layoutLoc,
+      });
+    }
+  }
+
+  if (input.isCreateRepo && !input.devplanExists) {
+    violations.push({
+      claim,
+      actual: 'missing',
+      location: `${docs}/DEVPLAN.md`,
+    });
+  }
+
+  return {
+    status: violations.length === 0 ? 'pass' : 'fail',
+    violations,
+  };
+}

--- a/test/fab-docs.test.ts
+++ b/test/fab-docs.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CREATE_ORIGIN,
+  checkDocumentationPresence,
+  draftQualitySection,
+  isCreateProducedRepo,
+  isFilledDraftQuality,
+} from '../src/kicad/fab.js';
+
+const FILLED_LAYOUT = `# Layout intent
+
+## Draft quality
+
+Power and critical nets routed; ratsnest remains on low-speed GPIO.
+A human should re-check USB differential pair length before fab.
+`;
+
+const INIT_LAYOUT = `# Layout intent
+
+Placement and routing intent: keepouts, pours, ESD placement.
+
+## Draft quality
+
+<!-- copperhead writes an honest assessment here after any layout pass -->
+`;
+
+const NO_SECTION_LAYOUT = `# Layout intent
+
+Placement notes only; no draft-quality assessment yet.
+`;
+
+describe('isCreateProducedRepo', () => {
+  it('detects origin create in config.json', () => {
+    expect(isCreateProducedRepo({ origin: CREATE_ORIGIN })).toBe(true);
+    expect(isCreateProducedRepo({ origin: 'init' })).toBe(false);
+    expect(isCreateProducedRepo({})).toBe(false);
+    expect(isCreateProducedRepo(null)).toBe(false);
+  });
+});
+
+describe('draftQualitySection / isFilledDraftQuality', () => {
+  it('returns null when the heading is absent', () => {
+    expect(draftQualitySection(NO_SECTION_LAYOUT)).toBeNull();
+  });
+
+  it('treats init scaffold (heading + HTML comment) as empty', () => {
+    const body = draftQualitySection(INIT_LAYOUT);
+    expect(body).not.toBeNull();
+    expect(isFilledDraftQuality(body!)).toBe(false);
+  });
+
+  it('treats real prose as filled', () => {
+    const body = draftQualitySection(FILLED_LAYOUT);
+    expect(body).not.toBeNull();
+    expect(isFilledDraftQuality(body!)).toBe(true);
+  });
+});
+
+describe('checkDocumentationPresence', () => {
+  it('fails when LAYOUT.md has no ## Draft quality section (delta spec)', () => {
+    const r = checkDocumentationPresence({
+      layoutMd: NO_SECTION_LAYOUT,
+      devplanExists: true,
+      isCreateRepo: false,
+    });
+    expect(r.status).toBe('fail');
+    expect(r.violations).toEqual([
+      {
+        claim: 'release-ready',
+        actual: 'missing ## Draft quality section',
+        location: 'docs/LAYOUT.md',
+      },
+    ]);
+  });
+
+  it('fails when ## Draft quality exists but is empty (init scaffold)', () => {
+    const r = checkDocumentationPresence({
+      layoutMd: INIT_LAYOUT,
+      devplanExists: false,
+      isCreateRepo: false,
+    });
+    expect(r.status).toBe('fail');
+    expect(r.violations[0]).toMatchObject({
+      claim: 'release-ready',
+      actual: '## Draft quality section is empty',
+      location: 'docs/LAYOUT.md',
+    });
+  });
+
+  it('fails when LAYOUT.md itself is missing', () => {
+    const r = checkDocumentationPresence({
+      layoutMd: null,
+      devplanExists: true,
+      isCreateRepo: false,
+    });
+    expect(r.status).toBe('fail');
+    expect(r.violations[0]?.actual).toBe('LAYOUT.md missing');
+  });
+
+  it('fails create repos missing DEVPLAN.md', () => {
+    const r = checkDocumentationPresence({
+      layoutMd: FILLED_LAYOUT,
+      devplanExists: false,
+      isCreateRepo: true,
+    });
+    expect(r.status).toBe('fail');
+    expect(r.violations).toEqual([
+      {
+        claim: 'release-ready',
+        actual: 'missing',
+        location: 'docs/DEVPLAN.md',
+      },
+    ]);
+  });
+
+  it('does not require DEVPLAN.md for init-only repos', () => {
+    const r = checkDocumentationPresence({
+      layoutMd: FILLED_LAYOUT,
+      devplanExists: false,
+      isCreateRepo: false,
+    });
+    expect(r.status).toBe('pass');
+    expect(r.violations).toEqual([]);
+  });
+
+  it('passes a complete create doc set', () => {
+    const r = checkDocumentationPresence({
+      layoutMd: FILLED_LAYOUT,
+      devplanExists: true,
+      isCreateRepo: true,
+    });
+    expect(r.status).toBe('pass');
+    expect(r.violations).toEqual([]);
+  });
+
+  it('can report both LAYOUT and DEVPLAN failures together', () => {
+    const r = checkDocumentationPresence({
+      layoutMd: NO_SECTION_LAYOUT,
+      devplanExists: false,
+      isCreateRepo: true,
+    });
+    expect(r.status).toBe('fail');
+    expect(r.violations).toHaveLength(2);
+    expect(r.violations.map((v) => v.location)).toEqual([
+      'docs/LAYOUT.md',
+      'docs/DEVPLAN.md',
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Adds the fab-gate documentation-presence check: LAYOUT.md must have a filled `## Draft quality` section, and create-produced repos must have DEVPLAN.md. Failures use the drift-report voice (`claim: release-ready`).

## Why

Closes #9 (OpenSpec `add-fab-release-gate` task 1.5). A board can pass ERC/DRC and still lack the honesty/docs required before fab; this check is the pure, offline piece of that gate.

## Design

- New [fab.ts](src/kicad/fab.ts): `checkDocumentationPresence()` is pure over file contents (no I/O, no LLM, no network).
- Empty `## Draft quality` means heading present but only whitespace/HTML comments (matches the `init` scaffold), so the heading alone does not pass.
- Create repos are detected via `.copperhead/config.json` `origin: "create"`. [config.ts](src/config.ts) now loads optional `origin`. `copperhead create` does not write that field yet; CLI `--fab` wiring is a follow-up.

## Spec / OpenSpec

Implements documentation-presence scenarios from `openspec/changes/add-fab-release-gate` (delta spec requirement "Documentation presence check"). Does not archive the change or wire `check --fab` (tasks 3.x).

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test -- test/fab-docs.test.ts` | 11 passed |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` | n/a, no LLM path |

New tests: [test/fab-docs.test.ts](test/fab-docs.test.ts) (missing section, empty init scaffold, complete pass, create missing DEVPLAN, init without DEVPLAN). Full `npm test` on this Windows machine still hits pre-existing failures (`kicad-cli` missing, POSIX path expectation in `test/safety.test.ts`); unrelated to this PR.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a
- Commands run and outcome:

```text
n/a: this PR adds a pure library function and unit tests only. No CLI flag or command behavior changed; `check --fab` is not wired yet.
```

## Docs

N/A (module/API comments only; README fab-gate section is a later task).

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, no agent tool list change.
- [ ] **Verification-gated out**: N/A, no mutation/repair path touched.
- [x] **`check`/`verify` stays LLM-free and network-free**: new fab docs check has zero provider/network imports; not yet imported by `check`, but designed for that contract.
- [x] **No sexp serialization**: `src/kicad/fab.ts` is docs-only string checks; no sexp write path.
- [ ] **Sync-obligations ledger**: N/A.
- [ ] **Secrets**: N/A.
- [ ] **Spec coherence**: N/A for archive; implements an in-flight delta-spec task without changing SPEC.md yet.