### PR TITLE
docs: add code of conduct, security policy, and issue templates

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<animeshchouhan@outlook.com>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug report
+description: Something in the CLI, agent loop, or KiCad integration behaves incorrectly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please do not report security issues here: use
+        [private vulnerability reporting](https://github.com/chouhanindustries/copperhead/security/advisories/new) instead.
+
+        Scrub API keys from any logs you paste.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you expected, and what you got instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands you ran. A minimal KiCad project or brief that triggers it helps a lot.
+      placeholder: |
+        1. copperhead init
+        2. copperhead do "add reverse-polarity protection on VIN"
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Output
+      description: Relevant terminal output, ERC/DRC report, or an excerpt of the run transcript from `.copperhead/runs/`. Remove credentials first.
+      render: shell
+    validations:
+      required: false
+
+  - type: dropdown
+    id: command
+    attributes:
+      label: Which command
+      options:
+        - create
+        - do
+        - check / verify
+        - init
+        - sync
+        - other or not command-specific
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Model backend
+      description: "`check` is LLM-free, so pick \"not applicable\" for bugs in it."
+      options:
+        - Anthropic API key
+        - OpenAI API key
+        - Codex CLI saved login
+        - Claude Code saved login
+        - Not applicable
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: copperhead version
+      description: Output of `copperhead --version`, or the commit SHA if running from source.
+      placeholder: "0.7.0"
+    validations:
+      required: true
+
+  - type: input
+    id: env
+    attributes:
+      label: Node, KiCad, and OS
+      description: Output of `node --version` and `kicad-cli --version`, plus your operating system.
+      placeholder: "node v20.11.0, kicad-cli 8.0.5, macOS 14.5"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: I removed API keys and other secrets from everything I pasted.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://docs.copperhead.sh
+    about: Installation, commands, configuration, and the KiCad integration.
+  - name: Questions and ideas
+    url: https://github.com/chouhanindustries/copperhead/discussions
+    about: Ask how to do something, or float an idea before it becomes a feature request.
+  - name: Report a security vulnerability
+    url: https://github.com/chouhanindustries/copperhead/security/advisories/new
+    about: Report privately. Please do not open a public issue for a security problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Propose new behavior or a change to the CLI surface.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        copperhead is spec-driven. Behavior lives in
+        [openspec/specs/SPEC.md](https://github.com/chouhanindustries/copperhead/blob/main/openspec/specs/SPEC.md),
+        and the near-term plan lives in [ROADMAP.md](https://github.com/chouhanindustries/copperhead/blob/main/ROADMAP.md).
+        Please skim both before filing: your idea may already be scoped for a later phase.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What are you trying to do today, and where does copperhead get in the way?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should happen instead. If it touches the CLI, show the command and the output you would expect.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: Workarounds you tried, or other designs you weighed and why you set them aside.
+    validations:
+      required: false
+
+  - type: textarea
+    id: invariants
+    attributes:
+      label: Effect on the invariants
+      description: |
+        Two invariants shape the whole tool: edits are spec-gated in (write tools are absent until an OpenSpec
+        proposal validates), and mutations are verification-gated out (nothing is done until ERC, and DRC when the
+        board changed, passes). Say whether your proposal touches either. "No effect" is a fine answer.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and the roadmap, and this is not already tracked.
+          required: true

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Supported versions
+
+copperhead is pre-1.0 and moves fast. Only the latest published release on npm receives security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.7.x   | Yes       |
+| < 0.7   | No        |
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a security problem.**
+
+Report privately through [GitHub's private vulnerability reporting](https://github.com/chouhanindustries/copperhead/security/advisories/new). That opens a draft advisory only the maintainers and you can see.
+
+If you cannot use GitHub advisories, email <animeshchouhan@outlook.com> with `[copperhead security]` in the subject.
+
+Please include:
+
+- The version or commit you tested.
+- What an attacker gains (read a file outside the repo, exfiltrate a key, run a command, and so on).
+- Reproduction steps, ideally a minimal KiCad project or prompt that triggers it.
+- Any logs, with credentials removed.
+
+## What to expect
+
+- **Acknowledgement** within 3 business days.
+- **Initial assessment** (confirmed / not a vulnerability / need more information) within 10 business days.
+- **Fix and disclosure**: we aim to ship a patched release within 90 days of confirmation, and we publish an advisory when the fix is out. Tell us if you have a disclosure deadline and we will work to it.
+- **Credit** in the advisory unless you prefer to stay anonymous.
+
+We do not run a paid bug bounty.
+
+## Scope
+
+In scope: this repository's source, its published npm package, and its GitHub Actions workflows.
+
+Out of scope: vulnerabilities in KiCad or `kicad-cli`, in the model providers (OpenAI, Anthropic, Codex CLI, Claude Code), or in third-party dependencies. Report those upstream. If a dependency issue is reachable through copperhead in a way the upstream advisory does not cover, we do want to hear about it.
+
+## Things that are by design, not vulnerabilities
+
+copperhead is an agent that edits files and runs subprocesses, so some behavior that looks alarming is intended:
+
+- **It edits files in the repository you point it at.** File tools are sandboxed to the repo root. A path escaping that root is a vulnerability; edits inside it are the product.
+- **It runs `kicad-cli` as a subprocess.** Arbitrary command execution beyond that is a vulnerability.
+- **It sends the contents of files it reads to the configured model provider.** Do not run it on a repository holding secrets you are unwilling to share with that provider.
+- **`copperhead check` never calls an LLM and never touches the network.** If you observe it doing either, that is a vulnerability, and a serious one.
+
+Also treated as vulnerabilities: an API key appearing unredacted in a transcript under `.copperhead/runs/`, in a run summary, or in terminal output; and a mutation being reported as complete without ERC (and DRC, when the board changed) having passed.
+
+## Handling secrets
+
+Model API keys belong in environment variables or `.env`, which is gitignored. Transcripts and summaries redact key-shaped strings when they are written. If you find a path that writes a key to disk or to stdout in the clear, report it privately using the process above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in contributing. This document covers the practical setup and the one piece of paperwork we require.
 
+By taking part you agree to our [Code of Conduct](.github/CODE_OF_CONDUCT.md). Found a security problem? Do not open an issue: follow the [security policy](.github/SECURITY.md) instead.
+
 ## Development setup
 
 Requirements: Node.js >= 20 and, for the KiCad integration paths, a local `kicad-cli` on your PATH.


### PR DESCRIPTION
## What

Adds the three community health files GitHub's community standards checklist flagged as missing: a code of conduct, a security policy, and issue templates. Also enables private vulnerability reporting on the repo so the advisory link in the security policy resolves.

## Why

The repo scored 5/8 on GitHub's community standards checklist. Description, README, Contributing, License, and the pull request template were already in place; Code of conduct, Security policy, and Issue templates were not. Without a security policy there was no stated private channel for reporting a vulnerability, so the only path was a public issue.

## Design

[SECURITY.md](.github/SECURITY.md) is written against this project's actual threat model rather than as boilerplate. copperhead is an agent that edits files and spawns subprocesses, so a lot of alarming-looking behavior is intended. The policy states the line explicitly:

By design, not a vulnerability:

- Editing files inside the repository you point it at (file tools are sandboxed to the repo root, so a path escaping that root is a vulnerability, but edits inside it are the product).
- Running `kicad-cli` as a subprocess.
- Sending the contents of files it reads to the configured model provider.

Treated as vulnerabilities, drawn from the SPEC.md invariants:

- A path escaping the repo root.
- An API key appearing unredacted in a transcript under `.copperhead/runs/`, in a run summary, or in terminal output (AC-4.1).
- `copperhead check` calling an LLM or touching the network.
- A mutation reported as complete without ERC (and DRC when the board changed) having passed.

Scope excludes KiCad, `kicad-cli`, and the model providers, with an explicit carve-out for a dependency issue reachable through copperhead in a way the upstream advisory does not cover.

[CODE_OF_CONDUCT.md](.github/CODE_OF_CONDUCT.md) is Contributor Covenant 2.1 verbatim, with the enforcement contact set to the `package.json` author address.

The issue forms collect what a copperhead report actually needs to be actionable: which command (`create` / `do` / `check` / `init` / `sync`), which model backend (and "not applicable", since `check` is LLM-free), and the `kicad-cli` plus Node versions. [feature_request.yml](.github/ISSUE_TEMPLATE/feature_request.yml) points reporters at SPEC.md and ROADMAP.md first and asks whether the proposal touches either invariant. [config.yml](.github/ISSUE_TEMPLATE/config.yml) disables blank issues and links to docs, Discussions, and the advisory form.

Note on the form schema: GitHub rejects a field that sets both `render` and `validations.required`. The "Steps to reproduce" textarea is required, so it does not set `render`; the optional "Output" textarea uses `render: shell`.

## Spec / OpenSpec

None. Docs and repository metadata only. No source file changes, so no acceptance criteria or delta specs move.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass (no source changes) |
| Build | `npm run build` | n/a, no source changes |
| Unit + offline | `npm test` | pass, 328 passed / 14 skipped across 29 files |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `COPPERHEAD_TEST_CODEX` | n/a, docs-only change |

Additional checks run for this PR specifically:

- `npm run lint:md`: 0 errors across 119 files, including the two new markdown files.
- Both new markdown files and all three YAML files verified em-dash-free.
- All three issue templates parsed with `js-yaml`, and asserted that no field combines `render` with `validations.required`.

No new or changed tests. No known pre-existing failures.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a
- Commands run and outcome: n/a. This PR changes only markdown documentation, GitHub issue form YAML, and one repository setting. It touches no CLI behavior, no agent loop code, no provider, and no part of the KiCad layer, so there is nothing to exercise in the manual-tests sandbox. The verification that does apply to it (markdown lint, YAML parse, issue form schema constraints) is recorded above.

The issue forms cannot be rendered until they are on the default branch. Confirm they render as expected at the repository's "New issue" page after merge.

## Docs

- New: [.github/SECURITY.md](.github/SECURITY.md), [.github/CODE_OF_CONDUCT.md](.github/CODE_OF_CONDUCT.md), [.github/ISSUE_TEMPLATE/bug_report.yml](.github/ISSUE_TEMPLATE/bug_report.yml), [.github/ISSUE_TEMPLATE/feature_request.yml](.github/ISSUE_TEMPLATE/feature_request.yml), [.github/ISSUE_TEMPLATE/config.yml](.github/ISSUE_TEMPLATE/config.yml).
- Changed: [CONTRIBUTING.md](CONTRIBUTING.md) now links to the code of conduct and routes security reports to the policy instead of the issue tracker.
- No CHANGELOG or DECISIONS entry: this is repository metadata, not a design change.

### Repository settings

Private vulnerability reporting was enabled via `PUT /repos/chouhanindustries/copperhead/private-vulnerability-reporting`, which is what makes the advisory link in SECURITY.md resolve.

One checklist item remains and cannot be done from a PR: **"Repository admins accept content reports"** has no REST API. A repository admin must enable it under Settings, Moderation options, Reported content.

Follow-up worth considering separately: secret scanning, push protection, and Dependabot security updates all report `disabled` on this repo.

---

## Invariant checklist

<!-- Docs-only PR: no source file is touched, so every invariant is N/A by construction.
     Ticked to record that each was considered, with the reason it cannot be affected. -->

- [x] **Spec-gated in**: N/A. No change to the agent tool list or its gating.
- [x] **Verification-gated out**: N/A. No change to the mutation, repair, or rollback path.
- [x] **`check`/`verify` stays LLM-free and network-free**: N/A. Nothing under `src/commands/check` is touched. SECURITY.md documents this invariant and names a violation of it as a reportable vulnerability.
- [x] **No sexp serialization**: N/A. Nothing under `src/kicad/` is touched.
- [x] **Sync-obligations ledger**: N/A. No change to the hooks or to commit gating.
- [x] **Secrets**: N/A to the code path; the redaction behavior is unchanged. The new files add no secret and no new secret-handling path. SECURITY.md documents the `sk-[A-Za-z0-9_-]+` redaction guarantee and asks reporters to scrub keys before pasting logs; the bug report form requires the reporter to confirm they did.
- [x] **Spec coherence**: N/A. No spec-level behavior changed, so SPEC.md and the change artifacts do not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
