### PR TITLE
fix(redact): redact base64 bearer tokens whole, match scheme case-insensitively

### DIFF
--- a/src/util/redact.ts
+++ b/src/util/redact.ts
@@ -5,10 +5,14 @@
  */
 const PATTERNS: RegExp[] = [
   /sk-[A-Za-z0-9_-]+/g,
-  /Bearer\s+[A-Za-z0-9._-]{16,}/g,
+  // Auth schemes are case-insensitive (RFC 7235 §2.1), and the token charset has
+  // to include base64's +, / and = or the match stops at the first one and the
+  // tail of the secret gets written out verbatim.
+  /Bearer\s+[A-Za-z0-9._+/=-]{16,}/gi,
   // Registry and forge tokens: a transcript that quotes a publish command or a
   // failing CI log can carry these just as easily as a model API key.
-  /npm_[A-Za-z0-9]{36,}/g,
+  // npm also issues UUID-shaped tokens, so the charset allows dashes.
+  /npm_[A-Za-z0-9-]{36,}/g,
   /gh[pousr]_[A-Za-z0-9]{36,}/g,
   /github_pat_[A-Za-z0-9_]{22,}/g,
 ];

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -49,6 +49,44 @@ describe('secret redaction (AC-4.1)', () => {
     expect(out).toBe('[REDACTED] [REDACTED] [REDACTED]');
   });
 
+  it('redacts a base64 bearer token whole, leaving no tail', () => {
+    // Synthetic token: correct shape, never valid. Standard base64 uses +, /
+    // and =; a charset that stops at the first one writes the rest to disk.
+    const input = 'Bearer ABCDEFGHIJKLMNOP+SECRETTAILabcdef/MORESECRET=';
+    const out = redactSecrets(input);
+
+    expect(out).toBe('[REDACTED]');
+    expect(out).not.toContain('SECRETTAIL');
+    expect(out).not.toContain('MORESECRET');
+  });
+
+  it('redacts bearer tokens regardless of scheme casing', () => {
+    // HTTP auth schemes are case-insensitive (RFC 7235 §2.1).
+    for (const scheme of ['Bearer', 'bearer', 'BEARER', 'BeArEr']) {
+      const out = redactSecrets(`authorization: ${scheme} abcdefghijklmnopqrst`);
+      expect(out, scheme).toBe('authorization: [REDACTED]');
+    }
+  });
+
+  it('redacts npm tokens that contain dashes', () => {
+    // npm also issues UUID-shaped tokens. Synthetic, never valid.
+    const out = redactSecrets('npm_0123456789abcdef-0123-4567-89ab-cdef01234567');
+    expect(out).toBe('[REDACTED]');
+  });
+
+  it('leaves ordinary prose alone', () => {
+    // The patterns are deliberately broad, but not so broad that a run summary
+    // loses readable text.
+    for (const text of [
+      'the bearer of this note',
+      'Bearer token missing',
+      'a npm_ package name',
+      'see the github_pat docs',
+    ]) {
+      expect(redactSecrets(text), text).toBe(text);
+    }
+  });
+
   it('transcript and summary are redacted at write time', async () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'ch-'));
     const t = new Transcript(dir);


### PR DESCRIPTION
## What

`redactSecrets()` in [redact.ts](src/util/redact.ts) now redacts a base64 bearer token in full instead of leaving its tail in the run transcript, matches the `Bearer` scheme case-insensitively, and covers npm tokens that contain dashes.

## Why

Closes #83.

`redactSecrets` is the write-time guard for `.copperhead/runs/`: both `Transcript.event()` and `Transcript.writeSummary()` route every line through it. Three shapes got past it, and the first is the dangerous kind because it redacted part of the token and wrote the rest to disk:

1. **Partial redaction of base64 bearer tokens.** The character class `[A-Za-z0-9._-]` excludes `+`, `/` and `=`, which is exactly what standard base64 uses, so the match stopped at the first one:

   ```
   in : Bearer ABCDEFGHIJKLMNOP+SECRETTAILabcdef/MORESECRET=
   out: [REDACTED]+SECRETTAILabcdef/MORESECRET=
   ```

   A partial redaction is worse than none: it reads as handled in review while the secret is still on disk.

2. **Case-sensitive scheme match.** HTTP auth schemes are case-insensitive (RFC 7235 section 2.1) and real clients log `bearer` and `BEARER`. Both passed through untouched.

3. **npm tokens with dashes.** npm also issues UUID-shaped tokens, and `npm_0123456789abcdef-0123-4567-89ab-cdef01234567` was not matched.

The file's own comment states the patterns are "deliberately broad: losing a few characters of log fidelity beats leaking a key". These are cases where that intent was not met.

## Design

Three small changes to the pattern list, no change to `redactSecrets`'s shape or call sites:

- the bearer character class gains `+/=` and the pattern gains the `i` flag
- the npm class gains `-`, matching how the neighbouring `github_pat_` pattern already allows `_`

The `i` flag is applied only to the bearer pattern. Every other entry is anchored to a literal lowercase prefix (`sk-`, `npm_`, `gh*_`, `github_pat_`) where the casing does not vary, so widening those would only add false-positive risk.

Deliberately not changed, to keep the diff honest about what it fixes:

- `ghp_ ghs_ gho_ ghu_ ghr_` are all already covered: `[pousr]` happens to contain every current GitHub prefix letter.
- `SYNAP_API_KEY` is absent from the patterns, but [synap.ts](src/memory/synap.ts) has no caller yet, so nothing can reach a transcript through it today.
- AWS, Google, Slack and GitLab key shapes are not matched, but copperhead never handles those credentials, so widening to them looked like scope creep. Happy to add if you would rather the net be wider.

## Spec / OpenSpec

No spec-level behavior change. This restores the intent of the existing AC-4.1 secret-redaction rail rather than altering it, so SPEC.md and the change artifacts are untouched.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | n/a (typecheck runs the same `tsc` project) |
| Unit + offline | `npm test` | 324 pass, 14 skip, 8 pre-existing failures (see below) |
| Live-LLM (opt-in) | keyed on `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` | not run (no key set) |

New tests, all in [safety.test.ts](test/safety.test.ts) under `secret redaction (AC-4.1)`:

- a base64 bearer token redacts whole, asserting the tail substrings `SECRETTAIL` and `MORESECRET` are absent rather than merely that `[REDACTED]` appears (the old behavior would have passed a "contains [REDACTED]" assertion)
- `Bearer` / `bearer` / `BEARER` / `BeArEr` all redact
- a dashed npm token redacts
- a guard-rail test: ordinary prose (`the bearer of this note`, `Bearer token missing`, `a npm_ package name`, `see the github_pat docs`) comes back byte-identical, so the widened character classes cannot start eating readable summary text

All tokens in the tests are synthetic and correctly shaped but never valid, matching the convention already in this file.

**Revert check.** With the new tests in place I restored the original `PATTERNS` array: exactly the 3 behavioral tests fail and the prose guard-rail passes under both implementations, so it is genuinely guarding rather than riding along.

**Pre-existing failures unrelated to this PR:** 8 tests fail in my environment, all `KicadCliMissingError: kicad-cli not found on PATH` (init-check, gating-sync, and the KiCad edit-probe suites). Identical counts before and after this change.

### Manual test log (required)

n/a with a reason: this change touches one pure string function and its unit tests. It does not alter CLI behavior, the agent loop, providers, or the KiCad layer, so there is no runtime surface to exercise in the sandbox beyond what the unit tests already cover. The redaction path itself is exercised end to end by the pre-existing "transcript and summary are redacted at write time" test, which writes and reads back a real transcript on disk and still passes.

## Docs

None needed: no user-facing behavior, configuration, or CLI surface changes.

---

## Invariant checklist

- [x] **Secrets**: transcripts and summaries redact `sk-[A-Za-z0-9_-]+` at write time; keys live only in env vars; `.gitignore` keeps `.env` and `.copperhead/runs/`. (This PR strengthens exactly this rail; the `sk-` pattern is unchanged.)
- [ ] N/A **Spec-gated in**: does not touch the agent tool list.
- [ ] N/A **Verification-gated out**: does not touch the mutation or repair path.
- [ ] N/A **`check`/`verify` stays LLM-free and network-free**: nothing under `src/commands/check` is touched.
- [ ] N/A **No sexp serialization**: `src/kicad/` is untouched.
- [ ] N/A **Sync-obligations ledger**: untouched.
- [ ] N/A **Spec coherence**: no spec-level behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret redaction for bearer tokens regardless of capitalization.
  * Expanded redaction coverage for base64-formatted bearer tokens and dashed npm tokens.
  * Prevented partial secrets from remaining visible after redaction.
  * Preserved ordinary text that only resembles a secret token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->