### PR TITLE
feat(agent): support reasoning models and Gemini via OpenAI provider

### DIFF
--- a/src/agent/providers/openai.ts
+++ b/src/agent/providers/openai.ts
@@ -37,6 +37,7 @@ export class OpenAIProvider implements Provider {
                       id: t.id,
                       type: 'function' as const,
                       function: { name: t.name, arguments: JSON.stringify(t.args) },
+                      ...(t.extra || {}),
                     })),
                   }
                 : {}),
@@ -55,11 +56,20 @@ export class OpenAIProvider implements Provider {
         : {}),
     });
     const choice = res.choices[0];
-    const toolCalls = ((choice?.message.tool_calls ?? []) as OpenAIToolCall[]).map((t) => ({
-      id: t.id,
-      name: t.function.name,
-      args: safeParse(t.function.arguments),
-    }));
+    const toolCalls = ((choice?.message.tool_calls ?? []) as any[]).map((t) => {
+      const extra: Record<string, any> = {};
+      for (const [k, v] of Object.entries(t)) {
+        if (k !== 'id' && k !== 'type' && k !== 'function') {
+          extra[k] = v;
+        }
+      }
+      return {
+        id: t.id,
+        name: t.function.name,
+        args: safeParse(t.function.arguments),
+        ...(Object.keys(extra).length ? { extra } : {}),
+      };
+    });
     return {
       text: choice?.message.content ?? null,
       toolCalls,

--- a/src/agent/providers/openai.ts
+++ b/src/agent/providers/openai.ts
@@ -32,6 +32,8 @@ export class OpenAIProvider implements Provider {
                       id: t.id,
                       type: 'function' as const,
                       function: { name: t.name, arguments: JSON.stringify(t.args) },
+                      // Preserve vendor-specific tool-call fields (e.g. Gemini thought signatures).
+                      // Dropping them makes the next turn's request 400.
                       ...(t.extra || {}),
                     })),
                   }
@@ -51,6 +53,9 @@ export class OpenAIProvider implements Provider {
         : {}),
     });
     const choice = res.choices[0];
+    // Capture any non-standard properties returned by the API (e.g. Gemini thought
+    // signatures) so they can be echoed back on subsequent turns. Dropping them
+    // causes reasoning-model backends to reject the follow-up request with 400.
     const toolCalls = ((choice?.message.tool_calls ?? []) as unknown as Record<string, unknown>[]).map((t: Record<string, unknown>) => {
       const extra: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(t)) {

--- a/src/agent/providers/openai.ts
+++ b/src/agent/providers/openai.ts
@@ -1,10 +1,5 @@
 import type { ChatOpts, Msg, Provider, ToolSchema, Turn } from '../types.js';
 
-interface OpenAIToolCall {
-  id: string;
-  function: { name: string; arguments: string };
-}
-
 export class OpenAIProvider implements Provider {
   readonly name = 'openai';
 
@@ -56,17 +51,18 @@ export class OpenAIProvider implements Provider {
         : {}),
     });
     const choice = res.choices[0];
-    const toolCalls = ((choice?.message.tool_calls ?? []) as any[]).map((t) => {
-      const extra: Record<string, any> = {};
+    const toolCalls = ((choice?.message.tool_calls ?? []) as unknown as Record<string, unknown>[]).map((t: Record<string, unknown>) => {
+      const extra: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(t)) {
         if (k !== 'id' && k !== 'type' && k !== 'function') {
           extra[k] = v;
         }
       }
+      const fn = t.function as { name: string; arguments: string };
       return {
-        id: t.id,
-        name: t.function.name,
-        args: safeParse(t.function.arguments),
+        id: t.id as string,
+        name: fn.name,
+        args: safeParse(fn.arguments),
         ...(Object.keys(extra).length ? { extra } : {}),
       };
     });

--- a/src/agent/providers/openai.ts
+++ b/src/agent/providers/openai.ts
@@ -1,4 +1,4 @@
-import type { ChatOpts, Msg, Provider, ToolSchema, Turn } from '../types.js';
+import type { ChatOpts, Msg, Provider, ToolSchema, Turn, ToolCall } from '../types.js';
 
 export class OpenAIProvider implements Provider {
   readonly name = 'openai';
@@ -28,14 +28,7 @@ export class OpenAIProvider implements Provider {
               content: m.content,
               ...(m.toolCalls?.length
                 ? {
-                    tool_calls: m.toolCalls.map((t) => ({
-                      id: t.id,
-                      type: 'function' as const,
-                      function: { name: t.name, arguments: JSON.stringify(t.args) },
-                      // Preserve vendor-specific tool-call fields (e.g. Gemini thought signatures).
-                      // Dropping them makes the next turn's request 400.
-                      ...(t.extra || {}),
-                    })),
+                    tool_calls: m.toolCalls.map(serializeToolCall),
                   }
                 : {}),
             };
@@ -56,21 +49,7 @@ export class OpenAIProvider implements Provider {
     // Capture any non-standard properties returned by the API (e.g. Gemini thought
     // signatures) so they can be echoed back on subsequent turns. Dropping them
     // causes reasoning-model backends to reject the follow-up request with 400.
-    const toolCalls = ((choice?.message.tool_calls ?? []) as unknown as Record<string, unknown>[]).map((t: Record<string, unknown>) => {
-      const extra: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(t)) {
-        if (k !== 'id' && k !== 'type' && k !== 'function') {
-          extra[k] = v;
-        }
-      }
-      const fn = t.function as { name: string; arguments: string };
-      return {
-        id: t.id as string,
-        name: fn.name,
-        args: safeParse(fn.arguments),
-        ...(Object.keys(extra).length ? { extra } : {}),
-      };
-    });
+    const toolCalls = ((choice?.message.tool_calls ?? []) as unknown as Record<string, unknown>[]).map(parseToolCall);
     return {
       text: choice?.message.content ?? null,
       toolCalls,
@@ -88,4 +67,31 @@ function safeParse(s: string): Record<string, unknown> {
   } catch {
     return { _raw: s };
   }
+}
+
+export function serializeToolCall(t: ToolCall) {
+  return {
+    id: t.id,
+    type: 'function' as const,
+    function: { name: t.name, arguments: JSON.stringify(t.args) },
+    // Preserve vendor-specific tool-call fields (e.g. Gemini thought signatures).
+    // Dropping them makes the next turn's request 400.
+    ...(t.extra || {}),
+  };
+}
+
+export function parseToolCall(t: Record<string, unknown>): ToolCall {
+  const extra: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(t)) {
+    if (k !== 'id' && k !== 'type' && k !== 'function') {
+      extra[k] = v;
+    }
+  }
+  const fn = t.function as { name: string; arguments: string };
+  return {
+    id: t.id as string,
+    name: fn.name,
+    args: safeParse(fn.arguments),
+    ...(Object.keys(extra).length ? { extra } : {}),
+  };
 }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -8,6 +8,7 @@ export interface ToolCall {
   id: string;
   name: string;
   args: Record<string, unknown>;
+  extra?: Record<string, any>;
 }
 
 export type Msg =

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -8,7 +8,7 @@ export interface ToolCall {
   id: string;
   name: string;
   args: Record<string, unknown>;
-  extra?: Record<string, any>;
+  extra?: Record<string, unknown>;
 }
 
 export type Msg =

--- a/test/toolcall-extra.test.ts
+++ b/test/toolcall-extra.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import type { ToolCall, Msg } from '../src/agent/types.js';
+import type { ToolCall } from '../src/agent/types.js';
+import { serializeToolCall, parseToolCall } from '../src/agent/providers/openai.js';
 
 describe('ToolCall extra field round-trip', () => {
-  it('preserves extra properties through assistant message serialization', () => {
+  it('preserves extra properties when serializing for the API (outgoing)', () => {
     // Simulate a tool call returned by Gemini with a thinking signature
     const toolCall: ToolCall = {
       id: 'call_abc',
@@ -11,49 +12,54 @@ describe('ToolCall extra field round-trip', () => {
       extra: { extra_content: { google: { thought_signature: 'sig123' } } },
     };
 
-    // Build the assistant message the way OpenAIProvider does
-    const assistantMsg: Msg = {
-      role: 'assistant',
-      content: null,
-      toolCalls: [toolCall],
-    };
+    const serialized = serializeToolCall(toolCall);
 
-    // Serialize the tool_calls the same way openai.ts does
-    const serialized = assistantMsg.role === 'assistant' && assistantMsg.toolCalls
-      ? assistantMsg.toolCalls.map((t) => ({
-          id: t.id,
-          type: 'function' as const,
-          function: { name: t.name, arguments: JSON.stringify(t.args) },
-          ...(t.extra || {}),
-        }))
-      : [];
-
-    // The extra_content must survive the round-trip
-    expect(serialized).toHaveLength(1);
-    expect(serialized[0].id).toBe('call_abc');
-    expect(serialized[0].function.name).toBe('search_files');
-    expect((serialized[0] as Record<string, unknown>).extra_content).toEqual({
+    expect(serialized.id).toBe('call_abc');
+    expect(serialized.function.name).toBe('search_files');
+    // The extra_content must survive the outgoing serialization
+    expect((serialized as Record<string, unknown>).extra_content).toEqual({
       google: { thought_signature: 'sig123' },
     });
   });
 
-  it('omits extra when no non-standard properties are present', () => {
+  it('omits extra when no non-standard properties are present (outgoing)', () => {
     const toolCall: ToolCall = {
       id: 'call_def',
       name: 'read_file',
       args: { path: 'README.md' },
     };
 
-    expect(toolCall.extra).toBeUndefined();
-
-    const serialized = {
-      id: toolCall.id,
-      type: 'function' as const,
-      function: { name: toolCall.name, arguments: JSON.stringify(toolCall.args) },
-      ...(toolCall.extra || {}),
-    };
+    const serialized = serializeToolCall(toolCall);
 
     // No extra_content key should be present
     expect(Object.keys(serialized)).toEqual(['id', 'type', 'function']);
+  });
+
+  it('captures vendor-specific metadata when parsing from the API (incoming)', () => {
+    const incomingApiPayload = {
+      id: 'call_xyz',
+      type: 'function',
+      function: {
+        name: 'propose_change',
+        arguments: '{"what_changes": "fix something"}',
+      },
+      // Non-standard metadata returned by the provider
+      extra_content: {
+        google: { thought_signature: 'abc987' }
+      },
+      some_other_field: true
+    };
+
+    const parsed = parseToolCall(incomingApiPayload);
+
+    expect(parsed.id).toBe('call_xyz');
+    expect(parsed.name).toBe('propose_change');
+    expect(parsed.args).toEqual({ what_changes: 'fix something' });
+    
+    // Everything else should be collected into the `extra` bag
+    expect(parsed.extra).toEqual({
+      extra_content: { google: { thought_signature: 'abc987' } },
+      some_other_field: true
+    });
   });
 });

--- a/test/toolcall-extra.test.ts
+++ b/test/toolcall-extra.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import type { ToolCall, Msg } from '../src/agent/types.js';
+
+describe('ToolCall extra field round-trip', () => {
+  it('preserves extra properties through assistant message serialization', () => {
+    // Simulate a tool call returned by Gemini with a thinking signature
+    const toolCall: ToolCall = {
+      id: 'call_abc',
+      name: 'search_files',
+      args: { query: '.gitignore' },
+      extra: { extra_content: { google: { thought_signature: 'sig123' } } },
+    };
+
+    // Build the assistant message the way OpenAIProvider does
+    const assistantMsg: Msg = {
+      role: 'assistant',
+      content: null,
+      toolCalls: [toolCall],
+    };
+
+    // Serialize the tool_calls the same way openai.ts does
+    const serialized = assistantMsg.role === 'assistant' && assistantMsg.toolCalls
+      ? assistantMsg.toolCalls.map((t) => ({
+          id: t.id,
+          type: 'function' as const,
+          function: { name: t.name, arguments: JSON.stringify(t.args) },
+          ...(t.extra || {}),
+        }))
+      : [];
+
+    // The extra_content must survive the round-trip
+    expect(serialized).toHaveLength(1);
+    expect(serialized[0].id).toBe('call_abc');
+    expect(serialized[0].function.name).toBe('search_files');
+    expect((serialized[0] as Record<string, unknown>).extra_content).toEqual({
+      google: { thought_signature: 'sig123' },
+    });
+  });
+
+  it('omits extra when no non-standard properties are present', () => {
+    const toolCall: ToolCall = {
+      id: 'call_def',
+      name: 'read_file',
+      args: { path: 'README.md' },
+    };
+
+    expect(toolCall.extra).toBeUndefined();
+
+    const serialized = {
+      id: toolCall.id,
+      type: 'function' as const,
+      function: { name: toolCall.name, arguments: JSON.stringify(toolCall.args) },
+      ...(toolCall.extra || {}),
+    };
+
+    // No extra_content key should be present
+    expect(Object.keys(serialized)).toEqual(['id', 'type', 'function']);
+  });
+});


### PR DESCRIPTION
## What

This PR adds support for reasoning models and Gemini by preserving non-standard or vendor-specific tool call properties (such as thinking signatures) across agent turns in the OpenAI provider.

## Why

OpenAI-compatible reasoning models (like Google Gemini via OPENAI_BASE_URL) return custom metadata in their tool calls (e.g. extra_content.google.thought_signature). If this metadata is stripped from subsequent assistant history messages, the API rejects the request on the next turn with a 400 Bad Request error. This PR preserves those fields through a generic extra bag on ToolCall.

## Design

Add a generic extra field to ToolCall in [types.ts](src/agent/types.ts). In [openai.ts](src/agent/providers/openai.ts), extraction excludes id, type, and function; everything else is captured into extra. On the outgoing side, extra is spread back onto each tool call object. Both spread sites carry a comment explaining why the field exists and what breaks without it.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | npm run typecheck | pass |
| Build | npm run build | pass |
| Unit + offline | npm test | pass (147 passed / 10 skipped) |
| Live-LLM (opt-in) | keyed on OPENAI_API_KEY + OPENAI_BASE_URL | pass (Gemini 3.5 Flash via AI Studio) |

### Manual test log (required)

- Sandbox variant used (create / edit): create
- Commands run and outcome:

Ran copperhead create against Gemini 3.5 Flash with OPENAI_BASE_URL pointing to generativelanguage.googleapis.com. The run completed 9 turns of spec-seed successfully, committing 5 files. The transcript at .copperhead/runs/2026-07-22T05-53-45-473Z/transcript.jsonl confirms extra.extra_content.google.thought_signature round-tripped on every assistant turn (turns 2 through 9). Without this patch, the run 400'd on turn 2.

## Docs

None required. The extra field is internal to the provider; no user-facing configuration changes.

---

## Invariant checklist

- [x] **Spec-gated in**: edit_file/write_file stay structurally absent from the agent tool list until an OpenSpec proposal validates (gated by omission, not prompt text).
- [x] **Verification-gated out**: mutations still end in ERC (and DRC when the board changed) passing, with repair up to maxRepairCycles then rollback to the git snapshot.
- [x] **check/verify stays LLM-free and network-free**: nothing reachable from src/commands/check touches a provider, an API key, or the network.
- [x] **No sexp serialization**: the src/kicad/ parser stays read-only; KiCad files are edited only via anchored exact-match text replace (no round-tripping).
- [x] **Sync-obligations ledger**: post-tool-call hooks keep feeding the ledger, and commit keeps refusing while obligations are open.
- [x] **Secrets**: transcripts and summaries redact sk- secrets at write time; keys live only in env vars; .gitignore keeps .env and .copperhead/runs/.
- [x] **Spec coherence**: N/A, no spec-level behavior changed.