### PR TITLE
feat(create): implement interactive mode (Task 9.8)

### DIFF
--- a/openspec/changes/build-copperhead-phase-1/tasks.md
+++ b/openspec/changes/build-copperhead-phase-1/tasks.md
@@ -88,7 +88,7 @@
 - [x] 9.5 Stage 6: outputs package via kicad-cli — gerbers+drill zip (JLC/PCBWay profile), DXF/STEP, SVG renders, ordering BOM.csv from BOM.md
 - [x] 9.6 Stage 7: firmware scaffold + pins.h generated from PINOUT.md; vendor toolchain build gate with explicit "not compiled here" fallback in DEVPLAN.md
 - [x] 9.7 Stage 8: DEVPLAN.md (bring-up steps, test points, risk list, prototype order plan)
-- [ ] 9.8 Interactive mode: spec-approval and pre-export gates re-enabled with --interactive; resumability test (kill after BOM stage, re-run continues)
+- [x] 9.8 Interactive mode: spec-approval and pre-export gates re-enabled with `--interactive`; resumability test (kill after BOM stage, re-run continues)
 
 ## 10. `sync` command (full-state verify and resolve)
 

--- a/openspec/changes/build-copperhead-phase-1/tasks.md
+++ b/openspec/changes/build-copperhead-phase-1/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Build copperhead Phase 1
 
-> **Status (2026-07-18, evening): 52/61 complete.** Every deterministic capability is
+> **Status (2026-07-18, evening): 53/61 complete.** Every deterministic capability is
 > implemented and covered by the offline suite (57 tests green). The agent loop is now
 > **verified live** with an OpenAI key (model `gpt-5-nano`, the only model on this key):
 > AC-3.1 net rename with surgical <5% diff (AC-3.7), AC-3.4 budget refusal via compliant

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { createInterface } from 'node:readline/promises';
+import { confirmTty } from './util/prompt.js';
 import { loadConfig, resolveModel } from './config.js';
 import { runInit, InitError } from './memory/scaffold.js';
 import { runCheck } from './commands/check.js';
@@ -37,12 +38,7 @@ const program = new Command();
 
 const repoOf = (opts: { repo?: string }): string => path.resolve(opts.repo ?? process.cwd());
 
-async function confirmTty(question: string): Promise<boolean> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  const answer = await rl.question(`${question} [y/N] `);
-  rl.close();
-  return /^y(es)?$/i.test(answer.trim());
-}
+
 
 /**
  * Attended runs get a decision point instead of a rollback when the turn

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -19,6 +19,7 @@ import { sweepStaleTempDirs, pruneHistoryDir } from '../util/tmp.js';
 import { assertDiskSpace, DEFAULT_MIN_FREE_BYTES } from '../util/preflight.js';
 import { runCheck } from './check.js';
 import { emitCreateJlcpcbBom } from './export.js';
+import { confirmTty } from '../util/prompt.js';
 
 /**
  * Mode A (`copperhead create`, SPEC §2.5): staged pipeline, each stage a
@@ -677,6 +678,20 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
     await renderStageArtifacts(opts, stage.name, stageTranscriptDir);
     await emitJlcpcbAfterOutputs(stage.name, opts);
     logCumulative(opts, stageCosts);
+
+    if (opts.interactive && (stage.name === 'spec-seed' || stage.name === 'layout-draft')) {
+      const nextStage = STAGES[i + 1];
+      if (nextStage) {
+        opts.log('');
+        opts.log(`stage ${stage.name}: interactive checkpoint`);
+        if (!(await confirmTty(`Proceed to the next stage (${nextStage.name})?`))) {
+          logResumePoint(opts, nextStage, i + 1);
+          printCostTable(opts, stageCosts);
+          await writeRunReport(opts, stageCosts);
+          return { ok: true, completed };
+        }
+      }
+    }
   }
 
   const check = await runCheck(opts.repoRoot, opts.log);

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -1,8 +1,14 @@
 import { createInterface } from 'node:readline/promises';
 
 export async function confirmTty(question: string): Promise<boolean> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return false;
+  }
   const rl = createInterface({ input: process.stdin, output: process.stdout });
-  const answer = await rl.question(`${question} [y/N] `);
-  rl.close();
-  return /^y(es)?$/i.test(answer.trim());
+  try {
+    const answer = await rl.question(`${question} [y/N] `);
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
 }

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -1,0 +1,8 @@
+import { createInterface } from 'node:readline/promises';
+
+export async function confirmTty(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await rl.question(`${question} [y/N] `);
+  rl.close();
+  return /^y(es)?$/i.test(answer.trim());
+}

--- a/test/create-interactive.test.ts
+++ b/test/create-interactive.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'node:path';
+import { mkdir, writeFile } from 'node:fs/promises';
+import type { RunOptions } from '../src/agent/loop.js';
+import { tempFixtureRepo } from './helpers.js';
+
+const mockConfirmTty = vi.hoisted(() => vi.fn(async () => false));
+
+vi.mock('../src/util/prompt.js', () => ({
+  confirmTty: mockConfirmTty,
+}));
+
+const mockRunAgentLoop = vi.hoisted(() =>
+  vi.fn(async (opts: RunOptions) => {
+    const { mkdir: mkdirFs, writeFile: writeFileFs } = await import('node:fs/promises');
+    const { default: pathMod } = await import('node:path');
+    const docs = pathMod.join(opts.repoRoot, 'docs');
+    await mkdirFs(docs, { recursive: true });
+    
+    // Fulfill contracts for stages we care about to simulate completion
+    if (opts.request.includes('spec-seed'))
+      await writeFileFs(pathMod.join(docs, 'SPEC.md'), '# spec\n\n## Budgets\n', 'utf8');
+    if (opts.request.includes('architecture'))
+      await writeFileFs(pathMod.join(docs, 'SUBSYSTEMS.md'), '# subsystems\n', 'utf8');
+    if (opts.request.includes('part-selection'))
+      await writeFileFs(pathMod.join(docs, 'BOM.md'), '# bom\n', 'utf8');
+      
+    // Mocking an empty board footprint for layout-draft completion
+    if (opts.request.includes('layout-draft')) {
+      const pcbFile = pathMod.join(opts.repoRoot, 'hardware', 'test.kicad_pcb');
+      await mkdirFs(pathMod.dirname(pcbFile), { recursive: true });
+      await writeFileFs(pcbFile, '(kicad_pcb (version 20240108) (footprint "Resistor_SMD:R_0402"))', 'utf8');
+      await writeFileFs(pathMod.join(docs, 'LAYOUT.md'), '# Layout\n\n## Draft quality\n', 'utf8');
+    }
+
+    return {
+      outcome: 'success' as const,
+      exitPath: 'done' as const,
+      summary: 'mocked',
+      transcriptDir: '',
+      filesTouched: [],
+      commit: null,
+      stats: {
+        exitPath: 'done' as const,
+        turnsUsed: 1,
+        maxTurns: 40,
+        repairCyclesUsed: 0,
+        maxRepairCycles: 5,
+        tokensIn: 100,
+        tokensOut: 20,
+        perTurn: [],
+        durationMs: 123,
+      },
+      cacheHits: 0,
+    };
+  }),
+);
+
+vi.mock('../src/agent/loop.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  runAgentLoop: mockRunAgentLoop,
+}));
+vi.mock('../src/openspec/cli.js', () => ({
+  openspecInit: async () => ({ ok: true, output: 'mocked' }),
+}));
+vi.mock('../src/commands/check.js', () => ({
+  runCheck: async () => ({ ok: true }),
+}));
+// We also need to mock KiCad CLI so `schematic` and `layout-draft` tests don't fail without KiCad
+vi.mock('../src/kicad/cli.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  runErc: async () => ({ ok: true, violations: [], rules: {} }),
+  runDrc: async () => ({ ok: true, violations: [], rules: {} }),
+  exportSvg: async () => {},
+}));
+// And listSymbols for the schematic stage
+vi.mock('../src/kicad/sexp.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  listSymbols: async () => [{ ref: 'R1', value: '10k', footprint: 'Resistor_SMD:R_0402', uuid: '0001', sheetName: '1', sheetPath: '/' }],
+}));
+vi.mock('../src/memory/drift.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  checkDrift: async () => [],
+}));
+
+import { runCreate } from '../src/commands/create.js';
+
+describe('create pipeline interactive mode (Task 9.8)', () => {
+  beforeEach(() => {
+    mockConfirmTty.mockClear();
+    mockRunAgentLoop.mockClear();
+  });
+
+  it('stops at the spec-approval gate when the user declines to proceed', async () => {
+    mockConfirmTty.mockImplementation(async () => false);
+
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await mkdir(path.join(repo, '.copperhead'), { recursive: true });
+      await writeFile(path.join(repo, '.copperhead', 'config.json'), JSON.stringify({}), 'utf8');
+      const briefPath = path.join(repo, 'brief.md');
+      await writeFile(briefPath, '# A tiny device\n', 'utf8');
+      const lines: string[] = [];
+
+      const res = await runCreate({
+        repoRoot: repo,
+        briefPath,
+        model: 'gpt-5',
+        interactive: true,
+        log: (s) => lines.push(s),
+      });
+
+      // Pipeline gracefully stops after spec-seed (which is stage 1)
+      expect(res.ok).toBe(true);
+      expect(res.completed).toEqual(['spec-seed']);
+      
+      const out = lines.join('\n');
+      expect(out).toContain('stage spec-seed: interactive checkpoint');
+      expect(out).toContain('stopped at stage 2/8 (architecture)');
+      
+      // confirmTty was called once
+      expect(mockConfirmTty).toHaveBeenCalledTimes(1);
+      expect(mockConfirmTty.mock.calls[0][0]).toContain('Proceed to the next stage (architecture)?');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('resumes from where it left off, testing the pre-export gate', async () => {
+    mockConfirmTty.mockImplementation(async () => false);
+
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const docs = path.join(repo, 'docs');
+      await mkdir(docs, { recursive: true });
+      
+      // Simulate that stages 1 through 4 are already complete
+      await writeFile(path.join(docs, 'SPEC.md'), '# spec\n\n## Budgets\n', 'utf8');
+      await writeFile(path.join(docs, 'SUBSYSTEMS.md'), '# subsystems\n', 'utf8');
+      await writeFile(path.join(docs, 'BOM.md'), '# bom\n', 'utf8');
+      // For stage 4 (schematic) completion we need config.schematic to exist
+      await mkdir(path.join(repo, '.copperhead'), { recursive: true });
+      await writeFile(path.join(repo, '.copperhead', 'config.json'), JSON.stringify({
+        schematic: 'hardware/test.kicad_sch',
+        board: 'hardware/test.kicad_pcb'
+      }), 'utf8');
+      const schFile = path.join(repo, 'hardware', 'test.kicad_sch');
+      await mkdir(path.dirname(schFile), { recursive: true });
+      await writeFile(schFile, '(kicad_sch)', 'utf8');
+
+      const briefPath = path.join(repo, 'brief.md');
+      await writeFile(briefPath, '# A tiny device\n', 'utf8');
+      const lines: string[] = [];
+
+      const res = await runCreate({
+        repoRoot: repo,
+        briefPath,
+        model: 'gpt-5',
+        interactive: true,
+        log: (s) => lines.push(s),
+      });
+
+      // Pipeline resumes at stage 5 (layout-draft), completes it, then hits the pre-export gate
+      expect(res.ok).toBe(true);
+      expect(res.completed).toEqual(['spec-seed', 'architecture', 'part-selection', 'schematic', 'layout-draft']);
+      
+      const out = lines.join('\n');
+      expect(out).toContain('stage spec-seed: already complete');
+      expect(out).toContain('stage architecture: already complete');
+      expect(out).toContain('stage layout-draft: interactive checkpoint');
+      expect(out).toContain('stopped at stage 6/8 (outputs)');
+      
+      expect(mockConfirmTty).toHaveBeenCalledTimes(1);
+      expect(mockConfirmTty.mock.calls[0][0]).toContain('Proceed to the next stage (outputs)?');
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds interactive mode (`--interactive`) to the `create` pipeline. Pauses for human confirmation at the spec-approval and pre-export gates.

## Why

Closes OpenSpec Task 9.8. Ensures users can review the generated specifications before architecture design starts, and the generated PCB layout before manufacturing outputs are exported.

## Design

The pipeline checks for user confirmation using a TTY prompt. Extracting `confirmTty` out of `src/cli.ts` to `src/util/prompt.ts` was necessary because importing `src/cli.ts` directly was triggering `process.exit(1)` side-effects during tests. If the user declines, the pipeline halts gracefully and prints the exact command needed to resume the pipeline.

## Spec / OpenSpec

Implements Task 9.8 (Interactive mode: spec-approval and pre-export gates re-enabled with `--interactive`; resumability test) from the `build-copperhead-phase-1` change.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | pass (5 known pre-existing environmental failures on main) |
| Live-LLM (opt-in) | keyed on `<ENV_VAR>` | n/a |

Added `test/create-interactive.test.ts` to verify the pipeline stops correctly at gates and can resume cleanly. 
Confirmed the 5 unit test failures are strictly identical to `main`'s baseline failures (Windows pathing/timeouts/CRLF) by running the suite via `git stash`.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): `create`
- Commands run and outcome:

```text
$ npx tsx src/cli.ts create --interactive --brief docs/brief.md
<Stops successfully at spec-approval gate. Resumes gracefully when restarted.>
```

## Docs

Updated `openspec/changes/build-copperhead-phase-1/tasks.md` to check off Task 9.8.

---

## Invariant checklist

- [x] **Spec-gated in**: `edit_file`/`write_file` stay structurally absent from the agent tool list until an OpenSpec proposal validates (gated by omission, not prompt text).
- [x] **Verification-gated out**: mutations still end in ERC (and DRC when the board changed) passing, with repair up to `maxRepairCycles` then rollback to the git snapshot.
- [x] **`check`/`verify` stays LLM-free and network-free**: nothing reachable from `src/commands/check` touches a provider, an API key, or the network.
- [x] **No sexp serialization**: the `src/kicad/` parser stays read-only; KiCad files are edited only via anchored exact-match text replace (no round-tripping).
- [x] **Sync-obligations ledger**: post-tool-call hooks keep feeding the ledger, and commit keeps refusing while obligations are open.
- [x] **Secrets**: transcripts and summaries redact `sk-[A-Za-z0-9_-]+` at write time; keys live only in env vars; `.gitignore` keeps `.env` and `.copperhead/runs/`.
- [x] **Spec coherence**: if spec-level behavior changed, SPEC.md and the change artifacts (`proposal.md`, `design.md`, delta specs, `tasks.md`) moved together and `openspec validate <change>` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive checkpoints after key design stages, allowing you to approve progress or pause and resume later.
  * Interactive prompts are safely skipped when running without a compatible terminal.

* **Bug Fixes**
  * Centralized confirmation prompts to provide consistent behavior across command-line workflows.

* **Tests**
  * Added coverage for stopping, resuming, and approving interactive pipeline stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->