### PR TITLE
fix(search): keep toolSearch inside the repo and survive symlink loops

### DIFF
--- a/src/agent/filetools.ts
+++ b/src/agent/filetools.ts
@@ -111,7 +111,9 @@ export async function toolSearch(
   // pointing at an ancestor is otherwise descended until the OS throws ELOOP,
   // which takes down search for the whole run.
   const realRoot = await realpath(repoRoot).catch(() => path.resolve(repoRoot));
-  const seenDirs = new Set<string>();
+  // Seeded with the root: a link pointing back at it would otherwise be walked
+  // once more, duplicating every root-level match under the link's path.
+  const seenDirs = new Set<string>([realRoot]);
 
   /** The real path of `abs`, or null when it resolves outside the repo. */
   async function insideRoot(abs: string): Promise<string | null> {

--- a/src/agent/filetools.ts
+++ b/src/agent/filetools.ts
@@ -111,9 +111,11 @@ export async function toolSearch(
   // pointing at an ancestor is otherwise descended until the OS throws ELOOP,
   // which takes down search for the whole run.
   const realRoot = await realpath(repoRoot).catch(() => path.resolve(repoRoot));
-  // Seeded with the root: a link pointing back at it would otherwise be walked
-  // once more, duplicating every root-level match under the link's path.
-  const seenDirs = new Set<string>([realRoot]);
+  // Loop protection is scoped to the *current path*, not the whole walk. A cycle
+  // always means revisiting an ancestor, so an ancestor set terminates the walk
+  // while still visiting siblings: a global set would also drop non-cyclic
+  // aliases, hiding a real directory behind an in-repo symlink pointing at it.
+  const ancestors = new Set<string>([realRoot]);
 
   /** The real path of `abs`, or null when it resolves outside the repo. */
   async function insideRoot(abs: string): Promise<string | null> {
@@ -140,9 +142,10 @@ export async function toolSearch(
       if (st.isDirectory()) {
         const real = await insideRoot(abs);
         if (real === null) continue;
-        if (seenDirs.has(real)) continue; // already walked: a symlink loop
-        seenDirs.add(real);
+        if (ancestors.has(real)) continue; // on the current path already: a loop
+        ancestors.add(real);
         await walk(abs);
+        ancestors.delete(real);
       } else if (st.size < 5_000_000 && (!globRe || globRe.test(rel))) {
         let text: string;
         try {

--- a/src/agent/filetools.ts
+++ b/src/agent/filetools.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir, readdir, stat } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, readdir, lstat, realpath, stat } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { resolveInRepo, isKicadFile } from '../util/paths.js';
@@ -106,14 +106,40 @@ export async function toolSearch(
   const re = new RegExp(pattern);
   const globRe = glob ? globToRegex(glob) : null;
   const matches: SearchMatch[] = [];
+  // The walk follows symlinks (stat does), so it needs the same containment rule
+  // the other file tools get from resolveInRepo, plus loop protection: a link
+  // pointing at an ancestor is otherwise descended until the OS throws ELOOP,
+  // which takes down search for the whole run.
+  const realRoot = await realpath(repoRoot).catch(() => path.resolve(repoRoot));
+  const seenDirs = new Set<string>();
+
+  /** The real path of `abs`, or null when it resolves outside the repo. */
+  async function insideRoot(abs: string): Promise<string | null> {
+    const real = await realpath(abs).catch(() => null);
+    if (real === null) return null;
+    if (real !== realRoot && !real.startsWith(realRoot + path.sep)) return null;
+    return real;
+  }
+
   async function walk(dir: string): Promise<void> {
     if (matches.length >= maxMatches) return;
     for (const entry of await readdir(dir)) {
       if (SKIP_DIRS.has(entry)) continue;
       const abs = path.join(dir, entry);
       const rel = path.relative(repoRoot, abs);
-      const st = await stat(abs);
+      // lstat describes the entry itself; stat would describe the link target
+      // and hide that this is a link at all.
+      const link = await lstat(abs).catch(() => null);
+      if (link === null) continue; // vanished mid-walk
+      if (link.isSymbolicLink() && (await insideRoot(abs)) === null) continue; // escapes the repo
+
+      const st = await stat(abs).catch(() => null);
+      if (st === null) continue; // broken link or race
       if (st.isDirectory()) {
+        const real = await insideRoot(abs);
+        if (real === null) continue;
+        if (seenDirs.has(real)) continue; // already walked: a symlink loop
+        seenDirs.add(real);
         await walk(abs);
       } else if (st.size < 5_000_000 && (!globRe || globRe.test(rel))) {
         let text: string;

--- a/src/agent/filetools.ts
+++ b/src/agent/filetools.ts
@@ -135,17 +135,20 @@ export async function toolSearch(
       // and hide that this is a link at all.
       const link = await lstat(abs).catch(() => null);
       if (link === null) continue; // vanished mid-walk
-      if (link.isSymbolicLink() && (await insideRoot(abs)) === null) continue; // escapes the repo
+      // Resolved once and reused below: containment and loop detection are the
+      // same question about the same entry, and realpath is a syscall.
+      const real = link.isSymbolicLink() ? await insideRoot(abs) : null;
+      if (link.isSymbolicLink() && real === null) continue; // escapes the repo
 
       const st = await stat(abs).catch(() => null);
       if (st === null) continue; // broken link or race
       if (st.isDirectory()) {
-        const real = await insideRoot(abs);
-        if (real === null) continue;
-        if (ancestors.has(real)) continue; // on the current path already: a loop
-        ancestors.add(real);
+        const realDir = real ?? (await insideRoot(abs));
+        if (realDir === null) continue;
+        if (ancestors.has(realDir)) continue; // on the current path already: a loop
+        ancestors.add(realDir);
         await walk(abs);
-        ancestors.delete(real);
+        ancestors.delete(realDir);
       } else if (st.size < 5_000_000 && (!globRe || globRe.test(rel))) {
         let text: string;
         try {

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -161,6 +161,23 @@ describe('file tools', () => {
     expect(matches[0]!.file).toBe(path.join('sub', 'a.txt'));
   });
 
+  it('search does not report a file twice through a link back to the repo root', async () => {
+    const base = await mkdtemp(path.join(tmpdir(), 'ch-search-dup-'));
+    const repo = path.join(base, 'repo');
+    await mkdir(path.join(repo, 'sub'), { recursive: true });
+    // A match at the ROOT is what exposes this: the loop test above only has a
+    // file under sub/, so re-walking the root produced nothing to duplicate.
+    await writeFile(path.join(repo, 'a.txt'), 'needle A\n', 'utf8');
+    await writeFile(path.join(repo, 'sub', 'b.txt'), 'needle B\n', 'utf8');
+    await symlink(repo, path.join(repo, 'sub', 'back'));
+
+    const matches = await toolSearch(repo, 'needle');
+
+    // Without seeding seenDirs with the root, this returns a third match at
+    // sub/back/a.txt — the same file reported under the link's path.
+    expect(matches.map((m) => m.file).sort()).toEqual(['a.txt', path.join('sub', 'b.txt')]);
+  });
+
   it('search still follows a symlink that stays inside the repo', async () => {
     const base = await mkdtemp(path.join(tmpdir(), 'ch-search-in-'));
     const repo = path.join(base, 'repo');

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { resolveInRepo, SandboxError, isKicadFile } from '../src/util/paths.js';
@@ -125,6 +125,55 @@ describe('file tools', () => {
     const mdOnly = await toolSearch(dir, 'KEY_DAH', '**/*.md');
     expect(mdOnly).toHaveLength(1);
     expect(mdOnly[0]!.file).toBe('a.md');
+  });
+
+  it('search does not read through a symlink that leaves the repo', async () => {
+    const base = await mkdtemp(path.join(tmpdir(), 'ch-search-esc-'));
+    const repo = path.join(base, 'repo');
+    const outside = path.join(base, 'outside');
+    await mkdir(path.join(repo, 'sub'), { recursive: true });
+    await mkdir(outside, { recursive: true });
+    await writeFile(path.join(repo, 'b.txt'), 'needle two\n', 'utf8');
+    await writeFile(path.join(repo, 'sub', 'a.txt'), 'needle here\n', 'utf8');
+    await writeFile(path.join(outside, 'leak.txt'), 'needle SECRET outside\n', 'utf8');
+    await symlink(outside, path.join(repo, 'link'));
+
+    const matches = await toolSearch(repo, 'needle');
+
+    // The escaping match used to come back as "link/leak.txt", which reads as a
+    // repo-relative path and hides that the content was outside the sandbox.
+    expect(matches.map((m) => m.file).sort()).toEqual(['b.txt', path.join('sub', 'a.txt')]);
+    expect(matches.some((m) => m.text.includes('SECRET'))).toBe(false);
+  });
+
+  it('search survives a symlink loop instead of dying with ELOOP', async () => {
+    const base = await mkdtemp(path.join(tmpdir(), 'ch-search-loop-'));
+    const repo = path.join(base, 'repo');
+    await mkdir(path.join(repo, 'sub'), { recursive: true });
+    await writeFile(path.join(repo, 'sub', 'a.txt'), 'needle here\n', 'utf8');
+    await symlink(repo, path.join(repo, 'sub', 'loop'));
+
+    // Previously this walked loop/sub/loop/sub/... until the OS threw, taking
+    // the search tool down for the rest of the run.
+    const matches = await toolSearch(repo, 'needle');
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.file).toBe(path.join('sub', 'a.txt'));
+  });
+
+  it('search still follows a symlink that stays inside the repo', async () => {
+    const base = await mkdtemp(path.join(tmpdir(), 'ch-search-in-'));
+    const repo = path.join(base, 'repo');
+    await mkdir(path.join(repo, 'real'), { recursive: true });
+    await writeFile(path.join(repo, 'real', 'lib.txt'), 'needle inside\n', 'utf8');
+    await symlink(path.join(repo, 'real'), path.join(repo, 'alias'));
+
+    const matches = await toolSearch(repo, 'needle');
+
+    // Symlinked library dirs are a normal KiCad layout: the file is reachable
+    // by both names, and neither traversal is an escape.
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+    expect(matches.every((m) => m.text.includes('needle inside'))).toBe(true);
   });
 
   it('isKicadFile covers the design formats', () => {

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -183,14 +183,37 @@ describe('file tools', () => {
     const repo = path.join(base, 'repo');
     await mkdir(path.join(repo, 'real'), { recursive: true });
     await writeFile(path.join(repo, 'real', 'lib.txt'), 'needle inside\n', 'utf8');
-    await symlink(path.join(repo, 'real'), path.join(repo, 'alias'));
+    // A symlinked *file*, not a directory: a directory alias is subject to
+    // readdir ordering, so only a file link pins "the link was followed"
+    // deterministically.
+    await symlink(path.join(repo, 'real', 'lib.txt'), path.join(repo, 'alias.txt'));
 
     const matches = await toolSearch(repo, 'needle');
 
-    // Symlinked library dirs are a normal KiCad layout: the file is reachable
-    // by both names, and neither traversal is an escape.
-    expect(matches.length).toBeGreaterThanOrEqual(1);
-    expect(matches.every((m) => m.text.includes('needle inside'))).toBe(true);
+    // Symlinked library paths are a normal KiCad layout: the file is reachable
+    // by both names, and neither traversal is an escape. Asserting the exact
+    // set is what makes this a guard rail — refusing to follow the link drops
+    // alias.txt and fails here.
+    expect(matches.map((m) => m.file).sort()).toEqual(['alias.txt', path.join('real', 'lib.txt')]);
+  });
+
+  it('search reports a directory reachable by both its real name and an alias', async () => {
+    const base = await mkdtemp(path.join(tmpdir(), 'ch-search-alias-'));
+    const repo = path.join(base, 'repo');
+    await mkdir(path.join(repo, 'zreal'), { recursive: true });
+    await writeFile(path.join(repo, 'zreal', 'lib.txt'), 'needle inside\n', 'utf8');
+    // Sorts before 'zreal', so readdir yields the alias first: with walk-global
+    // loop detection the real directory is pruned and a path-anchored glob
+    // finds nothing.
+    await symlink(path.join(repo, 'zreal'), path.join(repo, 'aalias'));
+
+    expect((await toolSearch(repo, 'needle')).map((m) => m.file).sort()).toEqual([
+      path.join('aalias', 'lib.txt'),
+      path.join('zreal', 'lib.txt'),
+    ]);
+    expect((await toolSearch(repo, 'needle', 'zreal/**')).map((m) => m.file)).toEqual([
+      path.join('zreal', 'lib.txt'),
+    ]);
   });
 
   it('isKicadFile covers the design formats', () => {

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -216,6 +216,17 @@ describe('file tools', () => {
     ]);
   });
 
+  it('search steps over a dangling symlink instead of failing the walk', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'ch-search-dangle-'));
+    await writeFile(path.join(repo, 'a.txt'), 'needle A\n', 'utf8');
+    await symlink(path.join(repo, 'gone'), path.join(repo, 'dangle'));
+
+    // A broken link is an ordinary thing to find in a checkout. The arm that
+    // actually saves the walk is realpath's in insideRoot: it fails first and
+    // drops the entry, so stat is never reached with a dangling target.
+    expect((await toolSearch(repo, 'needle')).map((m) => m.file)).toEqual(['a.txt']);
+  });
+
   it('isKicadFile covers the design formats', () => {
     expect(isKicadFile('a/b.kicad_sch')).toBe(true);
     expect(isKicadFile('a/b.kicad_pcb')).toBe(true);


### PR DESCRIPTION
## What

`toolSearch()` in [filetools.ts](src/agent/filetools.ts) no longer returns matches from files outside the repo root, and no longer dies with `ELOOP` when the repo contains a symlink loop.

## Why

Closes #87.

`toolSearch` is the one file tool that does not go through `resolveInRepo`: it walks with `readdir` + `stat` directly. `stat` follows symlinks, so two things went wrong. Both reproduced against the real exported function, not a reimplementation.

**1. It read outside the repo.** Temp repo with `link -> ../outside`, where `outside/leak.txt` contains `needle SECRET outside`:

```text
matches: 3
  b.txt 1 "needle two"
  link/leak.txt 1 "needle SECRET outside"     <-- outside the repo
  sub/a.txt 1 "needle here"
```

The match is reported as `link/leak.txt`, which reads as a repo-relative path, so neither the model nor a human reading the transcript can tell the content came from outside the sandbox.

**2. A symlink loop took the whole tool down.** Temp repo containing `sub/loop -> <repo root>`:

```text
ERROR: ELOOP: too many symbolic links encountered, stat
       '.../repo/sub/loop/sub/loop/sub/loop/sub/loop/sub/l...'
```

`dispatchTool` catches this so the run does not crash, but `search` is unusable for the rest of the run and the error text gives no hint that a symlink caused it. The walk had no visited set, so a loop was traversed until the OS refused rather than being detected.

This is a sibling of #85 but a separate code path: fixing `resolveInRepo` does not cover `toolSearch`, because `toolSearch` never calls it.

It is reachable without the agent creating anything. A symlinked KiCad symbol or footprint library is an ordinary project layout, and `.history/`, vendored directories, or any user repo may already contain one.

## Design

Three changes inside `toolSearch`, all local to the walk:

- **`lstat` before `stat`.** `lstat` describes the entry itself; `stat` describes the link target and hides that an entry is a link at all. A symlink whose real path lands outside the repo is skipped.
- **`insideRoot()` helper.** Resolves a path with `realpath` and applies the same containment rule `resolveInRepo` uses. The repo root is resolved once up front, because the root itself can sit behind a symlink (on macOS `/tmp` is `/private/tmp`), and comparing a resolved child against an unresolved root would reject everything.
- **A `seenDirs` set of real paths.** A directory whose real path was already walked is skipped, which terminates loops by construction instead of relying on the OS to throw.

Every `stat`/`realpath` call is `.catch(() => null)` with an explicit skip, so an entry that vanishes mid-walk or a broken symlink is stepped over rather than failing the search. That matches how the function already treats unreadable files.

A symlink that stays inside the repo is still followed: those are normal in KiCad projects and must keep working.

## Spec / OpenSpec

No spec-level behavior change. This brings `toolSearch` in line with the containment rule AC-4.2 already states for tool paths, so SPEC.md and the change artifacts stay as they are.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | n/a (typecheck runs the same `tsc` project) |
| Unit + offline | `npm test` | 323 pass, 14 skip, 8 pre-existing failures (see below) |
| Live-LLM (opt-in) | keyed on `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` | not run (no key set) |

New tests, in [safety.test.ts](test/safety.test.ts) under `file tools`:

- **the escape**: asserts the exact match list is `['b.txt', 'sub/a.txt']` and that no match text contains `SECRET`. Asserting the full list matters here, since the old behavior returned a plausible-looking extra path rather than an obvious error
- **the loop**: a repo containing `sub/loop -> <root>` returns its single real match instead of throwing
- **guard rail**: a symlink that stays inside the repo is still followed, so symlinked library dirs keep working

**Revert check.** With the new tests in place I restored the original `filetools.ts`: exactly the 2 behavioral tests fail, and the guard rail passes under both implementations, so it is genuinely guarding rather than riding along.

**Pre-existing failures unrelated to this PR:** 8 tests fail in my environment, all `KicadCliMissingError: kicad-cli not found on PATH` (init-check, gating-sync, and the KiCad edit-probe suites). Identical counts before and after this change.

### Manual test log (required)

Sandbox variant used: none. Drove the shipped `toolSearch` directly, which is a closer test of this change than a CLI run: the escape and the loop both happen inside the walk, and calling it by hand lets the probe assert on the returned match list rather than on agent output.

Commands run and outcome:

```text
$ npx tsc src/agent/filetools.ts src/util/paths.ts --outDir /tmp/tscout --module esnext --target es2022 --moduleResolution bundler

$ node /tmp/srch2.mjs     # escape probe, before
matches: 3
  b.txt 1 "needle two"
  link/leak.txt 1 "needle SECRET outside"
  sub/a.txt 1 "needle here"

$ node /tmp/srch.mjs      # loop probe, before
ERROR: ELOOP: too many symbolic links encountered, stat '.../sub/loop/sub/loop/sub/l...'

$ node /tmp/srch2.mjs     # escape probe, after
matches: 2
  b.txt 1 "needle two"
  sub/a.txt 1 "needle here"

$ node /tmp/srch.mjs      # loop probe, after
matches: 1
  sub/a.txt 1
```

## Docs

None needed: the `search` tool's schema, description, and output format are unchanged. A repo with no symlinks behaves identically.

---

## Invariant checklist

- [x] **Spec-gated in**: unchanged. `search` has `requiresUnlock: false` before and after; this PR changes what it may read, not when it exists.
- [ ] N/A **Verification-gated out**: the mutation and repair path is untouched.
- [x] **`check`/`verify` stays LLM-free and network-free**: this adds only `node:fs/promises` calls (`lstat`, `realpath`), no provider, key, or network access.
- [ ] N/A **No sexp serialization**: `src/kicad/` is untouched.
- [ ] N/A **Sync-obligations ledger**: untouched.
- [ ] N/A **Secrets**: no change to redaction or key handling.
- [ ] N/A **Spec coherence**: no spec-level behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository file search safety using symlink-aware traversal.
  * Prevented searches from accessing content outside the repository root.
  * Added safeguards to skip broken/vanished links and avoid symlink cycle failures, while preserving correct matches for valid in-repo links.
  * Reduced duplicate results and fixed glob behavior when content is reachable via both real paths and aliases.
* **Tests**
  * Expanded symlink-focused test coverage for escaping, cycles, deduplication, alias reachability, and dangling symlink handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->