### PR TITLE
fix(bom-export): repoint parser import to bom-table after #44/#45 semantic conflict

### DIFF
--- a/src/kicad/bom-export.ts
+++ b/src/kicad/bom-export.ts
@@ -1,4 +1,4 @@
-import { parseMarkdownTables, type TableRow } from '../memory/drift.js';
+import { parseMarkdownTables, type TableRow } from '../memory/bom-table.js';
 
 /**
  * Supplier-format BOM export (capability supplier-bom-export). Deterministic,


### PR DESCRIPTION
## What

One-line import fix in [bom-export.ts](src/kicad/bom-export.ts): repoints `parseMarkdownTables`/`TableRow` from `../memory/drift.js` to `../memory/bom-table.js`. No behavior change.

## Why

`main` is red. A semantic merge conflict between two PRs that each passed CI in isolation:

- #45 (`add-supplier-bom-export`, merged first) added `bom-export.ts` importing the parser from `drift.js`.
- #44 (`extract-bom-table-parser`, merged second) moved `parseMarkdownTables`/`TableRow` out of `drift.ts` into the new shared `bom-table.ts`.

Neither branch saw the other, so both were green pre-merge. Merged together, `bom-export.ts` imports symbols `drift.js` no longer exports, and `main` fails typecheck:

```text
src/kicad/bom-export.ts(1,10): error TS2459: Module '"../memory/drift.js"' declares 'parseMarkdownTables' locally, but it is not exported.
src/kicad/bom-export.ts(1,36): error TS2305: Module '"../memory/drift.js"' has no exported member 'TableRow'.
  (+ 5 downstream TS7006 implicit-any errors)
```

`bom-table.ts` is exactly the shared module #44 created for this consumer, and it exports both symbols, so this is the intended import.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | pass (200 passed, 10 skipped, 0 failed) |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` | n/a (no key) |

`test/bom-export.test.ts` (24 cases) passes unchanged against the repointed import.

### Manual test log (required)

- Sandbox variant used: n/a
- Commands run and outcome: n/a. This is a compile-time import path fix; it cannot fail at runtime without first failing `npm run typecheck`, which now passes. The existing `bom-export` test suite exercises the code through the new import.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, no agent tool list change.
- [ ] **Verification-gated out**: N/A, no mutation/repair path touched.
- [x] **`check`/`verify` stays LLM-free and network-free**: unaffected; `bom-table.ts` adds no provider/network imports and `bom-export.ts` is not in check's module graph.
- [x] **No sexp serialization**: N/A, `src/kicad/sexp.ts` untouched.
- [ ] **Sync-obligations ledger**: N/A.
- [ ] **Secrets**: N/A.
- [x] **Spec coherence**: N/A, pure import-path fix, no spec-level behavior change.