### PR TITLE
feat(spice): parse simulation blocks and compile assertions

### DIFF
--- a/openspec/changes/add-spice-verification-gate/specs/spice-verification/spec.md
+++ b/openspec/changes/add-spice-verification-gate/specs/spice-verification/spec.md
@@ -3,7 +3,7 @@
 ## ADDED Requirements
 
 ### Requirement: Simulation opt-in via SUBSYSTEMS.md
-A subsystem SHALL be flagged for SPICE verification by a `## Simulation` block in SUBSYSTEMS.md. The line-oriented block SHALL contain one `scope: sheet <path>` or `scope: nets <net>, <net>` field, one `analysis: op|dc|ac|tran` field, optional repeated `source: <port>=<number>` lines for driven ports, and one or more `assert: <assertion>` lines. The `sources` field name SHALL be accepted as an alias for `source`. A scope that references sheets or nets absent from the schematic SHALL be reported as a failure by `check`.
+A subsystem SHALL be flagged for SPICE verification by a `## Simulation` block in SUBSYSTEMS.md. The line-oriented block SHALL contain one `scope: sheet <path>` or `scope: nets <net>, <net>` field, one `analysis: op|dc|ac|tran` field, optional repeated `source: <port>=<number>` lines for driven ports, and one or more `assert: <assertion>` lines. The `sources` field name SHALL be accepted as an alias for `source`. Fenced code examples and non-field narrative lines SHALL NOT be parsed as live Simulation input. A scope that references sheets or nets absent from the schematic SHALL be reported as a failure by `check`.
 
 #### Scenario: Flagged subsystem is picked up
 - **WHEN** SUBSYSTEMS.md contains a `## Simulation` block scoped to the divider sheet with an `op` analysis
@@ -14,7 +14,7 @@ A subsystem SHALL be flagged for SPICE verification by a `## Simulation` block i
 - **THEN** `check` exits non-zero naming the block and the missing net
 
 ### Requirement: Assertion grammar
-Assertions SHALL use the closed grammar: measurables `V(<net>)`, `I(<refdes>)`, and `corner(<net>)`; comparators `between <a> and <b>`, `< <x>`, `> <x>`; numbers with SI suffixes. The gate SHALL compile assertions to ngspice `.meas` directives and SHALL reject any other syntax with a parse error naming the line. Raw ngspice control blocks SHALL NOT be accepted.
+Assertions SHALL use the closed grammar: measurables `V(<net>)`, `I(<refdes>)`, and `corner(<net>)`; comparators `between <a> and <b>`, `< <x>`, `> <x>`; numbers with SI suffixes. Both `between` bounds SHALL omit units or use the same unit, compared case-insensitively. The gate SHALL compile assertions to ngspice `.meas` directives and SHALL reject any other syntax with a parse error naming the line. Raw ngspice control blocks SHALL NOT be accepted.
 
 #### Scenario: Valid assertion compiles
 - **WHEN** a block contains `V(VREF) between 3.25 and 3.35`

--- a/openspec/changes/add-spice-verification-gate/specs/spice-verification/spec.md
+++ b/openspec/changes/add-spice-verification-gate/specs/spice-verification/spec.md
@@ -3,7 +3,7 @@
 ## ADDED Requirements
 
 ### Requirement: Simulation opt-in via SUBSYSTEMS.md
-A subsystem SHALL be flagged for SPICE verification by a `## Simulation` block in SUBSYSTEMS.md that names the netlist scope (a hierarchical sheet reference or an explicit net set), the analysis type (`op`, `dc`, `ac`, or `tran`), optional `sources` lines for driven ports, and one or more assertions. A scope that references sheets or nets absent from the schematic SHALL be reported as a failure by `check`.
+A subsystem SHALL be flagged for SPICE verification by a `## Simulation` block in SUBSYSTEMS.md. The line-oriented block SHALL contain one `scope: sheet <path>` or `scope: nets <net>, <net>` field, one `analysis: op|dc|ac|tran` field, optional repeated `source: <port>=<number>` lines for driven ports, and one or more `assert: <assertion>` lines. The `sources` field name SHALL be accepted as an alias for `source`. A scope that references sheets or nets absent from the schematic SHALL be reported as a failure by `check`.
 
 #### Scenario: Flagged subsystem is picked up
 - **WHEN** SUBSYSTEMS.md contains a `## Simulation` block scoped to the divider sheet with an `op` analysis

--- a/openspec/changes/add-spice-verification-gate/tasks.md
+++ b/openspec/changes/add-spice-verification-gate/tasks.md
@@ -3,8 +3,8 @@
 ## 1. Wrapper and grammar
 
 - [ ] 1.1 Implement ngspice wrapper in `src/kicad/spice.ts` mirroring the kicad-cli wrapper: execa batch mode, version detection, install hint, per-run timeout from config
-- [ ] 1.2 Implement the `## Simulation` block parser (scope, analysis, sources, assertions) with parse errors naming lines; reject raw control blocks
-- [ ] 1.3 Implement the assertion grammar → `.meas` directive compiler with SI-suffix number parsing; unit tests for every measurable/comparator pair
+- [x] 1.2 Implement the `## Simulation` block parser (scope, analysis, sources, assertions) with parse errors naming lines; reject raw control blocks
+- [x] 1.3 Implement the assertion grammar → `.meas` directive compiler with SI-suffix number parsing; unit tests for every measurable/comparator pair
 
 ## 2. Netlist scoping and execution
 

--- a/src/kicad/spice.ts
+++ b/src/kicad/spice.ts
@@ -98,10 +98,8 @@ export function parseSpiceNumber(raw: string, line = 1): SpiceNumber {
 
   const base = Number(match[1]);
   const suffix = (match[2] ?? '').toLowerCase();
-  const multiplier = SI_MULTIPLIERS[suffix];
-  if (multiplier === undefined) {
-    throw new SimulationParseError(line, `unsupported SI suffix in "${raw}"`);
-  }
+  // The regex limits suffixes to keys in SI_MULTIPLIERS.
+  const multiplier = SI_MULTIPLIERS[suffix]!;
 
   const value = base * multiplier;
   if (!Number.isFinite(value)) {
@@ -143,11 +141,7 @@ export function parseSpiceAssertion(raw: string, line = 1): SimulationAssertion 
   if (betweenMatch) {
     const lower = parseSpiceNumber(betweenMatch[1]!, line);
     const upper = parseSpiceNumber(betweenMatch[2]!, line);
-    if (
-      lower.unit.length > 0 &&
-      upper.unit.length > 0 &&
-      lower.unit.toLowerCase() !== upper.unit.toLowerCase()
-    ) {
+    if (lower.unit.toLowerCase() !== upper.unit.toLowerCase()) {
       throw new SimulationParseError(line, 'between bounds use different units');
     }
     if (lower.value >= upper.value) {
@@ -177,29 +171,61 @@ export function parseSpiceAssertion(raw: string, line = 1): SimulationAssertion 
 export function parseSimulationBlocks(markdown: string): SimulationBlock[] {
   const lines = markdown.split(/\r?\n/);
   const blocks: SimulationBlock[] = [];
+  let openFence: string | null = null;
+  let inDocumentComment = false;
 
   for (let index = 0; index < lines.length; index++) {
-    if (!/^##\s+Simulation\s*$/i.test(lines[index]!.trim())) continue;
+    const line = lines[index]!.trim();
+    const fence = markdownFence(line);
+    if (openFence) {
+      if (fence) openFence = toggleFence(openFence, fence);
+      continue;
+    }
+    if (inDocumentComment) {
+      if (line.includes('-->')) inDocumentComment = false;
+      continue;
+    }
+    if (fence) {
+      openFence = fence;
+      continue;
+    }
+    if (line.startsWith('<!--')) {
+      if (!line.includes('-->')) inDocumentComment = true;
+      continue;
+    }
+    if (!/^##\s+Simulation\s*$/i.test(line)) continue;
 
     const headingLine = index + 1;
     const body: Array<{ text: string; line: number }> = [];
     let cursor = index + 1;
     let inComment = false;
+    let bodyFence: string | null = null;
 
     for (; cursor < lines.length; cursor++) {
       const text = lines[cursor]!;
-      if (/^#{1,2}\s+/.test(text.trim())) break;
-
       const trimmed = text.trim();
+      const bodyFenceMarker = markdownFence(trimmed);
+      if (bodyFence) {
+        if (bodyFenceMarker) bodyFence = toggleFence(bodyFence, bodyFenceMarker);
+        continue;
+      }
       if (inComment) {
         if (trimmed.includes('-->')) inComment = false;
         continue;
       }
+      if (bodyFenceMarker) {
+        bodyFence = bodyFenceMarker;
+        continue;
+      }
+      if (/^#{1,6}\s+/.test(trimmed)) break;
+
       if (trimmed.startsWith('<!--')) {
         if (!trimmed.includes('-->')) inComment = true;
         continue;
       }
-      if (trimmed.length > 0) body.push({ text: trimmed, line: cursor + 1 });
+      if (trimmed.startsWith('.') || /^[A-Za-z]+\s*:/.test(trimmed)) {
+        body.push({ text: trimmed, line: cursor + 1 });
+      }
     }
 
     blocks.push(parseSimulationBlock(body, headingLine));
@@ -207,6 +233,16 @@ export function parseSimulationBlocks(markdown: string): SimulationBlock[] {
   }
 
   return blocks;
+}
+
+function markdownFence(line: string): string | null {
+  return /^(`{3,}|~{3,})/.exec(line)?.[1] ?? null;
+}
+
+function toggleFence(openFence: string | null, marker: string): string | null {
+  if (!openFence) return marker;
+  if (marker[0] === openFence[0] && marker.length >= openFence.length) return null;
+  return openFence;
 }
 
 function parseSimulationBlock(
@@ -270,20 +306,20 @@ function parseSimulationBlock(
 }
 
 function parseScope(raw: string, line: number): SimulationScope {
-  const match = /^(sheet|nets)\s+(.+)$/i.exec(raw);
+  const match = /^(sheet|nets)(?:\s+(.*))?$/i.exec(raw);
   if (!match) {
     throw new SimulationParseError(line, 'scope must be "sheet <path>" or "nets <a>, <b>"');
   }
 
+  const scopeValue = (match[2] ?? '').trim();
   if (match[1]!.toLowerCase() === 'sheet') {
-    const sheet = match[2]!.trim();
-    if (sheet.length === 0 || /[\r\n]/.test(sheet)) {
+    if (scopeValue.length === 0) {
       throw new SimulationParseError(line, 'sheet scope is empty');
     }
-    return { kind: 'sheet', sheet };
+    return { kind: 'sheet', sheet: scopeValue };
   }
 
-  const netList = match[2]!.trim().replace(/^\[(.*)\]$/, '$1');
+  const netList = scopeValue.replace(/^\[(.*)\]$/, '$1');
   const nets = netList
     .split(',')
     .map((net) => net.trim())

--- a/src/kicad/spice.ts
+++ b/src/kicad/spice.ts
@@ -1,0 +1,363 @@
+/**
+ * Parser and assertion compiler for the opt-in SPICE verification gate.
+ *
+ * This module is deliberately pure: it reads strings and produces data or
+ * ngspice deck fragments. Process execution belongs to the wrapper in task 1.1.
+ */
+
+export type SpiceAnalysis = 'op' | 'dc' | 'ac' | 'tran';
+
+export type SimulationScope =
+  | { kind: 'sheet'; sheet: string }
+  | { kind: 'nets'; nets: string[] };
+
+export interface SpiceNumber {
+  raw: string;
+  value: number;
+  unit: string;
+}
+
+export type SpiceMeasurable =
+  | { kind: 'voltage'; target: string }
+  | { kind: 'current'; target: string }
+  | { kind: 'corner'; target: string };
+
+export type SpiceComparator =
+  | { kind: 'between'; lower: SpiceNumber; upper: SpiceNumber }
+  | { kind: 'less-than'; bound: SpiceNumber }
+  | { kind: 'greater-than'; bound: SpiceNumber };
+
+export interface SimulationAssertion {
+  raw: string;
+  line: number;
+  measurable: SpiceMeasurable;
+  comparator: SpiceComparator;
+}
+
+export interface SimulationSource {
+  port: string;
+  value: SpiceNumber;
+  line: number;
+}
+
+export interface SimulationBlock {
+  line: number;
+  scope: SimulationScope;
+  analysis: SpiceAnalysis;
+  sources: SimulationSource[];
+  assertions: SimulationAssertion[];
+}
+
+export interface CompiledSpiceAssertion {
+  valueName: string;
+  checks: Array<{
+    name: string;
+    pass: 'nonnegative' | 'positive';
+  }>;
+  lines: string[];
+  deck: string;
+}
+
+export class SimulationParseError extends Error {
+  readonly line: number;
+
+  constructor(line: number, message: string) {
+    super(`line ${line}: ${message}`);
+    this.name = 'SimulationParseError';
+    this.line = line;
+  }
+}
+
+const ANALYSES = new Set<SpiceAnalysis>(['op', 'dc', 'ac', 'tran']);
+const SAFE_TARGET = /^[A-Za-z0-9_./:+-]+$/;
+const SAFE_MEASURE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const SI_MULTIPLIERS: Readonly<Record<string, number>> = {
+  '': 1,
+  t: 1e12,
+  g: 1e9,
+  meg: 1e6,
+  k: 1e3,
+  m: 1e-3,
+  u: 1e-6,
+  n: 1e-9,
+  p: 1e-12,
+  f: 1e-15,
+};
+
+/** Parse a SPICE-style number while preserving the original safe literal. */
+export function parseSpiceNumber(raw: string, line = 1): SpiceNumber {
+  const token = raw.trim();
+  const match =
+    /^([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?)(meg|[tgkmunpf])?([a-z]*)$/i.exec(
+      token,
+    );
+  if (!match) {
+    throw new SimulationParseError(line, `invalid SPICE number "${raw}"`);
+  }
+
+  const base = Number(match[1]);
+  const suffix = (match[2] ?? '').toLowerCase();
+  const multiplier = SI_MULTIPLIERS[suffix];
+  if (multiplier === undefined) {
+    throw new SimulationParseError(line, `unsupported SI suffix in "${raw}"`);
+  }
+
+  const value = base * multiplier;
+  if (!Number.isFinite(value)) {
+    throw new SimulationParseError(line, `SPICE number is out of range "${raw}"`);
+  }
+
+  return {
+    raw: token,
+    value,
+    unit: match[3] ?? '',
+  };
+}
+
+/** Parse one assertion from the closed grammar in the SPICE delta spec. */
+export function parseSpiceAssertion(raw: string, line = 1): SimulationAssertion {
+  const text = raw.trim();
+  const measurableMatch = /^(V|I|corner)\(([^()\s]+)\)\s+(.+)$/i.exec(text);
+  if (!measurableMatch) {
+    throw new SimulationParseError(line, `invalid SPICE assertion "${raw}"`);
+  }
+
+  const target = measurableMatch[2]!;
+  if (!SAFE_TARGET.test(target)) {
+    throw new SimulationParseError(line, `invalid measurable target "${target}"`);
+  }
+
+  const measurableToken = measurableMatch[1]!.toLowerCase();
+  const measurable: SpiceMeasurable =
+    measurableToken === 'v'
+      ? { kind: 'voltage', target }
+      : measurableToken === 'i'
+        ? { kind: 'current', target }
+        : { kind: 'corner', target };
+
+  const comparatorText = measurableMatch[3]!.trim();
+  const betweenMatch = /^between\s+(\S+)\s+and\s+(\S+)$/i.exec(comparatorText);
+  let comparator: SpiceComparator;
+
+  if (betweenMatch) {
+    const lower = parseSpiceNumber(betweenMatch[1]!, line);
+    const upper = parseSpiceNumber(betweenMatch[2]!, line);
+    if (
+      lower.unit.length > 0 &&
+      upper.unit.length > 0 &&
+      lower.unit.toLowerCase() !== upper.unit.toLowerCase()
+    ) {
+      throw new SimulationParseError(line, 'between bounds use different units');
+    }
+    if (lower.value >= upper.value) {
+      throw new SimulationParseError(line, 'between lower bound must be less than upper bound');
+    }
+    comparator = { kind: 'between', lower, upper };
+  } else {
+    const singleMatch = /^([<>])\s*(\S+)$/.exec(comparatorText);
+    if (!singleMatch) {
+      throw new SimulationParseError(line, `invalid comparator "${comparatorText}"`);
+    }
+    const bound = parseSpiceNumber(singleMatch[2]!, line);
+    comparator =
+      singleMatch[1] === '<'
+        ? { kind: 'less-than', bound }
+        : { kind: 'greater-than', bound };
+  }
+
+  return { raw: text, line, measurable, comparator };
+}
+
+/**
+ * Parse every `## Simulation` section from SUBSYSTEMS.md.
+ *
+ * Fields are line-oriented so errors can always identify the source line.
+ */
+export function parseSimulationBlocks(markdown: string): SimulationBlock[] {
+  const lines = markdown.split(/\r?\n/);
+  const blocks: SimulationBlock[] = [];
+
+  for (let index = 0; index < lines.length; index++) {
+    if (!/^##\s+Simulation\s*$/i.test(lines[index]!.trim())) continue;
+
+    const headingLine = index + 1;
+    const body: Array<{ text: string; line: number }> = [];
+    let cursor = index + 1;
+    let inComment = false;
+
+    for (; cursor < lines.length; cursor++) {
+      const text = lines[cursor]!;
+      if (/^#{1,2}\s+/.test(text.trim())) break;
+
+      const trimmed = text.trim();
+      if (inComment) {
+        if (trimmed.includes('-->')) inComment = false;
+        continue;
+      }
+      if (trimmed.startsWith('<!--')) {
+        if (!trimmed.includes('-->')) inComment = true;
+        continue;
+      }
+      if (trimmed.length > 0) body.push({ text: trimmed, line: cursor + 1 });
+    }
+
+    blocks.push(parseSimulationBlock(body, headingLine));
+    index = cursor - 1;
+  }
+
+  return blocks;
+}
+
+function parseSimulationBlock(
+  body: Array<{ text: string; line: number }>,
+  headingLine: number,
+): SimulationBlock {
+  let scope: SimulationScope | undefined;
+  let analysis: SpiceAnalysis | undefined;
+  const sources: SimulationSource[] = [];
+  const assertions: SimulationAssertion[] = [];
+
+  for (const entry of body) {
+    if (entry.text.startsWith('.')) {
+      throw new SimulationParseError(
+        entry.line,
+        `raw ngspice statement "${entry.text.split(/\s/, 1)[0]}" is not allowed`,
+      );
+    }
+
+    const fieldMatch = /^([A-Za-z]+)\s*:\s*(.+)$/.exec(entry.text);
+    if (!fieldMatch) {
+      throw new SimulationParseError(entry.line, `expected "field: value", got "${entry.text}"`);
+    }
+
+    const field = fieldMatch[1]!.toLowerCase();
+    const value = fieldMatch[2]!.trim();
+
+    switch (field) {
+      case 'scope':
+        if (scope) throw new SimulationParseError(entry.line, 'duplicate scope');
+        scope = parseScope(value, entry.line);
+        break;
+      case 'analysis': {
+        if (analysis) throw new SimulationParseError(entry.line, 'duplicate analysis');
+        const candidate = value.toLowerCase();
+        if (!ANALYSES.has(candidate as SpiceAnalysis)) {
+          throw new SimulationParseError(entry.line, `unsupported analysis "${value}"`);
+        }
+        analysis = candidate as SpiceAnalysis;
+        break;
+      }
+      case 'source':
+      case 'sources':
+        sources.push(parseSource(value, entry.line));
+        break;
+      case 'assert':
+        assertions.push(parseSpiceAssertion(value, entry.line));
+        break;
+      default:
+        throw new SimulationParseError(entry.line, `unknown Simulation field "${field}"`);
+    }
+  }
+
+  if (!scope) throw new SimulationParseError(headingLine, 'Simulation block is missing scope');
+  if (!analysis) throw new SimulationParseError(headingLine, 'Simulation block is missing analysis');
+  if (assertions.length === 0) {
+    throw new SimulationParseError(headingLine, 'Simulation block needs at least one assertion');
+  }
+
+  return { line: headingLine, scope, analysis, sources, assertions };
+}
+
+function parseScope(raw: string, line: number): SimulationScope {
+  const match = /^(sheet|nets)\s+(.+)$/i.exec(raw);
+  if (!match) {
+    throw new SimulationParseError(line, 'scope must be "sheet <path>" or "nets <a>, <b>"');
+  }
+
+  if (match[1]!.toLowerCase() === 'sheet') {
+    const sheet = match[2]!.trim();
+    if (sheet.length === 0 || /[\r\n]/.test(sheet)) {
+      throw new SimulationParseError(line, 'sheet scope is empty');
+    }
+    return { kind: 'sheet', sheet };
+  }
+
+  const netList = match[2]!.trim().replace(/^\[(.*)\]$/, '$1');
+  const nets = netList
+    .split(',')
+    .map((net) => net.trim())
+    .filter((net) => net.length > 0);
+  if (nets.length === 0 || nets.some((net) => !SAFE_TARGET.test(net))) {
+    throw new SimulationParseError(line, 'net scope must contain comma-separated net names');
+  }
+  return { kind: 'nets', nets: [...new Set(nets)] };
+}
+
+function parseSource(raw: string, line: number): SimulationSource {
+  const match = /^([A-Za-z_][A-Za-z0-9_./:+-]*)\s*=\s*(\S+)$/.exec(raw);
+  if (!match) {
+    throw new SimulationParseError(line, 'source must be "<port>=<number>"');
+  }
+  return {
+    port: match[1]!,
+    value: parseSpiceNumber(match[2]!, line),
+    line,
+  };
+}
+
+/**
+ * Compile a parsed assertion to one value measure and one or two margin
+ * measures. Inclusive bounds pass at zero; strict bounds must be positive.
+ */
+export function compileSpiceAssertion(
+  assertion: SimulationAssertion,
+  analysis: SpiceAnalysis,
+  name = `assertion_${assertion.line}`,
+): CompiledSpiceAssertion {
+  if (!SAFE_MEASURE_NAME.test(name)) {
+    throw new SimulationParseError(assertion.line, `invalid measure name "${name}"`);
+  }
+
+  let valueLine: string;
+  if (assertion.measurable.kind === 'corner') {
+    if (analysis !== 'ac') {
+      throw new SimulationParseError(assertion.line, 'corner() requires an ac analysis');
+    }
+    valueLine = `.meas ac ${name}_value WHEN vdb(${assertion.measurable.target})=-3 FALL=1`;
+  } else {
+    const expression =
+      assertion.measurable.kind === 'voltage'
+        ? `v(${assertion.measurable.target})`
+        : `i(${assertion.measurable.target})`;
+    const operation = analysis === 'op' ? 'FIND' : 'AVG';
+    valueLine = `.meas ${analysis} ${name}_value ${operation} ${expression}`;
+  }
+
+  const valueName = `${name}_value`;
+  const marginExpressions =
+    assertion.comparator.kind === 'between'
+      ? [
+          [`${name}_lower_margin`, `${valueName} - ${assertion.comparator.lower.raw}`],
+          [`${name}_upper_margin`, `${assertion.comparator.upper.raw} - ${valueName}`],
+        ]
+      : assertion.comparator.kind === 'less-than'
+        ? [[`${name}_margin`, `${assertion.comparator.bound.raw} - ${valueName}`]]
+        : [[`${name}_margin`, `${valueName} - ${assertion.comparator.bound.raw}`]];
+
+  const checks = marginExpressions.map(([checkName]) => ({
+    name: checkName!,
+    pass: assertion.comparator.kind === 'between' ? ('nonnegative' as const) : ('positive' as const),
+  }));
+  const checkLines = marginExpressions.map(
+    ([checkName, expression]) => `.meas ${analysis} ${checkName} PARAM='${expression}'`,
+  );
+  const compiledLines = [valueLine, ...checkLines];
+
+  return {
+    valueName,
+    checks,
+    lines: compiledLines,
+    deck: compiledLines.join('\n'),
+  };
+}

--- a/test/spice.test.ts
+++ b/test/spice.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SimulationParseError,
+  compileSpiceAssertion,
+  parseSimulationBlocks,
+  parseSpiceAssertion,
+  parseSpiceNumber,
+  type SpiceMeasurable,
+} from '../src/kicad/spice.js';
+
+describe('parseSimulationBlocks', () => {
+  it('parses sheet scope, analysis, sources, and assertions with source lines', () => {
+    const markdown = `# Power subsystem
+
+## Simulation
+scope: sheet /Power/Reference
+analysis: op
+source: VIN=3.3V
+sources: ENABLE=1
+assert: V(VREF) between 3.25 and 3.35
+assert: I(R5) < 25uA
+
+## Notes
+Keep the reference close to the ADC.
+`;
+
+    expect(parseSimulationBlocks(markdown)).toEqual([
+      {
+        line: 3,
+        scope: { kind: 'sheet', sheet: '/Power/Reference' },
+        analysis: 'op',
+        sources: [
+          {
+            port: 'VIN',
+            value: { raw: '3.3V', value: 3.3, unit: 'V' },
+            line: 6,
+          },
+          {
+            port: 'ENABLE',
+            value: { raw: '1', value: 1, unit: '' },
+            line: 7,
+          },
+        ],
+        assertions: [
+          {
+            raw: 'V(VREF) between 3.25 and 3.35',
+            line: 8,
+            measurable: { kind: 'voltage', target: 'VREF' },
+            comparator: {
+              kind: 'between',
+              lower: { raw: '3.25', value: 3.25, unit: '' },
+              upper: { raw: '3.35', value: 3.35, unit: '' },
+            },
+          },
+          {
+            raw: 'I(R5) < 25uA',
+            line: 9,
+            measurable: { kind: 'current', target: 'R5' },
+            comparator: {
+              kind: 'less-than',
+              bound: { raw: '25uA', value: 25 * 1e-6, unit: 'A' },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('parses explicit net scopes and removes duplicate nets', () => {
+    const markdown = `## Simulation
+scope: nets [VIN, VOUT, GND, VOUT]
+analysis: tran
+assert: V(VOUT) > 1.2V
+`;
+
+    expect(parseSimulationBlocks(markdown)[0]).toMatchObject({
+      scope: { kind: 'nets', nets: ['VIN', 'VOUT', 'GND'] },
+      analysis: 'tran',
+    });
+  });
+
+  it('returns an empty list when the document has no Simulation block', () => {
+    expect(parseSimulationBlocks('# Subsystems\n\nNo simulations configured.\n')).toEqual([]);
+  });
+
+  it('rejects raw ngspice control statements and names the source line', () => {
+    const markdown = `# Power
+
+## Simulation
+scope: sheet /Power
+analysis: op
+.control
+assert: V(VREF) > 3V
+`;
+
+    expect(() => parseSimulationBlocks(markdown)).toThrowError(
+      new SimulationParseError(6, 'raw ngspice statement ".control" is not allowed'),
+    );
+  });
+
+  it('reports the heading line when a required field is missing', () => {
+    const markdown = `# Power
+
+## Simulation
+scope: nets VIN, GND
+analysis: dc
+`;
+
+    expect(() => parseSimulationBlocks(markdown)).toThrowError(
+      new SimulationParseError(3, 'Simulation block needs at least one assertion'),
+    );
+  });
+});
+
+describe('parseSpiceNumber', () => {
+  it.each([
+    ['3.3', 3.3, ''],
+    ['25uA', 25e-6, 'A'],
+    ['10k', 10_000, ''],
+    ['2MEGOhm', 2e6, 'Ohm'],
+    ['-4.7mV', -4.7e-3, 'V'],
+    ['1e-9A', 1e-9, 'A'],
+  ])('parses %s with its SI multiplier', (raw, value, unit) => {
+    const parsed = parseSpiceNumber(raw);
+    expect(parsed).toMatchObject({ raw, unit });
+    expect(parsed.value).toBeCloseTo(value, 12);
+  });
+
+  it('rejects unsupported numeric syntax', () => {
+    expect(() => parseSpiceNumber('NaN', 14)).toThrowError(
+      new SimulationParseError(14, 'invalid SPICE number "NaN"'),
+    );
+  });
+});
+
+describe('parseSpiceAssertion', () => {
+  it('rejects arbitrary expressions outside the closed grammar', () => {
+    expect(() => parseSpiceAssertion('max(V(OUT)) < 5', 22)).toThrowError(
+      new SimulationParseError(22, 'invalid SPICE assertion "max(V(OUT)) < 5"'),
+    );
+  });
+
+  it('rejects reversed between bounds', () => {
+    expect(() => parseSpiceAssertion('V(OUT) between 5 and 3', 9)).toThrowError(
+      new SimulationParseError(9, 'between lower bound must be less than upper bound'),
+    );
+  });
+});
+
+describe('compileSpiceAssertion', () => {
+  it('compiles a V(VREF) between assertion with both bounds evaluated', () => {
+    const assertion = parseSpiceAssertion('V(VREF) between 3.25 and 3.35', 12);
+
+    expect(compileSpiceAssertion(assertion, 'op', 'vref')).toEqual({
+      valueName: 'vref_value',
+      checks: [
+        { name: 'vref_lower_margin', pass: 'nonnegative' },
+        { name: 'vref_upper_margin', pass: 'nonnegative' },
+      ],
+      lines: [
+        '.meas op vref_value FIND v(VREF)',
+        ".meas op vref_lower_margin PARAM='vref_value - 3.25'",
+        ".meas op vref_upper_margin PARAM='3.35 - vref_value'",
+      ],
+      deck: `.meas op vref_value FIND v(VREF)
+.meas op vref_lower_margin PARAM='vref_value - 3.25'
+.meas op vref_upper_margin PARAM='3.35 - vref_value'`,
+    });
+  });
+
+  const measurables: Array<[string, SpiceMeasurable, string]> = [
+    ['V(net)', { kind: 'voltage', target: 'OUT' }, 'v(OUT)'],
+    ['I(refdes)', { kind: 'current', target: 'R5' }, 'i(R5)'],
+    ['corner(net)', { kind: 'corner', target: 'OUT' }, 'vdb(OUT)'],
+  ];
+  const comparators = [
+    'between 1kHz and 2kHz',
+    '< 2kHz',
+    '> 1kHz',
+  ] as const;
+
+  it.each(
+    measurables.flatMap(([measurableLabel, measurable, expression]) =>
+      comparators.map(
+        (comparator) =>
+          [`${measurableLabel} ${comparator}`, measurable, expression, comparator] as const,
+      ),
+    ),
+  )('compiles %s', (_label, measurable, expression, comparator) => {
+    const measurableText =
+      measurable.kind === 'voltage'
+        ? 'V(OUT)'
+        : measurable.kind === 'current'
+          ? 'I(R5)'
+          : 'corner(OUT)';
+    const assertion = parseSpiceAssertion(`${measurableText} ${comparator}`);
+    const result = compileSpiceAssertion(assertion, 'ac', 'check');
+
+    expect(result.lines[0]).toContain(expression);
+    expect(result.lines).toHaveLength(comparator.startsWith('between') ? 3 : 2);
+    expect(result.lines.slice(1).every((line) => line.includes("PARAM='"))).toBe(true);
+    const expectedPass = comparator.startsWith('between') ? 'nonnegative' : 'positive';
+    expect(result.checks.every((check) => check.pass === expectedPass)).toBe(true);
+  });
+
+  it('only permits corner measurements in an AC analysis', () => {
+    const assertion = parseSpiceAssertion('corner(OUT) < 10k');
+    expect(() => compileSpiceAssertion(assertion, 'tran')).toThrowError(
+      new SimulationParseError(1, 'corner() requires an ac analysis'),
+    );
+  });
+});

--- a/test/spice.test.ts
+++ b/test/spice.test.ts
@@ -83,6 +83,87 @@ assert: V(VOUT) > 1.2V
     expect(parseSimulationBlocks('# Subsystems\n\nNo simulations configured.\n')).toEqual([]);
   });
 
+  it('ignores fenced examples and narrative around a live Simulation block', () => {
+    const markdown = `# Format example
+
+\`\`\`markdown
+## Simulation
+scope: nets EXAMPLE, GND
+analysis: op
+assert: V(EXAMPLE) > 1V
+\`\`\`
+
+## Power reference
+
+## Simulation
+scope: nets VREF, GND
+analysis: op
+assert: V(VREF) between 3.25 and 3.35
+This subsystem powers the ADC.
+\`\`\`text
+## Simulation
+scope: nets IGNORED, GND
+analysis: op
+assert: V(IGNORED) > 1V
+\`\`\`
+### Details
+- The reference is local to the ADC sheet.
+`;
+
+    const blocks = parseSimulationBlocks(markdown);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      line: 12,
+      scope: { kind: 'nets', nets: ['VREF', 'GND'] },
+      analysis: 'op',
+      assertions: [{ raw: 'V(VREF) between 3.25 and 3.35' }],
+    });
+  });
+
+  it('ignores single-line and multi-line HTML comments', () => {
+    const markdown = `## Simulation
+<!-- source: COMMENTED=1 -->
+scope: sheet /Power
+<!--
+analysis: dc
+source: ALSO_COMMENTED=2
+--> source: TRAILING_TEXT_IS_DROPPED=3
+analysis: op
+source: VIN=3.3V
+assert: V(VREF) > 3V
+`;
+
+    const [block] = parseSimulationBlocks(markdown);
+    expect(block).toMatchObject({
+      scope: { kind: 'sheet', sheet: '/Power' },
+      analysis: 'op',
+      sources: [{ port: 'VIN', line: 9 }],
+      assertions: [{ line: 10 }],
+    });
+  });
+
+  it('ignores Simulation blocks inside document-level HTML comments', () => {
+    const markdown = `<!--
+## Simulation
+scope: nets COMMENTED, GND
+analysis: op
+assert: V(COMMENTED) > 1V
+-->
+
+## Simulation
+scope: nets LIVE, GND
+analysis: op
+assert: V(LIVE) > 1V
+`;
+
+    const blocks = parseSimulationBlocks(markdown);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      line: 8,
+      scope: { kind: 'nets', nets: ['LIVE', 'GND'] },
+    });
+  });
+
   it('rejects raw ngspice control statements and names the source line', () => {
     const markdown = `# Power
 
@@ -110,6 +191,86 @@ analysis: dc
       new SimulationParseError(3, 'Simulation block needs at least one assertion'),
     );
   });
+
+  it.each([
+    {
+      name: 'unsupported analysis',
+      markdown: `## Simulation
+scope: nets OUT, GND
+analysis: noise
+assert: V(OUT) > 1V
+`,
+      line: 3,
+      message: 'unsupported analysis "noise"',
+    },
+    {
+      name: 'unknown field',
+      markdown: `## Simulation
+scope: nets OUT, GND
+mode: op
+analysis: op
+assert: V(OUT) > 1V
+`,
+      line: 3,
+      message: 'unknown Simulation field "mode"',
+    },
+    {
+      name: 'unsupported scope kind',
+      markdown: `## Simulation
+scope: board /Power
+analysis: op
+assert: V(OUT) > 1V
+`,
+      line: 2,
+      message: 'scope must be "sheet <path>" or "nets <a>, <b>"',
+    },
+    {
+      name: 'empty sheet scope',
+      markdown: `## Simulation
+scope: sheet
+analysis: op
+assert: V(OUT) > 1V
+`,
+      line: 2,
+      message: 'sheet scope is empty',
+    },
+    {
+      name: 'invalid net name',
+      markdown: `## Simulation
+scope: nets OUT, BAD NET
+analysis: op
+assert: V(OUT) > 1V
+`,
+      line: 2,
+      message: 'net scope must contain comma-separated net names',
+    },
+    {
+      name: 'malformed source',
+      markdown: `## Simulation
+scope: nets OUT, GND
+analysis: op
+source: VIN 3.3V
+assert: V(OUT) > 1V
+`,
+      line: 4,
+      message: 'source must be "<port>=<number>"',
+    },
+    {
+      name: 'empty field value',
+      markdown: `## Simulation
+scope: nets OUT, GND
+analysis: op
+source:
+assert: V(OUT) > 1V
+`,
+      line: 4,
+      message: 'expected "field: value", got "source:"',
+    },
+  ])('rejects $name and names its line', ({ markdown, line, message }) => {
+    expect(() => parseSimulationBlocks(markdown)).toThrowError(
+      new SimulationParseError(line, message),
+    );
+  });
 });
 
 describe('parseSpiceNumber', () => {
@@ -131,6 +292,12 @@ describe('parseSpiceNumber', () => {
       new SimulationParseError(14, 'invalid SPICE number "NaN"'),
     );
   });
+
+  it('rejects finite-range overflow', () => {
+    expect(() => parseSpiceNumber('1e999V', 15)).toThrowError(
+      new SimulationParseError(15, 'SPICE number is out of range "1e999V"'),
+    );
+  });
 });
 
 describe('parseSpiceAssertion', () => {
@@ -143,6 +310,28 @@ describe('parseSpiceAssertion', () => {
   it('rejects reversed between bounds', () => {
     expect(() => parseSpiceAssertion('V(OUT) between 5 and 3', 9)).toThrowError(
       new SimulationParseError(9, 'between lower bound must be less than upper bound'),
+    );
+  });
+
+  it.each([
+    {
+      raw: "V(OUT') < 5V",
+      line: 23,
+      message: `invalid measurable target "OUT'"`,
+    },
+    {
+      raw: 'V(OUT) between 3.25 and 3.35V',
+      line: 24,
+      message: 'between bounds use different units',
+    },
+    {
+      raw: 'V(OUT) <= 5V',
+      line: 25,
+      message: 'invalid comparator "<= 5V"',
+    },
+  ])('rejects $raw and names its line', ({ raw, line, message }) => {
+    expect(() => parseSpiceAssertion(raw, line)).toThrowError(
+      new SimulationParseError(line, message),
     );
   });
 });
@@ -207,6 +396,13 @@ describe('compileSpiceAssertion', () => {
     const assertion = parseSpiceAssertion('corner(OUT) < 10k');
     expect(() => compileSpiceAssertion(assertion, 'tran')).toThrowError(
       new SimulationParseError(1, 'corner() requires an ac analysis'),
+    );
+  });
+
+  it('rejects unsafe measure names', () => {
+    const assertion = parseSpiceAssertion('V(OUT) > 1V', 27);
+    expect(() => compileSpiceAssertion(assertion, 'op', 'bad-name')).toThrowError(
+      new SimulationParseError(27, 'invalid measure name "bad-name"'),
     );
   });
 });


### PR DESCRIPTION
## What

Adds the parser and compiler for opt-in `## Simulation` blocks in `SUBSYSTEMS.md`.

The new pure KiCad-layer module parses sheet or net scopes, analysis type, driven sources, and assertions. It compiles the closed assertion grammar to ngspice `.meas` fragments and reports parse failures with the original Markdown line number.

## Why

The planned SPICE gate needs a safe input boundary before netlist export or ngspice execution can be added. Accepting arbitrary control text would make the gate difficult to review and unsafe to assemble into a deck.

Closes #10.

## Design

- The parser is line-oriented so every failure points back to the source line.
- It accepts one scope, one analysis, repeated `source` or `sources` entries, and one or more assertions.
- Fenced examples, HTML-commented blocks, non-field narrative, and lower-level Markdown sections are not treated as live Simulation input.
- Raw dot commands such as `.control` are rejected before any process layer is involved.
- SI values are parsed to normalized numbers while retaining the original safe SPICE literal for deck generation.
- `between` requires both bounds to omit units or use the same unit.
- Each assertion produces one value measure plus bound-margin measures. `between` emits separate lower and upper checks. The returned check metadata distinguishes inclusive bounds from strict `<` and `>` bounds.
- `corner(net)` is limited to AC analysis and compiles to the first 3 dB crossing.
- The module has no filesystem, subprocess, provider, or network dependency.

## Spec / OpenSpec

- Active change: `openspec/changes/add-spice-verification-gate`
- Completes tasks 1.2 and 1.3.
- Clarifies the line-oriented block fields in the `spice-verification` delta spec.
- `openspec validate add-spice-verification-gate` passes.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | partial locally: 242 pass, 7 fail because `kicad-cli` is not installed, 14 skipped |
| Focused parser/compiler | `npm test -- test/spice.test.ts` | pass, 40/40 |
| Markdown | `npm run lint:md` | pass, 106 files |
| Package | `npm pack --dry-run` | pass |
| OpenSpec | `npx --yes @fission-ai/openspec@latest validate add-spice-verification-gate --no-interactive` | pass |
| Live-LLM (opt-in) | API-key-gated suite | skipped, this change is pure and does not use a provider |

The seven full-suite failures are all downstream of the missing local `kicad-cli` prerequisite. The repository CI workflow installs KiCad before running the same suite.

New tests cover both scope forms, repeated sources, fenced and HTML-commented examples, trailing narrative, line-numbered validation errors, raw control rejection, SI suffixes, consistent units, the exact VREF range example, all nine measurable and comparator pairings, and the AC-only corner rule.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): `edit`
- Commands run and outcome:

```text
$ ./manual-tests/setup.sh edit
sandbox ready: manual-tests/runs/edit

$ node --input-type=module -e 'import { readFile } from "node:fs/promises"; import { parseSimulationBlocks, compileSpiceAssertion } from "./dist/kicad/spice.js"; const markdown = await readFile("manual-tests/runs/edit/docs/SUBSYSTEMS.md", "utf8"); const [block] = parseSimulationBlocks(markdown); if (!block) throw new Error("Simulation block not found"); console.log(`parsed ${block.scope.kind} scope, ${block.analysis} analysis, ${block.sources.length} source, ${block.assertions.length} assertions`); for (const [index, assertion] of block.assertions.entries()) console.log(compileSpiceAssertion(assertion, block.analysis, `assertion_${index + 1}`).deck); try { parseSimulationBlocks("## Simulation\nscope: nets VREF,GND\nanalysis: op\n.control\nassert: V(VREF) > 3\n"); } catch (error) { console.log(String(error)); }'
parsed sheet scope, op analysis, 1 source, 2 assertions
.meas op assertion_1_value FIND v(VREF)
.meas op assertion_1_lower_margin PARAM='assertion_1_value - 3.25'
.meas op assertion_1_upper_margin PARAM='3.35 - assertion_1_value'
.meas op assertion_2_value FIND i(R5)
.meas op assertion_2_margin PARAM='25uA - assertion_2_value'
SimulationParseError: line 4: raw ngspice statement ".control" is not allowed
```

The parser/compiler tasks are not wired into the CLI yet. That work starts at task 2.2, so the built module was exercised directly against the repository's edit sandbox.

## Docs

Updated the active SPICE delta spec with the accepted field syntax, inert Markdown rules, and unit consistency requirement. OpenSpec tasks 1.2 and 1.3 are marked complete. User-facing docs remain part of task 5.1 after the gate is wired.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, agent edit tools are not touched.
- [ ] **Verification-gated out**: N/A, mutation and rollback paths are not touched.
- [x] **`check`/`verify` stays LLM-free and network-free**: the new parser/compiler is pure and does not import a provider, subprocess, or network path.
- [x] **No sexp serialization**: the new KiCad-layer parser reads Markdown strings only and never reads, rewrites, or serializes a KiCad s-expression.
- [ ] **Sync-obligations ledger**: N/A, ledger hooks and commit gates are not touched.
- [ ] **Secrets**: N/A, transcripts, environment handling, and ignore rules are not touched.
- [x] **Spec coherence**: the active delta spec and task list move with the implementation, and OpenSpec validation passes.
