### PR TITLE
feat: bypass pre-commit hook during agent commits via --no-verify

### DIFF
--- a/openspec/changes/build-copperhead-phase-1/design.md
+++ b/openspec/changes/build-copperhead-phase-1/design.md
@@ -97,7 +97,7 @@ Staleness is prevented mechanically, not by prompting. The loop maintains an in-
 
 The ledger state is written into `summary.md`, so an aborted run shows exactly which sync obligations were left open. This turns "keep everything in sync" from an instruction the model might forget into a gate the run cannot pass without satisfying — the same philosophy as ERC/DRC (nothing is done until the tools agree).
 
-For human edits outside the agent: `init` installs a git pre-commit hook that runs `copperhead check` (ERC + DRC + drift + openspec validate + mechanical constraints), so a hand edit that desyncs docs fails at commit time too. Opt-out via `init --no-hooks`; the hook script is a two-liner calling the installed CLI, never a copy of logic.
+For human edits outside the agent: `init` installs a git pre-commit hook that runs `copperhead check` (ERC + DRC + drift + openspec validate + mechanical constraints), so a hand edit that desyncs docs fails at commit time too. Opt-out via `init --no-hooks`; the hook script is a two-liner calling the installed CLI, never a copy of logic. Copperhead's own commits bypass this hook (using `--no-verify`) because they have already passed the identical run-level verification gates inside the loop.
 
 `docs/CHANGELOG.md` is the design changelog: append-only, one entry per committed run, newest first — the narrative "what changed and why" companion to git history, written for hardware reviewers who won't read diffs of s-expressions.
 

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -354,7 +354,7 @@ export async function uncommittedCount(repo: string): Promise<number> {
 export async function commitAll(repo: string, message: string): Promise<string> {
   await ensureIgnored(repo, GIT_ADD_EXCLUDES);
   await git(repo, ['add', '-A']);
-  await git(repo, ['commit', '-m', message]);
+  await git(repo, ['commit', '--no-verify', '-m', message]);
   return git(repo, ['rev-parse', 'HEAD']);
 }
 

--- a/test/git-commit.test.ts
+++ b/test/git-commit.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { writeFile, chmod } from 'node:fs/promises';
+import path from 'node:path';
+import { execa } from 'execa';
+import { tempFixtureRepo } from './helpers.js';
+import { commitAll } from '../src/util/git.js';
+
+describe('git commitAll with pre-commit hooks', () => {
+  it('bypasses the pre-commit hook using --no-verify', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const hooksDir = path.join(repo, '.git', 'hooks');
+      const hookPath = path.join(hooksDir, 'pre-commit');
+      
+      // Install a pre-commit hook that always fails
+      const script = `#!/bin/sh\nexit 1\n`;
+      await writeFile(hookPath, script, 'utf8');
+      await chmod(hookPath, 0o755);
+
+      // Create a change in the repo
+      await writeFile(path.join(repo, 'dummy.txt'), 'hello', 'utf8');
+
+      // Call commitAll, which should succeed because it bypasses the hook
+      const commitSha = await commitAll(repo, 'test commit bypassing hook');
+      expect(commitSha).toBeDefined();
+      expect(commitSha.length).toBeGreaterThan(0);
+
+      // Verify the commit actually exists in git log
+      const { stdout } = await execa('git', ['log', '-1', '--format=%s'], { cwd: repo });
+      expect(stdout.trim()).toBe('test commit bypassing hook');
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/test/observability.test.ts
+++ b/test/observability.test.ts
@@ -143,10 +143,9 @@ describe('exit paths and run-end addenda (task 4.6)', () => {
       await writeFile(path.join(repo, 'docs', 'DECISIONS.md'), '# Decisions\n', 'utf8');
       await execa('git', ['add', '-A'], { cwd: repo });
       await execa('git', ['commit', '-q', '-m', 'docs'], { cwd: repo });
-      // a failing pre-commit hook makes the end-of-run `git commit` exit non-zero
-      const hook = path.join(repo, '.git', 'hooks', 'pre-commit');
-      await writeFile(hook, '#!/bin/sh\necho "check failed" >&2\nexit 1\n', 'utf8');
-      await chmod(hook, 0o755);
+      // force a signing failure that git commit cannot satisfy (even with --no-verify)
+      await execa('git', ['config', 'commit.gpgsign', 'true'], { cwd: repo });
+      await execa('git', ['config', 'gpg.program', 'false'], { cwd: repo });
 
       const lines: string[] = [];
       const provider = new ScriptedProvider([finishTurn('done', 'all good')]);


### PR DESCRIPTION
## What

Bypasses the pre-commit hook during agent-driven commits via the `--no-verify` flag.

## Why

Fixes the remaining deadlock vectors in issue #21. The pre-commit hook exists to prevent human hand edits from causing drift. However, when the copperhead agent commits, it has already passed all of its own run-level checks (ledger obligations, ERC/DRC verification). Running the pre-commit hook here is redundant and can deadlock during bootstrap stages (where documents legitimately lead the schematic).

## Design

- Modified `commitAll` in `src/util/git.ts` to execute `git commit --no-verify -m ...`.
- Added a unit test in `test/git-commit.test.ts` to assert that `commitAll` succeeds even when a failing pre-commit hook is installed.

## Spec / OpenSpec

n/a

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | pass (new test suite `git-commit.test.ts` passes) |
| Live-LLM (opt-in) | keyed on `<ENV_VAR>` | n/a |

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a (Git commit utility enhancement).
- Commands run and outcome:

```text
$ npx vitest run test/git-commit.test.ts
✓ test/git-commit.test.ts (1 test) 1265ms
  ✓ git commitAll with pre-commit hooks > bypasses the pre-commit hook using --no-verify  1263ms

 ```

  ## Docs

n/a

---

## Invariant checklist
- [x] **Spec-gated in**: N/A (tooling-only)
- [x] **Verification-gated out**: N/A (tooling-only)
- [x] **`check` / `verify` stays LLM-free and network-free**: N/A (tooling-only)
- [x] **No sexp serialization**: N/A (tooling-only)
- [x] **Sync-obligations ledger**: N/A (tooling-only)
- [x] **Secrets**: N/A (tooling-only)
- [x] **Spec coherence**: N/A (no spec-level behavior changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automated commits now complete reliably even when local pre-commit hooks fail.
  * Commit signing failures remain detectable and are reported appropriately.

* **Tests**
  * Added coverage confirming successful commits bypass failing pre-commit hooks while preserving the expected commit message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->