### PR TITLE
docs: document `export bom` and fix CLI/model-routing consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ copperhead create --brief brief.md   # brief → full output package
 copperhead export bom --supplier jlcpcb   # supplier-ready ordering file from docs/BOM.md
 ```
 
-Global flags: `--repo <path>` (default: cwd) and `--json` for machine-readable output. `do` and `create` take `--model` and `--interactive`; `do` also takes `--dry-run`, `--max-turns`, and `--allow-dirty`.
+Global flags: `--repo <path>` (default: cwd), `--json` for machine-readable output, and `--plain` for plain log-style output with no status line. `do` and `create` take `--model` and `--interactive`; `do` also takes `--dry-run`, `--max-turns`, and `--allow-dirty`.
 
 `--model` accepts `gpt-5` (OpenAI), `claude` / `claude-<id>` (Anthropic API), `claude-code` / `claude-code:<id>` (Claude Code, saved login), and `codex` / `codex:<id>` (Codex CLI, saved login). Routing is by prefix; `claude-code` is matched before the `claude` prefix.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -20,6 +20,7 @@ Every command probes `kicad-cli` before doing anything and exits 1 if it is not 
 | `do` | [Edit an existing board](/workflows/edit-existing-board/) | Yes | One change: propose, edit, verify, propagate, commit. |
 | `create` | [Design from a brief](/workflows/create-from-brief/) | Yes | Full pipeline from a markdown brief to an output package. |
 | `sync` | Either | Verify phase no, resolve phase yes | Reconciles docs, files, and constraints. |
+| `export bom` | Ordering | No | Writes a supplier-format BOM from `docs/BOM.md`. Deterministic, no network. |
 
 ## Global options
 
@@ -132,11 +133,37 @@ Each stage is a full `do` loop with its own prompt and gate. Stage completion is
 | 3 | `parts` | `docs/BOM.md`, MPNs flagged `UNVERIFIED` |
 | 4 | `schematic` | The `.kicad_sch`, ERC clean after each sheet |
 | 5 | `layout` | Draft placement and critical routing, DRC clean, plus a `## Draft quality` section in `LAYOUT.md` |
-| 6 | `outputs` | `outputs/`: gerbers, drill, DXF, STEP, SVG, `BOM.csv` |
+| 6 | `outputs` | `outputs/`: gerbers, drill, DXF, STEP, SVG, `BOM.csv`, and a JLCPCB assembly BOM (`outputs/jlcpcb-bom.csv`, as [`export bom`](#copperhead-export-bom) writes) |
 | 7 | `firmware` | `firmware/` scaffold, `pins.h` generated from `PINOUT.md` |
 | 8 | `devplan` | `docs/DEVPLAN.md` |
 
 Stages build on each other's uncommitted state, so `create` runs them as if `--allow-dirty` were set.
+
+## `copperhead export bom`
+
+Turns the drift-checked `docs/BOM.md` into a file a supplier accepts without hand-editing. Deterministic, LLM-free, and network-free, so it is safe anywhere `check` is. It reads `BOM.md` (never the schematic), so it inherits the drift guarantee and refuses to export while `BOM.md` disagrees with the schematic.
+
+```bash
+copperhead export bom --supplier <name> [--boards <n>] [--spares <percent>] [--include-unverified]
+```
+
+| Option | Description |
+| --- | --- |
+| `--supplier <name>` | **Required.** `jlcpcb`, `digikey`, or `mouser`. JLCPCB gets the assembly-service format (Comment, Designator, Footprint, LCSC Part #, designators grouped per line); DigiKey and Mouser get cart-upload lists (MPN, manufacturer, quantity, customer reference). |
+| `--boards <n>` | Order quantity in boards. Default `1`. |
+| `--spares <percent>` | Spare-parts percentage. Default `10`. |
+| `--include-unverified` | Opt `UNVERIFIED` rows that carry an MPN back in. Never includes MPN-less rows. |
+
+Writes `outputs/<supplier>-bom.csv` and prints the path plus the included/excluded counts. Per-line quantity is `ceil(perBoardCount × boards × (1 + spares/100))`, raised to `perBoardCount × boards + 2` for passive lines (footprints `R_`/`C_`/`L_`), because percentage-only spares under-order low-count passives.
+
+Rows without an MPN, and rows still flagged `UNVERIFIED`, are excluded from the supplier file and named in a warnings footer on stderr (stdout stays clean for `> file` redirects).
+
+`docs/BOM.md` may carry optional `Manufacturer` and `LCSC` columns beyond the base `Refdes | Value | Footprint | MPN | Rationale`; the exporter matches columns by header, so add them when you want them populated. Only *appending* columns is safe: keep `Refdes | Value | Footprint` first and in that order, because the drift check reads those three by position.
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | The supplier file was written. |
+| `1` | A bad flag, a missing `BOM.md`, or drift between `BOM.md` and the schematic. |
 
 ## Repo scripts
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -28,6 +28,7 @@ Every command probes `kicad-cli` before doing anything and exits 1 if it is not 
 | --- | --- |
 | `--repo <path>` | Target repository. Defaults to the current directory. |
 | `--json` | Machine-readable output on stdout. |
+| `--plain` | Plain log-style output with no interactive status line. Useful for CI logs and pipes. |
 | `-V, --version` | Print the version. |
 
 Global options go before the subcommand: `copperhead --json check`.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -92,6 +92,7 @@ Accepted model values (routing is by prefix, matched top to bottom):
 
 | Value | Provider | Key |
 | --- | --- | --- |
+| `codex` / `codex:<id>` | Codex CLI, saved login | none (uses your logged-in Codex CLI / ChatGPT login) |
 | `claude-code` / `claude-code:<id>` | Claude Code, saved login | none (uses `CLAUDE_CODE_OAUTH_TOKEN` / your logged-in CLI) |
 | `claude` / `claude-<id>` | Anthropic API | `ANTHROPIC_API_KEY` |
 | `gpt-5` / anything else | OpenAI API | `OPENAI_API_KEY` |

--- a/docs/src/content/docs/workflows/create-from-brief.md
+++ b/docs/src/content/docs/workflows/create-from-brief.md
@@ -80,7 +80,7 @@ Eight stages, each one a full `do` loop with its own prompt and gate. A stage th
 | 3. Parts | `docs/BOM.md`, MPNs flagged `UNVERIFIED` with justification |
 | 4. Schematic | The `.kicad_sch`, sheet by sheet, ERC clean after each |
 | 5. Layout | First-draft placement and critical routing, DRC clean |
-| 6. Outputs | `outputs/`: gerbers, drill, DXF, STEP, SVG, `BOM.csv` |
+| 6. Outputs | `outputs/`: gerbers, drill, DXF, STEP, SVG, `BOM.csv`, and a JLCPCB assembly BOM (`outputs/jlcpcb-bom.csv`) |
 | 7. Firmware | `firmware/` scaffold with `pins.h` generated from `PINOUT.md` |
 | 8. Dev plan | `docs/DEVPLAN.md`: bring-up order, test points, risks |
 
@@ -99,5 +99,6 @@ Then read `docs/DECISIONS.md` for what was decided and why, and `docs/SPEC.md` f
 ## Next
 
 - [Edit an existing board](/workflows/edit-existing-board/): every change after the first
+- [Order the parts](/reference/cli/#copperhead-export-bom): turn `docs/BOM.md` into a DigiKey, Mouser, or JLCPCB file with `copperhead export bom`
 - [Simple demo](/getting-started/demo/): this flow end to end, one command
 - [`copperhead create`](/reference/cli/#copperhead-create): flags and stage reference


### PR DESCRIPTION
## What

Brings the docs into line with the actual CLI surface as of v0.6.0:

1. Documents `copperhead export bom` on the docs site (docs.copperhead.sh), which never covered the supplier BOM export shipped in v0.6.0.
2. Fixes CLI/model-routing drift found in a consistency pass across the README and the docs site.

## Why

Pure docs drift. `export bom` landed in v0.6.0 and was documented in the [README](README.md) only: the PR that added it never touched the docs site. Once looking, two more gaps surfaced between the docs and [src/cli.ts](src/cli.ts) / [src/agent/loop.ts](src/agent/loop.ts). For a tool whose thesis is that drift is a build failure, the docs describing it should not drift either.

## Design

Docs-only. Every fact verified against source:

- **`export bom`** ([reference/cli.md](docs/src/content/docs/reference/cli.md)): added to the commands-at-a-glance table plus a full command section (supplier formats, `--boards`/`--spares`/`--include-unverified`, the quantity formula with the passive-line floor, MPN/UNVERIFIED exclusions, exit codes), verified against [src/cli.ts:233](src/cli.ts#L233) and [src/commands/export.ts](src/commands/export.ts). Create stage 6 in both [reference/cli.md](docs/src/content/docs/reference/cli.md) and [workflows/create-from-brief.md](docs/src/content/docs/workflows/create-from-brief.md) now names the auto-emitted `outputs/jlcpcb-bom.csv`, with an "Order the parts" next-step link.
- **Global `--plain` flag** ([src/cli.ts:69](src/cli.ts#L69)): was documented nowhere. Added to the docs-site global options table and the README global-flags line.
- **`codex` model routing** ([reference/configuration.md](docs/src/content/docs/reference/configuration.md)): the model-routing table omitted `codex`, so a `codex` model read as routing to the OpenAI API. Added the `codex` / `codex:<id>` row; [makeProvider](src/agent/loop.ts#L68) matches it first.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Markdown lint | `npx markdownlint-cli2 <changed docs>` | pass (0 errors, 4 files) |
| Typecheck | `npm run typecheck` | n/a (no code changed) |
| Build | `npm run build` | n/a (no code changed) |
| Unit + offline | `npm test` | n/a (no code changed) |
| Live-LLM (opt-in) | n/a | n/a |

### Manual test log (required)

Docs-only change with no runtime behavior to exercise.

- Sandbox variant used (`create` / `edit`): n/a
- Commands run and outcome: markdownlint on all changed files, 0 errors.

## Docs

This PR is the docs change: docs-site CLI reference and configuration, the create-from-brief workflow, and the README global-flags line.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A (docs-only)
- [ ] **Verification-gated out**: N/A (docs-only)
- [ ] **`check`/`verify` stays LLM-free and network-free**: N/A (docs-only)
- [ ] **No sexp serialization**: N/A (docs-only)
- [ ] **Sync-obligations ledger**: N/A (docs-only)
- [ ] **Secrets**: N/A (docs-only)
- [ ] **Spec coherence**: N/A (no spec-level behavior changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
