### PR TITLE
fix(preflight): treat an empty COPPERHEAD_MIN_FREE_MB as unset

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -16,7 +16,7 @@ import type { RunMetaInput } from '../agent/runmeta.js';
 import { fmtDuration, fmtTokens, type ProgressRenderer } from '../agent/render.js';
 import { openspecInit } from '../openspec/cli.js';
 import { sweepStaleTempDirs, pruneHistoryDir } from '../util/tmp.js';
-import { assertDiskSpace, DEFAULT_MIN_FREE_BYTES } from '../util/preflight.js';
+import { assertDiskSpace, resolveMinFreeBytes } from '../util/preflight.js';
 import { runCheck } from './check.js';
 import { emitCreateJlcpcbBom } from './export.js';
 
@@ -525,9 +525,7 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
   // KiCad local history and can otherwise fill the disk mid-stage, failing with
   // an opaque ENOSPC only after doing expensive work. Threshold overridable via
   // COPPERHEAD_MIN_FREE_MB; an unknown reading (unsupported platform) skips it.
-  const minFreeMb = Number(process.env.COPPERHEAD_MIN_FREE_MB);
-  const minFree = Number.isFinite(minFreeMb) && minFreeMb >= 0 ? minFreeMb * 1024 * 1024 : DEFAULT_MIN_FREE_BYTES;
-  await assertDiskSpace(opts.repoRoot, minFree);
+  await assertDiskSpace(opts.repoRoot, resolveMinFreeBytes(process.env.COPPERHEAD_MIN_FREE_MB));
   // Reclaim scratch dirs leaked by earlier runs whose cleanup was skipped (a
   // watchdog SIGKILL or hard abort bypasses the per-call `finally`). Age-gated,
   // so a concurrent run's fresh dirs are never touched; best-effort, so it never

--- a/src/util/preflight.ts
+++ b/src/util/preflight.ts
@@ -31,6 +31,25 @@ export const DEFAULT_MIN_FREE_BYTES = 2 * 1024 * 1024 * 1024;
 const gib = (n: number): string => `${(n / 1024 / 1024 / 1024).toFixed(1)} GiB`;
 
 /**
+ * Resolve the free-space threshold from a `COPPERHEAD_MIN_FREE_MB` value.
+ *
+ * An empty or whitespace-only value is treated as unset, not as zero:
+ * `Number('')` is `0`, so parsing the raw value would turn an env var that was
+ * declared but never filled in (a blank line in `.env`, an unset CI variable)
+ * into a 0-byte threshold, silently disabling the check this module exists for.
+ * Anything else unparseable, negative, or non-finite also falls back.
+ */
+export function resolveMinFreeBytes(
+  raw: string | undefined,
+  fallback = DEFAULT_MIN_FREE_BYTES,
+): number {
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const mb = Number(raw);
+  if (!Number.isFinite(mb) || mb < 0) return fallback;
+  return mb * 1024 * 1024;
+}
+
+/**
  * Free bytes available to this (unprivileged) user on the filesystem holding
  * `dir`, or null when the platform/Node build cannot report it — callers treat
  * null as "unknown" and skip the check rather than blocking a legitimate run.

--- a/src/util/preflight.ts
+++ b/src/util/preflight.ts
@@ -37,15 +37,13 @@ const gib = (n: number): string => `${(n / 1024 / 1024 / 1024).toFixed(1)} GiB`;
  * `Number('')` is `0`, so parsing the raw value would turn an env var that was
  * declared but never filled in (a blank line in `.env`, an unset CI variable)
  * into a 0-byte threshold, silently disabling the check this module exists for.
- * Anything else unparseable, negative, or non-finite also falls back.
+ * Anything else unparseable, negative, or non-finite also falls back to
+ * `DEFAULT_MIN_FREE_BYTES`, which is exported for callers that need it.
  */
-export function resolveMinFreeBytes(
-  raw: string | undefined,
-  fallback = DEFAULT_MIN_FREE_BYTES,
-): number {
-  if (raw === undefined || raw.trim() === '') return fallback;
+export function resolveMinFreeBytes(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_MIN_FREE_BYTES;
   const mb = Number(raw);
-  if (!Number.isFinite(mb) || mb < 0) return fallback;
+  if (!Number.isFinite(mb) || mb < 0) return DEFAULT_MIN_FREE_BYTES;
   return mb * 1024 * 1024;
 }
 

--- a/test/session-limit-disk.test.ts
+++ b/test/session-limit-disk.test.ts
@@ -3,7 +3,13 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { sessionLimit, isRateLimit } from '../src/util/retry.js';
-import { assertDiskSpace, freeDiskBytes, PreflightError } from '../src/util/preflight.js';
+import {
+  assertDiskSpace,
+  DEFAULT_MIN_FREE_BYTES,
+  freeDiskBytes,
+  PreflightError,
+  resolveMinFreeBytes,
+} from '../src/util/preflight.js';
 
 describe('sessionLimit (2.4 / I13 — a schedulable pause, not a bug)', () => {
   it('detects a saved-login session limit and extracts the reset time', () => {
@@ -57,5 +63,38 @@ describe('disk-space preflight (4.1)', () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('resolveMinFreeBytes (COPPERHEAD_MIN_FREE_MB)', () => {
+  it('uses the default when the variable is unset', () => {
+    expect(resolveMinFreeBytes(undefined)).toBe(DEFAULT_MIN_FREE_BYTES);
+  });
+
+  it('treats an empty or blank value as unset, not as zero', () => {
+    // Number('') is 0, so parsing the raw value would set a 0-byte threshold
+    // and silently disable the check. A declared-but-unfilled variable is
+    // exactly what a blank .env line or an unset CI variable produces.
+    for (const raw of ['', ' ', '   ', '\t', '\n']) {
+      expect(resolveMinFreeBytes(raw), JSON.stringify(raw)).toBe(DEFAULT_MIN_FREE_BYTES);
+    }
+  });
+
+  it('falls back on values that are not a usable number', () => {
+    for (const raw of ['abc', '-1', 'Infinity', 'NaN', '1,000']) {
+      expect(resolveMinFreeBytes(raw), raw).toBe(DEFAULT_MIN_FREE_BYTES);
+    }
+  });
+
+  it('converts a valid value from MiB to bytes', () => {
+    expect(resolveMinFreeBytes('500')).toBe(500 * 1024 * 1024);
+    expect(resolveMinFreeBytes('  500  ')).toBe(500 * 1024 * 1024);
+    expect(resolveMinFreeBytes('0.5')).toBe(0.5 * 1024 * 1024);
+  });
+
+  it('still honours an explicit 0 as an opt-out', () => {
+    // Distinguishable from the empty case above, which is the point: an
+    // operator can still turn the check off on purpose.
+    expect(resolveMinFreeBytes('0')).toBe(0);
   });
 });


### PR DESCRIPTION
## What

An empty or whitespace-only `COPPERHEAD_MIN_FREE_MB` is now treated as unset (falls back to the 2 GiB default) instead of becoming a 0-byte threshold that silently disables the disk preflight.

## Why

Closes #89.

The override parsed with a bare `Number()`, and `Number('')` is `0`, not `NaN`:

```ts
const minFreeMb = Number(process.env.COPPERHEAD_MIN_FREE_MB);
const minFree = Number.isFinite(minFreeMb) && minFreeMb >= 0 ? minFreeMb * 1024 * 1024 : DEFAULT_MIN_FREE_BYTES;
```

`assertDiskSpace` then returns immediately, since `free >= 0` is always true.

| `COPPERHEAD_MIN_FREE_MB` | `Number()` | threshold |
| --- | --- | --- |
| unset | `NaN` | 2.0 GiB (correct) |
| `abc` | `NaN` | 2.0 GiB (correct) |
| `500` | `500` | 0.488 GiB (correct) |
| (empty) | `0` | **0 GiB, check disabled** |
| `" "` (blank) | `0` | **0 GiB, check disabled** |

The failure mode is exactly the one Issue 16 exists to prevent: the run starts on a nearly-full disk and dies partway through with a raw `ENOSPC` from whichever write loses, after doing expensive work. Since the intent of `Number.isFinite(...) && >= 0` is clearly "fall back on a bad value", an empty value reads as a bad value that was not caught.

An empty value is easy to produce, including from this repo's own `.env` loader. All of these set it to `''`:

```text
COPPERHEAD_MIN_FREE_MB=
COPPERHEAD_MIN_FREE_MB=""
```

So does a CI job with `COPPERHEAD_MIN_FREE_MB: ${{ vars.SOMETHING_UNSET }}`. An operator doing this is trying to keep the default and instead turns the guard off.

## Design

The parse moves out of `runCreate` and into an exported `resolveMinFreeBytes()` in [preflight.ts](src/util/preflight.ts), next to `assertDiskSpace` and `DEFAULT_MIN_FREE_BYTES`. Two reasons: it is the only piece of this that is worth testing directly, and it belongs with the other preflight knobs rather than inline in an 8-stage pipeline function.

The only behavioral change is the added `raw.trim() === ''` check. Everything else is preserved deliberately:

- an explicit `0` still opts out. That is now distinguishable from the empty-value accident, which is the point: an operator can still turn the check off on purpose, and a blank variable no longer does it by mistake
- `abc`, `-1`, `NaN` still fall back, as before
- `Infinity` still falls back. I noticed this reads slightly wrong (`COPPERHEAD_MIN_FREE_MB=Infinity` means "never run" but becomes 2 GiB) and deliberately did not change it: it is a separate judgement call and not what this issue is about. Happy to follow up if you want it to refuse instead.

`create.ts` loses its now-unused `DEFAULT_MIN_FREE_BYTES` import.

## Spec / OpenSpec

No spec-level behavior change. This restores the intended behavior of the existing 4.1 disk preflight rather than altering what it promises, so SPEC.md and the change artifacts stay as they are.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | n/a (typecheck runs the same `tsc` project) |
| Unit + offline | `npm test` | 325 pass, 14 skip, 8 pre-existing failures (see below) |
| Live-LLM (opt-in) | keyed on `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` | not run (no key set) |

New tests, in [session-limit-disk.test.ts](test/session-limit-disk.test.ts) under `resolveMinFreeBytes`:

- unset falls back to the default
- **empty and blank values (`''`, `' '`, `'   '`, tab, newline) fall back**, which is the regression
- unparseable values (`abc`, `-1`, `Infinity`, `NaN`, `1,000`) fall back
- a valid value converts MiB to bytes, including one with surrounding whitespace and a fractional value
- an explicit `0` is still honoured as an opt-out

**Revert check.** With the tests in place I restored the original parse: exactly 1 test fails, the empty/blank case. The other four pass under both implementations, which is what I wanted, they confirm the fix did not achieve correctness by simply rejecting more inputs.

**Pre-existing failures unrelated to this PR:** 8 tests fail in my environment, all `KicadCliMissingError: kicad-cli not found on PATH` (init-check, gating-sync, and the KiCad edit-probe suites). Identical counts before and after this change.

### Manual test log (required)

n/a with a reason: the change is a pure parsing function plus the one call site that feeds it. Exercising it at runtime would mean filling a real disk to below the threshold, which the existing `assertDiskSpace` tests already cover synthetically by passing thresholds directly (0 and `Number.MAX_SAFE_INTEGER`). The behavior this PR changes is entirely upstream of that call, and is covered directly by the new unit tests.

For what it is worth, I did verify the empty-value path end to end at the value level rather than assuming it:

```text
Number('')      -> 0      (threshold 0 bytes, assertDiskSpace returns immediately)
Number(' ')     -> 0      (same)
Number('abc')   -> NaN    (correctly falls back to 2 GiB)
```

and confirmed against this repo's own `.env` parser that `COPPERHEAD_MIN_FREE_MB=` and `COPPERHEAD_MIN_FREE_MB=""` both yield `''`.

## Docs

None needed. The documented behavior (`COPPERHEAD_MIN_FREE_MB=500`, default 2 GiB) is unchanged; this makes the implementation match it. The remedy text in `assertDiskSpace` already describes the override correctly.

---

## Invariant checklist

- [ ] N/A **Spec-gated in**: the agent tool list is untouched.
- [ ] N/A **Verification-gated out**: the mutation and repair path is untouched.
- [x] **`check`/`verify` stays LLM-free and network-free**: `preflight.ts` has no provider, key, or network access, and this change adds none.
- [ ] N/A **No sexp serialization**: `src/kicad/` is untouched.
- [ ] N/A **Sync-obligations ledger**: untouched.
- [ ] N/A **Secrets**: no change to redaction or key handling. The env var carries no secret.
- [ ] N/A **Spec coherence**: no spec-level behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk-space threshold handling for the create command.
  * Blank, invalid, negative, or unset values now safely use the default threshold.
  * Valid decimal values are converted accurately, while `0` can explicitly disable the minimum threshold.
* **Tests**
  * Added coverage for minimum free-disk threshold resolution across unset, whitespace, invalid, decimal, and `0` inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->