### PR TITLE
feat: Claude Code–style REPL with copper chrome and board inspect commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ In an existing KiCad repository:
 ```bash
 export ANTHROPIC_API_KEY=...   # or OPENAI_API_KEY
 copperhead init                # scaffold docs/ from the schematic; idempotent
+copperhead                     # interactive agent shell (Claude Code–style REPL)
+copperhead demo --tour          # what the agent does (no LLM)
+copperhead demo --model cursor # full USB-C breakout create pipeline
+# or one-shot:
 copperhead do "add reverse-polarity protection on VIN"
 copperhead check               # ERC + DRC + doc drift; no LLM, CI-safe
 ```

--- a/docs/src/content/docs/getting-started/demo.md
+++ b/docs/src/content/docs/getting-started/demo.md
@@ -12,10 +12,12 @@ The quickest end-to-end demo uses the USB-C power breakout brief. It is intentio
 From the copperhead checkout:
 
 ```bash
+copperhead demo --model cursor
+# or from a checkout:
 npm run demo:simple
 ```
 
-The script creates or resumes a git repo at `demo-runs/usb-c-breakout/`, initializes it if needed, creates a baseline commit for copperhead's rollback snapshots, and runs the create pipeline against:
+Both create or resume a git repo at `demo-runs/usb-c-breakout/`, initialize it if needed, create a baseline commit for copperhead's rollback snapshots, and run the create pipeline against:
 
 ```text
 examples/simple/usb-c-breakout.md

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -6,15 +6,17 @@ sidebar:
 ---
 
 ```text
-copperhead [global options] <command>
+copperhead [global options] [<command>]
 ```
 
-Every command probes `kicad-cli` before doing anything and exits 1 if it is not on your `PATH`. A `.env` in the working directory is loaded before any command resolves a model or a provider; a real environment variable always beats the file.
+With no subcommand, `copperhead` starts the interactive agent shell. Every command probes `kicad-cli` before doing anything and exits 1 if it is not on your `PATH`. A `.env` in the working directory is loaded before any command resolves a model or a provider; a real environment variable always beats the file.
 
 ## Commands at a glance
 
 | Command | Flow | LLM? | What it does |
 | --- | --- | --- | --- |
+| `repl` (default) | [Edit an existing board](/workflows/edit-existing-board/) | Yes | Interactive agent shell; each prompt is one `do`-equivalent run. |
+| `demo` | [Simple demo](/getting-started/demo/) | Tour no / pipeline yes | Tour of what copperhead does, or run the USB-C breakout create pipeline. |
 | `init` | Setup | No | Scaffolds `docs/` from an existing schematic. |
 | `check` (`verify`) | Either | No | ERC, DRC, drift, constraints, spec validation. CI-safe. |
 | `do` | [Edit an existing board](/workflows/edit-existing-board/) | Yes | One change: propose, edit, verify, propagate, commit. |
@@ -30,6 +32,41 @@ Every command probes `kicad-cli` before doing anything and exits 1 if it is not 
 | `-V, --version` | Print the version. |
 
 Global options go before the subcommand: `copperhead --json check`.
+
+## `copperhead` / `copperhead repl`
+
+Interactive agent shell (default when no command is given). On a TTY, prints a short banner and prompts for change requests — each line runs the same gated loop as `copperhead do`, then returns to the prompt.
+
+```bash
+copperhead
+copperhead "add reverse-polarity protection on VIN"   # seed request, then stay in the shell
+copperhead repl --model claude-code
+```
+
+| Option | Description |
+| --- | --- |
+| `--model <model>` | Model / provider selection (same as `do`). |
+| `--max-turns <n>` | Turn budget per request. |
+| `--interactive` | Pause for approval after each proposal validates. |
+
+Slash commands inside the shell: `/help`, `/demo`, `/examples`, `/status`, `/check`, `/parts`, `/nets`, `/bom`, `/sync`, `/drift`, `/constraints`, `/openspec`, `/config`, `/git`, `/runs`, `/last`, `/model`, `/version`, `/clear`, `/quit` (`/exit`, `/q`). Type `/` to see live filtered suggestions immediately; ↑/↓ + Enter picks one, Tab completes. Requires a TTY (or a seed request for a one-shot non-TTY run). `--json` is refused; use `copperhead do … --json` instead.
+
+## `copperhead demo`
+
+Tour of what the agent does, or an end-to-end create pipeline against the packaged USB-C power breakout brief (same as `npm run demo:simple`).
+
+```bash
+copperhead demo --tour                 # overview only (no LLM)
+copperhead demo --model cursor         # scaffold + create pipeline
+copperhead demo --dir /tmp/my-demo     # custom demo repo path
+```
+
+| Option | Description |
+| --- | --- |
+| `--tour` | Print the overview and exit. |
+| `--model <model>` | Model for the create pipeline. |
+| `--interactive` | Re-enable human gates during create. |
+| `--dir <path>` | Demo repo directory. Default `demo-runs/usb-c-breakout` (or `COPPERHEAD_DEMO_DIR`). |
 
 ## `copperhead init`
 

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -235,6 +235,21 @@ This kills the last "docs drift" failure mode: requirements (openspec) → budge
 ## 3. CLI surface (Phase 1)
 
 ```
+copperhead [repl] ["<change request>"] [--model …]
+    Interactive agent shell (default when no subcommand is given).
+    Claude Code–style prompt loop on a TTY: each line runs one
+    `do`-equivalent change (same gates), then returns to the prompt.
+    Slash commands: /help, /demo, /examples, /status, /check, /parts, /nets,
+    /bom, /sync, /drift, /constraints, /openspec, /config, /git, /runs, /last,
+    /model, /version, /clear, /quit. Inspect commands are verify-only (no LLM
+    resolve / create). An optional first request runs before the loop. Non-TTY
+    without a request refuses and points at `copperhead do`.
+
+copperhead demo [--tour] [--model …] [--dir <path>]
+    Print a short tour of what the agent does (`--tour`), or scaffold
+    `demo-runs/usb-c-breakout/` and run the create pipeline against the
+    packaged USB-C power breakout brief (same as `npm run demo:simple`).
+
 copperhead create --brief brief.md   # Mode A: full pipeline (§2.5)
 copperhead init [--path hardware/]
     Detect .kicad_sch/.kicad_pcb, parse symbols/footprints/nets,
@@ -472,7 +487,7 @@ Format: Given / When / Then. "Fixture" = the open-telegraph repo (or the tiny te
 - **AC-8.5 (run-end addenda on every path)** Every terminal branch (success, refusal, turn-budget, repair-cycles, provider error, stall, commit failure) emits a `run-end` event and a `## Run stats` summary section with: exit path (`done`/`refused`/`turn-budget-exhausted`/`repair-cycles-exhausted`/`commit-failed`/`provider-error`/`stalled`), turns used vs budget, repair cycles used vs budget, token totals + per-turn breakdown, and wall-clock duration; the CLI prints one final outcome line (exit path, verification, commit hash if any, duration, tokens).
 - **AC-8.6 (commit failure is an outcome)** When the end-of-run git commit fails (e.g. `git add -A` exits 128 on an embedded repo), the run rolls back per the snapshot contract and ends with `exitPath: commit-failed`; `summary.md` is still written and names the git error; no unhandled stack trace reaches the user.
 - **AC-8.7 (progress with tokens)** In plain mode, each turn's output is prefixed `[turn k/N · <in> in / <out> out]` with cumulative totals (compact `12.3k` formatting); tool results stay one line each.
-- **AC-8.8 (interactive on a TTY)** With stdout a TTY and neither `--json` nor `--plain`: a bottom-pinned status line redraws in place (spinner while a provider call is in flight, elapsed time, turn counter vs budget, cumulative tokens); assistant text and tool results scroll above it; the final outcome line replaces it; cursor and status line are restored/cleared on exit including Ctrl-C. A renderer reused across runs (the `create` pipeline) renders every stage: each outcome line releases the status line and the next stage re-establishes it.
+- **AC-8.8 (interactive on a TTY)** With stdout a TTY and neither `--json` nor `--plain`: a bottom-pinned status line redraws in place (spinner while a provider call is in flight, elapsed time, turn counter vs budget, cumulative tokens); assistant text and tool results scroll above it; the final outcome line replaces it; cursor and status line are restored/cleared on exit including Ctrl-C. A renderer reused across runs (the `create` pipeline) renders every stage: each outcome line releases the status line and the next stage re-establishes it. Interactive chrome may use muted SGR color (copper accent, dim secondary text, green/amber/red for outcome); color is never required for correctness.
 - **AC-8.9 (plain fallback)** With stdout piped, or `--json`, or the global `--plain` flag: output is line-oriented and contains zero ANSI escape sequences. With `--json`, progress lines go to stderr; stdout carries only the machine-readable result.
 - **AC-8.10 (redaction holds)** A string matching `sk-[A-Za-z0-9_-]+` planted in any metadata field appears redacted in both the persisted `run-start` event and `summary.md` (extends AC-4.1 to the new surfaces).
 

--- a/scripts/demo-simple.sh
+++ b/scripts/demo-simple.sh
@@ -48,8 +48,20 @@ elif ! git -C "$DEMO_DIR" diff --cached --quiet; then
   git -C "$DEMO_DIR" commit -q -m "demo: update demo scaffolding"
 fi
 
-printf 'copperhead simple demo\n'
-printf 'repo:  %s\n' "$DEMO_DIR"
-printf 'brief: %s\n\n' "$BRIEF"
+# Short paths for the banner — absolute walls of text make the TTY feel noisy.
+short_path() {
+  local p="$1"
+  if [[ "$p" == "$HOME"/* ]]; then
+    printf '~/%s' "${p#"$HOME"/}"
+  elif [[ "$p" == "$ROOT"/* ]]; then
+    printf '%s' "${p#"$ROOT"/}"
+  else
+    printf '%s' "$p"
+  fi
+}
+
+printf 'copperhead · simple demo\n'
+printf 'repo:  %s\n' "$(short_path "$DEMO_DIR")"
+printf 'brief: %s\n\n' "$(short_path "$BRIEF")"
 
 npm run dev -- --repo "$DEMO_DIR" create --brief "$BRIEF" "$@"

--- a/src/agent/animate.ts
+++ b/src/agent/animate.ts
@@ -1,0 +1,114 @@
+/**
+ * Subtle TTY motion for attended copperhead chrome. Disabled when color is
+ * off, stdout is not a TTY, CI=1, or COPPERHEAD_NO_ANIM=1.
+ */
+
+import { copper, isColorEnabled } from './theme.js';
+
+export function prefersAnimation(): boolean {
+  return (
+    isColorEnabled() &&
+    Boolean(process.stdout.isTTY) &&
+    !process.env.CI &&
+    !process.env.COPPERHEAD_NO_ANIM
+  );
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+const CLEAR = '\r\x1b[2K';
+const SHOW = '\x1b[?25h';
+const HIDE = '\x1b[?25l';
+
+/** Growing fiducial frames (3 rows). Exported for tests. */
+export function fiducialBootFrames(): string[][] {
+  return [
+    ['           ', '      ·      ', '           '],
+    ['           ', '      │      ', '           '],
+    ['      │      ', '   ──◯──   ', '      │      '],
+    ['      │      ', '  ────◯────  ', '      │      '],
+  ].map((frame) => frame.map((row) => copper(row)));
+}
+
+/**
+ * Startup reveal: quick fiducial power-on, then cascade the real banner lines.
+ */
+export async function revealBanner(
+  lines: string[],
+  write: (line: string) => void,
+  opts?: { out?: NodeJS.WriteStream },
+): Promise<void> {
+  const out = opts?.out ?? process.stdout;
+
+  if (!prefersAnimation()) {
+    for (const line of lines) write(line);
+    return;
+  }
+
+  out.write(HIDE);
+  try {
+    // Fiducial power-on (in-place), then erase and cascade the real banner
+    // so scrollback keeps one clean lockup — not a trail of boot frames.
+    const frames = fiducialBootFrames();
+    out.write('\n');
+    for (const row of frames[0]!) out.write(CLEAR + row + '\n');
+    for (let i = 1; i < frames.length; i++) {
+      await sleep(50);
+      out.write(`\x1b[${frames[i]!.length}A`);
+      for (const row of frames[i]!) out.write(CLEAR + row + '\n');
+    }
+    await sleep(90);
+
+    // Erase boot block: leading newline + 3 mark rows.
+    out.write('\x1b[4A');
+    for (let i = 0; i < 4; i++) out.write(CLEAR + (i < 3 ? '\n' : ''));
+    out.write('\x1b[3A\r');
+
+    for (const line of lines) {
+      write(line);
+      await sleep(line.trim() === '' ? 6 : 15);
+    }
+  } finally {
+    out.write(SHOW);
+  }
+}
+
+/** Copper horizontal rule (PCB-trace vibe). */
+export function traceRule(width = 32): string {
+  return copper('  ' + '─'.repeat(Math.max(8, Math.min(width, 48))));
+}
+
+/** Cascade lines (help / demo sections). Instant when animation is off. */
+export async function staggerWrite(
+  lines: string[],
+  write: (line: string) => void,
+  delayMs = 12,
+): Promise<void> {
+  if (!prefersAnimation()) {
+    for (const line of lines) write(line);
+    return;
+  }
+  for (const line of lines) {
+    write(line);
+    await sleep(delayMs);
+  }
+}
+
+/**
+ * Pulse the prompt chevron while idle. Returns stop(). No-op without animation.
+ */
+export function pulsePrompt(
+  out: NodeJS.WriteStream,
+  render: (phase: number) => string,
+): () => void {
+  if (!prefersAnimation()) return () => {};
+  let phase = 0;
+  const timer = setInterval(() => {
+    phase = (phase + 1) % 3;
+    out.write(CLEAR + render(phase) + SHOW);
+  }, 650);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}

--- a/src/agent/logo.ts
+++ b/src/agent/logo.ts
@@ -1,0 +1,49 @@
+/**
+ * Terminal lockup derived from the copperhead brand mark (PCB fiducial:
+ * circle + crosshairs) used on https://docs.copperhead.sh/ and
+ * docs/public/favicon.svg — copper `#b87333` on dark.
+ */
+
+import { copper, dim } from './theme.js';
+import { traceRule } from './animate.js';
+
+/** Narrow 3-line fiducial glyph (no wordmark). */
+export function fiducialLines(): string[] {
+  return [
+    '      │',
+    '  ────◯────',
+    '      │',
+  ].map((line) => copper(line));
+}
+
+/**
+ * Logo + wordmark lockup for REPL / attended startup.
+ * Falls back to a one-line wordmark when the terminal is very narrow.
+ */
+export function logoLockup(opts: {
+  version: string;
+  tagline?: string;
+  columns?: number;
+}): string[] {
+  const tag = opts.tagline ?? 'interactive shell';
+  const cols = opts.columns ?? process.stdout.columns ?? 80;
+
+  if (cols < 40) {
+    return [`${copper('copperhead')}  ${dim(`v${opts.version} · ${tag}`)}`, ''];
+  }
+
+  // Side-by-side: fiducial mark | wordmark + meta (matches docs lockup layout).
+  const mark = ['      │', '  ────◯────', '      │'];
+  const words = [
+    '',
+    `${copper('copperhead')}  ${dim(`v${opts.version}`)}`,
+    dim(tag),
+  ];
+
+  return [
+    '',
+    ...mark.map((m, i) => `${copper(m)}  ${words[i] ?? ''}`),
+    traceRule(34),
+    '',
+  ];
+}

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -11,6 +11,7 @@ import { loadConfig, CONFIG_DIR, type CopperheadConfig } from '../config.js';
 import { Transcript, type ExitPath, type RunStats } from './transcript.js';
 import { collectRunMeta, renderCliHeader, type RunMeta, type RunMetaInput } from './runmeta.js';
 import { plainRenderer, fmtDuration, fmtTokens, type ProgressRenderer } from './render.js';
+import { styleHeaderLines } from './theme.js';
 import { ObligationsLedger } from './ledger.js';
 import { gitPreflight, isDirty, snapshot, restore, commitAll, changedFiles, preserveFailedRun } from '../util/git.js';
 import { withRetry, isRateLimit, sessionLimit } from '../util/retry.js';
@@ -247,7 +248,7 @@ async function runWithMemory(
     interactive: opts.interactive ?? false,
     input: opts.meta,
   });
-  for (const line of renderCliHeader(meta)) log(line);
+  for (const line of styleHeaderLines(renderCliHeader(meta))) log(line);
   // Revisit obligations deferred while their artifact didn't exist re-open now
   // if it does (must run before loadConstraints so the prompt sees the updated
   // registry). They land in this run's fresh ledger, so finish gates on them.

--- a/src/agent/render.ts
+++ b/src/agent/render.ts
@@ -3,7 +3,12 @@
  * once at startup: interactive (TTY, no --json/--plain) pins a status line to
  * the bottom of the terminal and redraws it in place; plain emits line-oriented
  * output with zero ANSI escapes — the mode CI, pipes, and tests see.
+ *
+ * Interactive mode adds subtle SGR chrome (copper accent, dim secondary text).
+ * Plain mode never emits color (AC-8.9).
  */
+
+import { copper, dim, setColorEnabled, styleOutcome, toolLine, warn } from './theme.js';
 
 export interface ProgressRenderer {
   log(line: string): void;
@@ -106,20 +111,36 @@ export class InteractiveRenderer implements ProgressRenderer {
   }
 
   private statusText(): string {
-    const parts = [
-      `turn ${this.turn}/${this.maxTurns}`,
-      `${fmtTokens(this.tokensIn)} in / ${fmtTokens(this.tokensOut)} out`,
-      fmtDuration(Date.now() - this.startMs),
-    ];
+    const turn = `turn ${this.turn}/${this.maxTurns}`;
+    const tokens = dim(`${fmtTokens(this.tokensIn)} in / ${fmtTokens(this.tokensOut)} out`);
+    const elapsed = dim(fmtDuration(Date.now() - this.startMs));
+    const parts = [turn, tokens, elapsed];
     if (this.busy) {
       // Fold streamed-output volume into the busy segment so a large turn's
       // status line visibly grows — a hung one stays frozen (5.1).
-      parts.push(this.streamedChars ? `${this.busy} ~${fmtTokens(this.streamedChars)} ch` : this.busy);
+      const busy = this.streamedChars
+        ? `${this.busy} ~${fmtTokens(this.streamedChars)} ch`
+        : this.busy;
+      parts.push(warn(busy));
     }
-    const spinner = this.busy ? FRAMES[this.frame % FRAMES.length] : '·';
-    const line = `${spinner} ${parts.join(' · ')}`;
+    const spinner = this.busy ? copper(FRAMES[this.frame % FRAMES.length]!) : dim('·');
+    const line = `${spinner} ${parts.join(dim(' · '))}`;
+    // Truncate by visible length roughly: strip SGR when measuring so color
+    // codes don't eat the column budget and clip the readable text early.
     const width = this.out.columns ?? 80;
-    return line.length > width ? line.slice(0, width - 1) : line;
+    const visible = line.replace(/\x1b\[[0-9;]*m/g, '');
+    if (visible.length <= width) return line;
+    // Fall back to an uncolored truncated line when the terminal is too narrow.
+    const plain = [
+      this.busy ? FRAMES[this.frame % FRAMES.length]! : '·',
+      turn,
+      `${fmtTokens(this.tokensIn)} in / ${fmtTokens(this.tokensOut)} out`,
+      fmtDuration(Date.now() - this.startMs),
+      ...(this.busy
+        ? [this.streamedChars ? `${this.busy} ~${fmtTokens(this.streamedChars)} ch` : this.busy]
+        : []),
+    ].join(' · ');
+    return plain.length > width ? plain.slice(0, width - 1) : plain;
   }
 
   private redraw(): void {
@@ -162,7 +183,7 @@ export class InteractiveRenderer implements ProgressRenderer {
   }
 
   toolResult(name: string, firstLine: string): void {
-    this.log(`  [${name}] ${firstLine}`);
+    this.log(toolLine(name, firstLine));
   }
 
   status(text: string | null): void {
@@ -181,7 +202,7 @@ export class InteractiveRenderer implements ProgressRenderer {
 
   finish(line: string): void {
     if (this.statusShown) this.out.write(CLEAR_LINE);
-    this.out.write(line + '\n');
+    this.out.write(styleOutcome(line) + '\n');
     this.suspend();
   }
 
@@ -215,7 +236,10 @@ export class InteractiveRenderer implements ProgressRenderer {
  * (AC-2.4): the only thing a --json invocation writes to stdout is its JSON.
  */
 export function makeRenderer(opts: { json: boolean; plain: boolean }): ProgressRenderer {
+  const interactive = !opts.json && !opts.plain && Boolean(process.stdout.isTTY);
+  // Color tracks the interactive path so --plain / pipes stay zero-ANSI (AC-8.9).
+  setColorEnabled(interactive && !process.env.NO_COLOR);
   if (opts.json) return plainRenderer((line) => console.error(line));
-  if (!opts.plain && process.stdout.isTTY) return new InteractiveRenderer();
+  if (interactive) return new InteractiveRenderer();
   return plainRenderer((line) => console.log(line));
 }

--- a/src/agent/runmeta.ts
+++ b/src/agent/runmeta.ts
@@ -9,7 +9,7 @@ import type { CopperheadConfig, ModelSource } from '../config.js';
 
 /** Caller-supplied run identity: facts the loop cannot probe for itself. */
 export interface RunMetaInput {
-  command?: 'do' | 'create' | 'sync';
+  command?: 'do' | 'create' | 'sync' | 'repl';
   modelSource?: ModelSource;
   version?: string;
   kicadCliVersion?: string;
@@ -29,7 +29,7 @@ export interface RunMeta {
   modelSource: ModelSource | null;
   runId: string;
   startedAt: string;
-  command: 'do' | 'create' | 'sync' | null;
+  command: 'do' | 'create' | 'sync' | 'repl' | null;
   interactive: boolean;
   stage: { name: string; index: number; total: number } | null;
   brief: { path: string; sha256: string } | null;
@@ -150,14 +150,14 @@ export async function collectRunMeta(opts: CollectRunMetaOptions): Promise<RunMe
 
 const unk = (v: string | null | undefined): string => v ?? 'unknown';
 
-/** ≤ 2 lines, printed before the first turn (AC-8.4). */
+/** ≤ 2 lines, printed before the first turn (AC-8.4).
+ *  Live header stays compact: install path / platform live in summary.md only. */
 export function renderCliHeader(meta: RunMeta): string[] {
   const v = meta.versions;
   const line1 = [
-    `copperhead v${unk(v.copperhead)}${v.installPath ? ` (${v.installPath})` : ''}`,
+    `copperhead v${unk(v.copperhead)}`,
     `kicad-cli ${unk(v.kicadCli)}`,
     `node ${v.node}`,
-    v.platform,
   ].join(' · ');
 
   const repoState =
@@ -167,12 +167,11 @@ export function renderCliHeader(meta: RunMeta): string[] {
         ? `dirty(${meta.git.uncommittedFiles})`
         : 'clean';
   const line2 = [
-    `run ${meta.runId}`,
     unk(meta.command),
     ...(meta.stage ? [`stage ${meta.stage.name} (${meta.stage.index}/${meta.stage.total})`] : []),
     `model ${meta.model} (${meta.provider}, via ${unk(meta.modelSource)})`,
     `turns ≤${meta.config.maxTurns}`,
-    `repo ${unk(meta.git.branch)}@${meta.git.commit?.slice(0, 7) ?? 'unknown'} ${repoState}`,
+    `${unk(meta.git.branch)}@${meta.git.commit?.slice(0, 7) ?? 'unknown'} ${repoState}`,
   ].join(' · ');
   return [line1, line2];
 }

--- a/src/agent/theme.ts
+++ b/src/agent/theme.ts
@@ -1,0 +1,77 @@
+/**
+ * Subtle interactive-TTY chrome: muted hierarchy with a copper accent.
+ * Plain / --json / piped output must stay free of SGR (AC-8.9), so helpers
+ * no-op unless color has been explicitly enabled for this process.
+ */
+
+const ESC = '\x1b[';
+const RESET = `${ESC}0m`;
+
+/** True after makeRenderer selects the interactive path. */
+let colorEnabled = false;
+
+export function setColorEnabled(on: boolean): void {
+  colorEnabled = on;
+}
+
+export function isColorEnabled(): boolean {
+  return colorEnabled;
+}
+
+function paint(code: string, s: string): string {
+  if (!colorEnabled || s === '') return s;
+  return `${ESC}${code}m${s}${RESET}`;
+}
+
+/** Secondary metadata — dim gray. */
+export const dim = (s: string): string => paint('90', s);
+/** Brand / active accent — copper #b87333 ≈ 256-color 172. */
+export const copper = (s: string): string => paint('38;5;172', s);
+/** Success — PCB green. */
+export const ok = (s: string): string => paint('32', s);
+/** Busy / caution — amber. */
+export const warn = (s: string): string => paint('33', s);
+/** Failure. */
+export const err = (s: string): string => paint('31', s);
+
+/**
+ * Style a create-pipeline stage line. Keeps the `stage <name>:` prefix so
+ * existing log greps and operator muscle memory still work.
+ */
+export function stageLine(name: string, detail: string, kind: 'info' | 'ok' | 'warn' | 'err' = 'info'): string {
+  const label = dim(`stage ${name}:`);
+  const body =
+    kind === 'ok' ? ok(detail) : kind === 'warn' ? warn(detail) : kind === 'err' ? err(detail) : detail;
+  return `${label} ${body}`;
+}
+
+/** Tool-result scrollback line: short glyph + name + first line of result. */
+export function toolLine(name: string, firstLine: string): string {
+  const clean = /\b(clean|ok|pass(?:ed)?|success|done)\b/i.test(firstLine) && !/\b(fail|error|violat)/i.test(firstLine);
+  const glyph = clean ? ok('✓') : copper('▸');
+  return `  ${glyph} ${dim(name)}  ${firstLine}`;
+}
+
+/** Color the final outcome line from its exit-path token. */
+export function styleOutcome(line: string): string {
+  if (!colorEnabled) return line;
+  const head = line.split(' · ')[0] ?? line;
+  const rest = line.slice(head.length);
+  if (head === 'done') return ok(head) + dim(rest);
+  if (/refus|fail|error|exhaust|stall/i.test(head)) return err(head) + dim(rest);
+  return copper(head) + dim(rest);
+}
+
+/** Dim secondary segments of the two-line CLI header (brand stays copper). */
+export function styleHeaderLines(lines: string[]): string[] {
+  if (!colorEnabled) return lines;
+  return lines.map((line, i) => {
+    if (i === 0) {
+      // copperhead vX · rest…
+      const m = line.match(/^(copperhead v\S+)(.*)$/);
+      if (!m) return dim(line);
+      return copper(m[1]!) + dim(m[2]!);
+    }
+    return dim(line);
+  });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,8 @@ import { runInit, InitError } from './memory/scaffold.js';
 import { runCheck } from './commands/check.js';
 import { syncVerify, syncResolve, formatSyncReport } from './commands/sync.js';
 import { runCreate } from './commands/create.js';
+import { runDemo, demoTourText } from './commands/demo.js';
+import { runRepl } from './commands/repl.js';
 import {
   runExportBom,
   parseSupplier,
@@ -70,6 +72,52 @@ program
 
 const rendererOf = () =>
   makeRenderer({ json: Boolean(program.opts().json), plain: Boolean(program.opts().plain) });
+
+program
+  .command('repl', { isDefault: true })
+  .description('interactive agent shell (default when no command is given)')
+  .argument('[request...]', 'optional first change request before the prompt loop')
+  .option('--model <model>', 'codex | gpt-5 | claude | claude-code (or a provider-specific model id)')
+  .option('--max-turns <n>', 'turn budget per request')
+  .option('--interactive', 'pause for approval after each proposal validates')
+  .action(
+    async (
+      requestParts: string[],
+      opts: { model?: string; maxTurns?: string; interactive?: boolean },
+    ) => {
+      const repo = repoOf(program.opts());
+      if (program.opts().json) {
+        console.error(
+          'copperhead: --json is not supported with the interactive shell. Use `copperhead do "<request>" --json`.',
+        );
+        process.exit(1);
+      }
+      try {
+        const kicadVer = await kicadCliVersion();
+        const config = await loadConfig(repo);
+        const { model, source } = resolveModel(opts.model, config);
+        const continuePrompt = budgetContinuePrompt();
+        const seed = requestParts.length ? requestParts.join(' ') : undefined;
+        const res = await runRepl({
+          repoRoot: repo,
+          model,
+          modelSource: source,
+          version,
+          kicadCliVersion: kicadVer,
+          ...(opts.maxTurns ? { maxTurns: parseInt(opts.maxTurns, 10) } : {}),
+          interactive: opts.interactive ?? false,
+          ...(seed ? { seed } : {}),
+          confirm: confirmTty,
+          ...(continuePrompt ? { onBudgetExhausted: continuePrompt } : {}),
+          renderer: rendererOf(),
+        });
+        process.exit(res.ok ? 0 : 1);
+      } catch (err) {
+        console.error((err as Error).message);
+        process.exit(1);
+      }
+    },
+  );
 
 program
   .command('init')
@@ -191,6 +239,46 @@ program
       const res = await syncResolve(repo, report, model, json ? () => {} : (s) => console.log(s), {
         renderer: rendererOf(),
         meta: { command: 'sync', modelSource: source, version, kicadCliVersion: kicadVer },
+      });
+      process.exit(res.ok ? 0 : 1);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('demo')
+  .description('tour of what copperhead does, or run the USB-C breakout create pipeline')
+  .option('--model <model>', 'codex | cursor | gpt-5 | claude | claude-code (or a provider-specific model id)')
+  .option('--interactive', 're-enable the human gates (spec approval, pre-export)')
+  .option('--dir <path>', 'demo repo directory (default: demo-runs/usb-c-breakout)')
+  .option('--tour', 'print the overview only; do not run the pipeline')
+  .action(async (opts: { model?: string; interactive?: boolean; dir?: string; tour?: boolean }) => {
+    if (opts.tour) {
+      // Color on for attended TTY tours even without a renderer.
+      const { setColorEnabled } = await import('./agent/theme.js');
+      setColorEnabled(Boolean(process.stdout.isTTY) && !program.opts().plain && !process.env.NO_COLOR);
+      console.log(demoTourText());
+      process.exit(0);
+    }
+    try {
+      const kicadVer = await kicadCliVersion();
+      // Resolve model from the caller's cwd config / env / flag; the demo repo
+      // is scaffolded next and typically has no model of its own yet.
+      const config = await loadConfig(repoOf(program.opts()));
+      const { model, source } = resolveModel(opts.model, config);
+      const continuePrompt = budgetContinuePrompt();
+      const res = await runDemo({
+        model,
+        modelSource: source,
+        version,
+        kicadCliVersion: kicadVer,
+        interactive: opts.interactive ?? false,
+        ...(opts.dir ? { demoDir: opts.dir } : {}),
+        ...(continuePrompt ? { onBudgetExhausted: continuePrompt } : {}),
+        log: (s) => console.log(s),
+        renderer: rendererOf(),
       });
       process.exit(res.ok ? 0 : 1);
     } catch (err) {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -14,6 +14,7 @@ import { diagnoseStageFailure, transcriptExcerpt, withTimeout, type StageDiagnos
 import type { Provider } from '../agent/types.js';
 import type { RunMetaInput } from '../agent/runmeta.js';
 import { fmtDuration, fmtTokens, type ProgressRenderer } from '../agent/render.js';
+import { copper, dim, ok, stageLine, warn } from '../agent/theme.js';
 import { openspecInit } from '../openspec/cli.js';
 import { sweepStaleTempDirs, pruneHistoryDir } from '../util/tmp.js';
 import { assertDiskSpace, DEFAULT_MIN_FREE_BYTES } from '../util/preflight.js';
@@ -161,7 +162,7 @@ export interface CreateOptions {
 async function emitJlcpcbAfterOutputs(stageName: string, opts: CreateOptions): Promise<void> {
   if (stageName !== 'outputs') return;
   const out = await emitCreateJlcpcbBom(opts.repoRoot);
-  if (out) opts.log(`stage outputs: emitted ${out} (JLCPCB assembly BOM)`);
+  if (out) opts.log(stageLine('outputs', `emitted ${out} (JLCPCB assembly BOM)`, 'ok'));
 }
 
 /** Stages whose output is a KiCad file worth rendering to an image (5.4). */
@@ -203,16 +204,26 @@ async function commitResumedStage(opts: CreateOptions, config: CopperheadConfig,
   const foreign = dirty.filter((f) => !isManagedPath(f, config));
   if (foreign.length) {
     opts.log(
-      `stage ${stageName}: already-complete work is uncommitted, but the tree also has non-copperhead changes ` +
-        `(${foreign.slice(0, 3).join(', ')}${foreign.length > 3 ? ', …' : ''}); leaving it uncommitted so nothing of yours is swept up`,
+      stageLine(
+        stageName,
+        `already-complete work is uncommitted, but the tree also has non-copperhead changes ` +
+          `(${foreign.slice(0, 3).join(', ')}${foreign.length > 3 ? ', …' : ''}); leaving it uncommitted so nothing of yours is swept up`,
+        'warn',
+      ),
     );
     return;
   }
   try {
     const sha = await commitAll(opts.repoRoot, `copperhead: resume — commit completed stage ${stageName}`);
-    opts.log(`stage ${stageName}: committed already-complete work ${sha.slice(0, 10)} so a later rollback cannot wipe it (2.4)`);
-  } catch (err) {
-    opts.log(`stage ${stageName}: could not commit resumed work (${(err as Error).message})`);
+    opts.log(
+      stageLine(
+        stageName,
+        `committed already-complete work ${sha.slice(0, 10)} so a later rollback cannot wipe it (2.4)`,
+        'ok',
+      ),
+    );
+  } catch (e) {
+    opts.log(stageLine(stageName, `could not commit resumed work (${(e as Error).message})`, 'err'));
   }
 }
 
@@ -243,12 +254,18 @@ async function renderStageArtifacts(opts: CreateOptions, stageName: string, tran
     try {
       await exportSvg(kind, path.join(opts.repoRoot, file), artifactsDir);
       rendered++;
-    } catch (err) {
-      opts.log(`stage ${stageName}: could not render ${kind} SVG (${(err as Error).message})`);
+    } catch (e) {
+      opts.log(stageLine(stageName, `could not render ${kind} SVG (${(e as Error).message})`, 'warn'));
     }
   }
   if (rendered) {
-    opts.log(`stage ${stageName}: rendered ${rendered} SVG artifact(s) into ${path.relative(opts.repoRoot, artifactsDir)}/`);
+    opts.log(
+      stageLine(
+        stageName,
+        `rendered ${rendered} SVG artifact(s) into ${path.relative(opts.repoRoot, artifactsDir)}/`,
+        'ok',
+      ),
+    );
   }
 }
 
@@ -331,10 +348,14 @@ function resumeCommand(opts: CreateOptions): string {
  */
 function logResumePoint(opts: CreateOptions, stage: Stage, index: number): void {
   opts.log('');
-  opts.log(`⏸  stopped at stage ${index + 1}/${STAGES.length} (${stage.name}). To resume from here, run:`);
-  opts.log(`     ${resumeCommand(opts)}`);
   opts.log(
-    `   (${index} stage(s) already complete are detected from repo state and skipped; it resumes at ${stage.name}.)`,
+    warn(`⏸  stopped at stage ${index + 1}/${STAGES.length} (${stage.name}). To resume from here, run:`),
+  );
+  opts.log(copper(`     ${resumeCommand(opts)}`));
+  opts.log(
+    dim(
+      `   (${index} stage(s) already complete are detected from repo state and skipped; it resumes at ${stage.name}.)`,
+    ),
   );
 }
 
@@ -380,14 +401,19 @@ function printCostTable(opts: CreateOptions, costs: StageCost[]): void {
     `  ${r.stage.padEnd(w.stage)}  ${r.wall.padStart(w.wall)}  ${r.turns.padStart(w.turns)}  ${r.out.padStart(w.out)}  ${r.cache.padStart(w.cache)}`;
   const rule = `  ${'-'.repeat(w.stage)}  ${'-'.repeat(w.wall)}  ${'-'.repeat(w.turns)}  ${'-'.repeat(w.out)}  ${'-'.repeat(w.cache)}`;
   opts.log('');
-  opts.log('Per-stage cost summary (5.2):');
-  opts.log(line(header));
-  opts.log(rule);
+  opts.log(copper('Per-stage cost summary'));
+  opts.log(dim(line(header)));
+  opts.log(dim(rule));
   for (const r of rows) opts.log(line(r));
   if (total) {
-    opts.log(rule);
-    opts.log(line(total));
+    opts.log(dim(rule));
+    opts.log(boldTotal(line(total)));
   }
+}
+
+function boldTotal(s: string): string {
+  // TOTAL row: keep digits readable, accent only the label when color is on.
+  return s.replace(/^(\s*)TOTAL/, (_, sp: string) => `${sp}${copper('TOTAL')}`);
 }
 
 /** Sum the cost of the stages that actually ran this invocation (resumed stages
@@ -422,8 +448,10 @@ function logCumulative(opts: CreateOptions, stageCosts: StageCost[]): void {
   const t = ranTotals(stageCosts);
   if (!t.turns && !t.wallMs) return; // nothing has actually run yet (all resumed)
   opts.log(
-    `pipeline so far: ${stageCosts.length}/${STAGES.length} stages · ${fmtDuration(t.wallMs)} · ` +
-      `${fmtTokens(t.tokensOut)} out tokens · ${cachePct(t.cacheHits, t.turns)}% cache hits`,
+    dim(
+      `pipeline so far: ${stageCosts.length}/${STAGES.length} stages · ${fmtDuration(t.wallMs)} · ` +
+        `${fmtTokens(t.tokensOut)} out tokens · ${cachePct(t.cacheHits, t.turns)}% cache hits`,
+    ),
   );
 }
 
@@ -533,11 +561,11 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
   // so a concurrent run's fresh dirs are never touched; best-effort, so it never
   // blocks a run (I8).
   const swept = await sweepStaleTempDirs(Date.now());
-  if (swept.length) opts.log(`startup: reclaimed ${swept.length} stale temp dir(s) from earlier runs`);
+  if (swept.length) opts.log(dim(`startup: reclaimed ${swept.length} stale temp dir(s) from earlier runs`));
   // Cap the gitignored .history/ so KiCad local history cannot grow unbounded
   // across a long run and fill the disk (4.1, I8). Best-effort; keeps the newest.
   const pruned = await pruneHistoryDir(opts.repoRoot);
-  if (pruned) opts.log(`startup: pruned ${pruned} old .history/ entrie(s) to cap local-history growth`);
+  if (pruned) opts.log(dim(`startup: pruned ${pruned} old .history/ entrie(s) to cap local-history growth`));
   await openspecInit(opts.repoRoot);
   const completed: string[] = [];
   const stageCosts: StageCost[] = [];
@@ -550,10 +578,12 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
     // contract can eventually be met. No-op once a project exists.
     if (stage.name === 'schematic') {
       const created = await bootstrapKicadProject(opts.repoRoot, brief);
-      if (created) opts.log(`stage schematic: scaffolded empty KiCad project (${created} + board + project), wired into config`);
+      if (created) {
+        opts.log(stageLine('schematic', `scaffolded empty KiCad project (${created} + board + project), wired into config`));
+      }
     }
     if (await stage.isComplete(opts.repoRoot, config.docs)) {
-      opts.log(`stage ${stage.name}: already complete (resuming past it)`);
+      opts.log(stageLine(stage.name, 'already complete (resuming past it)', 'ok'));
       await commitResumedStage(opts, config, stage.name);
       completed.push(stage.name);
       stageCosts.push({ name: stage.name, resumed: true, wallMs: 0, turns: 0, tokensIn: 0, tokensOut: 0, cacheHits: 0 });
@@ -585,9 +615,16 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
       // whenever the project already exists.
       if (stage.name === 'schematic') {
         const rescaffolded = await bootstrapKicadProject(opts.repoRoot, brief);
-        if (rescaffolded && attempt > 1) opts.log(`stage schematic: re-scaffolded empty KiCad project after rollback, wired into config`);
+        if (rescaffolded && attempt > 1) {
+          opts.log(stageLine('schematic', 're-scaffolded empty KiCad project after rollback, wired into config'));
+        }
       }
-      opts.log(`stage ${stage.name}: running${attempt > 1 ? ` (attempt ${attempt}/${config.maxStageRetries + 1})` : ''}`);
+      opts.log(
+        stageLine(
+          stage.name,
+          `running${attempt > 1 ? ` (attempt ${attempt}/${config.maxStageRetries + 1})` : ''}`,
+        ),
+      );
       const res = await runAgentLoop({
         repoRoot: opts.repoRoot,
         model: opts.model,
@@ -635,12 +672,16 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
 
       if (attempt > config.maxStageRetries) {
         opts.log(
-          `stage ${stage.name}: ${failure}; exhausted ${config.maxStageRetries} auto-retry(ies). Stopping for a human.`,
+          stageLine(
+            stage.name,
+            `${failure}; exhausted ${config.maxStageRetries} auto-retry(ies). Stopping for a human.`,
+            'err',
+          ),
         );
         break;
       }
 
-      opts.log(`stage ${stage.name}: ${failure}; asking the model whether to retry…`);
+      opts.log(stageLine(stage.name, `${failure}; asking the model whether to retry…`, 'warn'));
       const diagnosis = await diagnose({
         model: opts.model,
         timeoutMs: config.turnTimeoutMs,
@@ -656,9 +697,15 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
       // not under-report by omitting it.
       cost.tokensIn += diagnosis.usage?.inputTokens ?? 0;
       cost.tokensOut += diagnosis.usage?.outputTokens ?? 0;
-      opts.log(`stage ${stage.name}: diagnosis → ${diagnosis.verdict} — ${diagnosis.reason}`);
+      opts.log(
+        stageLine(
+          stage.name,
+          `diagnosis → ${diagnosis.verdict} — ${diagnosis.reason}`,
+          diagnosis.verdict === 'abort' ? 'err' : 'warn',
+        ),
+      );
       if (diagnosis.verdict === 'abort') {
-        opts.log(`stage ${stage.name}: recovery supervisor recommends stopping for a human.`);
+        opts.log(stageLine(stage.name, 'recovery supervisor recommends stopping for a human.', 'err'));
         break;
       }
       guidance = diagnosis.guidance ?? `The previous attempt failed: ${failure}. ${diagnosis.reason}`;
@@ -680,7 +727,11 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
   }
 
   const check = await runCheck(opts.repoRoot, opts.log);
-  opts.log(check.ok ? 'create pipeline complete; all checks green' : 'create pipeline complete with check failures');
+  opts.log(
+    check.ok
+      ? ok('create pipeline complete; all checks green')
+      : warn('create pipeline complete with check failures'),
+  );
   printCostTable(opts, stageCosts);
   await writeRunReport(opts, stageCosts);
   return { ok: check.ok, completed };

--- a/src/commands/demo.ts
+++ b/src/commands/demo.ts
@@ -1,0 +1,168 @@
+/**
+ * End-to-end demo: scaffold a tiny git repo and run `create` against the
+ * USB-C power breakout brief (same path as `npm run demo:simple`).
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+import { mkdir, writeFile, readFile, appendFile } from 'node:fs/promises';
+import { execa } from 'execa';
+import type { ProgressRenderer } from '../agent/render.js';
+import type { RunMetaInput } from '../agent/runmeta.js';
+import type { BudgetExhaustedStats } from '../agent/loop.js';
+import { copper, dim, ok } from '../agent/theme.js';
+import { traceRule } from '../agent/animate.js';
+import { shortPath } from '../util/paths.js';
+import { runCreate } from './create.js';
+
+const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const DEFAULT_BRIEF = path.join(PKG_ROOT, 'examples/simple/usb-c-breakout.md');
+const DEFAULT_DEMO_DIR = path.join(PKG_ROOT, 'demo-runs/usb-c-breakout');
+
+export interface DemoOptions {
+  model: string;
+  modelSource: RunMetaInput['modelSource'];
+  version: string;
+  kicadCliVersion: string;
+  interactive?: boolean;
+  /** Override demo repo (defaults to demo-runs/usb-c-breakout or COPPERHEAD_DEMO_DIR). */
+  demoDir?: string;
+  briefPath?: string;
+  log?: (line: string) => void;
+  renderer: ProgressRenderer;
+  onBudgetExhausted?: (stats: BudgetExhaustedStats) => Promise<number>;
+}
+
+/** Resolve the packaged USB-C brief; throws a clear error if the install is incomplete. */
+export function defaultBriefPath(): string {
+  if (!existsSync(DEFAULT_BRIEF)) {
+    throw new Error(
+      `demo brief missing at ${DEFAULT_BRIEF}; reinstall copperhead or run from a full checkout`,
+    );
+  }
+  return DEFAULT_BRIEF;
+}
+
+export function defaultDemoDir(): string {
+  return process.env.COPPERHEAD_DEMO_DIR ?? DEFAULT_DEMO_DIR;
+}
+
+/**
+ * Prepare a clean-enough git repo for the create pipeline (git init, ignore
+ * runs/, baseline config + commit). Mirrors scripts/demo-simple.sh.
+ */
+export async function scaffoldDemoRepo(demoDir: string): Promise<void> {
+  await mkdir(demoDir, { recursive: true });
+
+  const git = async (...args: string[]) => execa('git', args, { cwd: demoDir });
+
+  if (!existsSync(path.join(demoDir, '.git'))) {
+    await git('init', '-q');
+  }
+
+  const hasName = await execa('git', ['config', 'user.name'], { cwd: demoDir, reject: false });
+  if (hasName.exitCode !== 0) await git('config', 'user.name', 'copperhead demo');
+  const hasEmail = await execa('git', ['config', 'user.email'], { cwd: demoDir, reject: false });
+  if (hasEmail.exitCode !== 0) await git('config', 'user.email', 'demo@copperhead.local');
+
+  const gi = path.join(demoDir, '.gitignore');
+  if (!existsSync(gi)) await writeFile(gi, '', 'utf8');
+  const giText = await readFile(gi, 'utf8');
+  if (!giText.split('\n').includes('.copperhead/runs/')) {
+    await appendFile(gi, (giText.endsWith('\n') || giText === '' ? '' : '\n') + '.copperhead/runs/\n');
+  }
+
+  const cfgDir = path.join(demoDir, '.copperhead');
+  await mkdir(cfgDir, { recursive: true });
+  const cfg = path.join(cfgDir, 'config.json');
+  if (!existsSync(cfg)) {
+    // Create stages need a larger turn budget than a single `do` edit.
+    await writeFile(
+      cfg,
+      `${JSON.stringify({ docs: 'docs/', maxTurns: 100, maxRepairCycles: 5 }, null, 2)}\n`,
+      'utf8',
+    );
+  }
+
+  await git('add', '.gitignore', '.copperhead/config.json');
+  const head = await execa('git', ['rev-parse', '--verify', 'HEAD'], { cwd: demoDir, reject: false });
+  if (head.exitCode !== 0) {
+    await git('commit', '-q', '-m', 'demo: initialize repository');
+  } else {
+    const staged = await execa('git', ['diff', '--cached', '--quiet'], { cwd: demoDir, reject: false });
+    if (staged.exitCode !== 0) {
+      await git('commit', '-q', '-m', 'demo: update demo scaffolding');
+    }
+  }
+}
+
+/** What copperhead is — printed by `/demo` and `copperhead demo --tour`. */
+export function demoTourText(): string {
+  return [
+    '',
+    copper('  What copperhead does'),
+    traceRule(28),
+    '',
+    dim('  Cursor for circuit boards. You describe a change; the agent edits'),
+    dim('  real KiCad files, keeps design docs in sync, and verifies with'),
+    dim('  kicad-cli ERC/DRC before anything is committed.'),
+    '',
+    copper('  The loop'),
+    traceRule(16),
+    '',
+    `  ${copper('1.')} ${dim('Propose')}   write an OpenSpec change (edit tools stay locked until it validates)`,
+    `  ${copper('2.')} ${dim('Edit')}      anchored edits to .kicad_sch / .kicad_pcb + docs`,
+    `  ${copper('3.')} ${dim('Verify')}    run ERC (and DRC if the board changed); repair or roll back`,
+    `  ${copper('4.')} ${dim('Remember')}  DECISIONS.md + CHANGELOG + a run summary next to the transcript`,
+    '',
+    copper('  Try it'),
+    traceRule(14),
+    '',
+    `  ${copper('copperhead demo')}              ${dim('full create pipeline (USB-C breakout)')}`,
+    `  ${copper('copperhead')}                   ${dim('interactive shell — type a change request')}`,
+    `  ${copper('copperhead do "add an LED"')}    ${dim('one-shot edit on the current repo')}`,
+    '',
+    copper('  Example prompts'),
+    traceRule(22),
+    '',
+    dim('  • add reverse-polarity protection on VIN'),
+    dim('  • rename net KEY_DAH to KEY_DASH'),
+    dim('  • move the key input to a different RTC-capable pin'),
+    '',
+  ].join('\n');
+}
+
+export async function runDemo(opts: DemoOptions): Promise<{ ok: boolean; demoDir: string }> {
+  const log = opts.log ?? ((l: string) => console.log(l));
+  const demoDir = path.resolve(opts.demoDir ?? defaultDemoDir());
+  const briefPath = path.resolve(opts.briefPath ?? defaultBriefPath());
+
+  log('');
+  log(`  ${copper('copperhead demo')}  ${dim('USB-C power breakout')}`);
+  log(`  ${dim('repo')}   ${shortPath(demoDir)}`);
+  log(`  ${dim('brief')}  ${shortPath(briefPath)}`);
+  log('');
+
+  await scaffoldDemoRepo(demoDir);
+  log(ok('  scaffold ready'));
+  log('');
+
+  const res = await runCreate({
+    repoRoot: demoDir,
+    briefPath,
+    model: opts.model,
+    interactive: opts.interactive ?? false,
+    ...(opts.onBudgetExhausted ? { onBudgetExhausted: opts.onBudgetExhausted } : {}),
+    log,
+    renderer: opts.renderer,
+    meta: {
+      command: 'create',
+      modelSource: opts.modelSource,
+      version: opts.version,
+      kicadCliVersion: opts.kicadCliVersion,
+    },
+  });
+
+  return { ok: res.ok, demoDir };
+}

--- a/src/commands/repl-inspect.ts
+++ b/src/commands/repl-inspect.ts
@@ -1,0 +1,353 @@
+/**
+ * Read-only inspect helpers for REPL slash commands (/sync, /config, /runs…).
+ * All deterministic, no LLM.
+ */
+
+import path from 'node:path';
+import { existsSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import { execa } from 'execa';
+import { loadConfig } from '../config.js';
+import { checkDrift } from '../memory/drift.js';
+import { loadConstraints } from '../memory/constraints.js';
+import { parseBomTable } from '../memory/bom-table.js';
+import { syncVerify, formatSyncReport } from './sync.js';
+import { listSymbols, listNets, pinNets } from '../kicad/sexp.js';
+import { openspecValidate } from '../openspec/cli.js';
+import { copper, dim, ok, warn, err } from '../agent/theme.js';
+import { traceRule } from '../agent/animate.js';
+import { shortPath } from '../util/paths.js';
+import { branchName, headCommit, isDirty, isGitRepo, uncommittedCount } from '../util/git.js';
+
+function meta(label: string, value: string): string {
+  return `  ${dim(label.padEnd(12))} ${value}`;
+}
+
+async function sortedRunIds(repoRoot: string): Promise<string[]> {
+  const runsDir = path.join(repoRoot, '.copperhead', 'runs');
+  if (!existsSync(runsDir)) return [];
+  return (await readdir(runsDir, { withFileTypes: true }))
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort()
+    .reverse();
+}
+
+async function resolveSchematic(
+  repoRoot: string,
+): Promise<{ schPath: string } | { message: string }> {
+  const config = await loadConfig(repoRoot);
+  if (!config.schematic) {
+    return { message: 'no schematic configured (run copperhead init)' };
+  }
+  const schPath = path.join(repoRoot, config.schematic);
+  if (!existsSync(schPath)) {
+    return { message: `schematic missing: ${config.schematic}` };
+  }
+  return { schPath };
+}
+
+/** `/sync` — verify-only inconsistency report (never auto-resolves). */
+export async function formatSyncInspect(repoRoot: string): Promise<string> {
+  const report = await syncVerify(repoRoot);
+  const body = formatSyncReport(report);
+  const headline =
+    !report.resolvable.length && !report.violations.length
+      ? ok('  sync: clean')
+      : report.violations.length
+        ? err(`  sync: ${report.violations.length} requirement violation(s), ${report.resolvable.length} resolvable`)
+        : warn(`  sync: ${report.resolvable.length} resolvable inconsistency(ies)`);
+  return ['', copper('  Sync'), traceRule(12), '', headline, '', ...body.split('\n').map((l) => `  ${l}`), ''].join(
+    '\n',
+  );
+}
+
+/** `/config` — full resolved config view. */
+export async function formatConfigInspect(repoRoot: string): Promise<string> {
+  const c = await loadConfig(repoRoot);
+  const lines = [
+    '',
+    copper('  Config'),
+    traceRule(14),
+    '',
+    meta('schematic', c.schematic ?? dim('null')),
+    meta('board', c.board ?? dim('null')),
+    meta('docs', c.docs),
+    meta('model', c.model ?? dim('null (use --model / env)')),
+    meta('maxTurns', String(c.maxTurns)),
+    meta('repair', String(c.maxRepairCycles)),
+    meta('origin', c.origin ?? dim('unset')),
+    meta('llmCache', c.llmCache ? 'on' : 'off'),
+    meta('budgets', Object.keys(c.budgets).length ? JSON.stringify(c.budgets) : dim('{}')),
+  ];
+  if (c.stageMaxTurns && Object.keys(c.stageMaxTurns).length) {
+    lines.push(meta('stageTurns', JSON.stringify(c.stageMaxTurns)));
+  }
+  lines.push('');
+  lines.push(dim(`  file  ${shortPath(path.join(repoRoot, '.copperhead/config.json'))}`));
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** `/git` — porcelain status + branch tip. */
+export async function formatGitInspect(repoRoot: string): Promise<string> {
+  if (!(await isGitRepo(repoRoot))) {
+    return ['', warn('  git: not a repository'), ''].join('\n');
+  }
+  const [branch, commit, dirty, n, porcelain] = await Promise.all([
+    branchName(repoRoot).catch(() => 'unknown'),
+    headCommit(repoRoot).catch(() => 'unknown'),
+    isDirty(repoRoot).catch(() => null),
+    uncommittedCount(repoRoot).catch(() => null),
+    execa('git', ['status', '--porcelain'], { cwd: repoRoot }).then((r) =>
+      r.stdout ? r.stdout.split('\n').filter(Boolean) : [],
+    ),
+  ]);
+  const state =
+    dirty === null ? 'unknown' : dirty ? warn(`dirty (${n ?? '?'} file(s))`) : ok('clean');
+  const lines = [
+    '',
+    copper('  Git'),
+    traceRule(10),
+    '',
+    meta('branch', `${branch}@${commit.slice(0, 7)}`),
+    meta('state', state),
+    '',
+  ];
+  if (porcelain.length) {
+    lines.push(dim('  changes:'));
+    for (const row of porcelain.slice(0, 40)) lines.push(`  ${row}`);
+    if (porcelain.length > 40) lines.push(dim(`  … and ${porcelain.length - 40} more`));
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+/** `/drift` — doc↔schematic only (no ERC/DRC). */
+export async function formatDriftInspect(repoRoot: string): Promise<string> {
+  const config = await loadConfig(repoRoot);
+  if (!config.schematic) {
+    return ['', warn('  drift: no schematic configured (run copperhead init)'), ''].join('\n');
+  }
+  const mismatches = await checkDrift(repoRoot, config.docs, config.schematic);
+  if (!mismatches.length) {
+    return ['', ok('  drift: docs match schematic'), ''].join('\n');
+  }
+  const lines = [
+    '',
+    copper('  Drift'),
+    traceRule(12),
+    '',
+    warn(`  ${mismatches.length} mismatch(es):`),
+    '',
+  ];
+  for (const m of mismatches.slice(0, 30)) {
+    lines.push(`  ${copper('▸')} ${m.doc}`);
+    lines.push(dim(`      claim   ${m.claim}`));
+    lines.push(dim(`      actual  ${m.actual}`));
+  }
+  if (mismatches.length > 30) lines.push(dim(`  … and ${mismatches.length - 30} more`));
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** `/constraints` — registry summary. */
+export async function formatConstraintsInspect(repoRoot: string): Promise<string> {
+  const registry = await loadConstraints(repoRoot);
+  const keys = Object.keys(registry).sort();
+  if (!keys.length) {
+    return ['', dim('  constraints: none recorded yet'), ''].join('\n');
+  }
+  const lines = [
+    '',
+    copper('  Constraints'),
+    traceRule(20),
+    '',
+    dim(`  ${keys.length} open constraint(s)`),
+    '',
+  ];
+  for (const key of keys.slice(0, 40)) {
+    const c = registry[key]!;
+    const bound =
+      c.value !== undefined
+        ? String(c.value)
+        : [c.min !== undefined ? `min ${c.min}` : '', c.max !== undefined ? `max ${c.max}` : '']
+            .filter(Boolean)
+            .join(', ') || (c.forbidden?.length ? `forbidden ${c.forbidden.join(',')}` : '—');
+    lines.push(`  ${copper(key)}  ${bound}`);
+    lines.push(dim(`    source ${c.source} · affects ${c.affects.join(', ') || '—'}`));
+  }
+  if (keys.length > 40) lines.push(dim(`  … and ${keys.length - 40} more`));
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** `/runs` — recent `.copperhead/runs/` summaries. */
+export async function formatRunsInspect(repoRoot: string): Promise<string> {
+  const runsDir = path.join(repoRoot, '.copperhead', 'runs');
+  const entries = await sortedRunIds(repoRoot);
+  if (!entries.length) {
+    return ['', dim('  runs: none yet'), ''].join('\n');
+  }
+
+  const lines = ['', copper('  Recent runs'), traceRule(18), ''];
+  for (const id of entries.slice(0, 12)) {
+    const summaryPath = path.join(runsDir, id, 'summary.md');
+    const reportPath = path.join(runsDir, id, 'REPORT.md');
+    let outcome = dim('unknown');
+    if (existsSync(summaryPath)) {
+      const text = await readFile(summaryPath, 'utf8');
+      const m =
+        text.match(/exitPath[:\s*`]+([a-z-]+)/i) ||
+        text.match(/\*\*Exit(?:\s*path)?:\*\*\s*`?([a-z-]+)/i) ||
+        text.match(/## Run stats[\s\S]*?`([a-z-]+)`/);
+      if (m?.[1]) {
+        const pathName = m[1];
+        outcome =
+          pathName === 'done' ? ok(pathName) : /fail|error|refus|exhaust|stall/i.test(pathName) ? err(pathName) : warn(pathName);
+      } else if (/## Run stats/i.test(text)) {
+        outcome = dim('recorded');
+      }
+    }
+    const extras = existsSync(reportPath) ? dim(' · report') : '';
+    lines.push(`  ${copper(id)}  ${outcome}${extras}`);
+  }
+  if (entries.length > 12) lines.push(dim(`  … and ${entries.length - 12} older`));
+  lines.push('');
+  lines.push(dim(`  dir  ${shortPath(runsDir)}`));
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** `/parts` — schematic symbol table (refdes / value / footprint). */
+export async function formatPartsInspect(repoRoot: string): Promise<string> {
+  const resolved = await resolveSchematic(repoRoot);
+  if ('message' in resolved) {
+    return ['', warn(`  parts: ${resolved.message}`), ''].join('\n');
+  }
+  const syms = await listSymbols(resolved.schPath);
+  if (!syms.length) {
+    return ['', dim('  parts: schematic has no components'), ''].join('\n');
+  }
+  const refW = Math.max(4, ...syms.map((s) => s.ref.length));
+  const valW = Math.min(24, Math.max(5, ...syms.map((s) => s.value.length)));
+  const lines = [
+    '',
+    copper('  Parts'),
+    traceRule(12),
+    '',
+    dim(`  ${'ref'.padEnd(refW)}  ${'value'.padEnd(valW)}  footprint`),
+    '',
+  ];
+  for (const s of syms.slice(0, 60)) {
+    const val = s.value.length > valW ? s.value.slice(0, valW - 1) + '…' : s.value;
+    lines.push(`  ${copper(s.ref.padEnd(refW))}  ${val.padEnd(valW)}  ${dim(s.footprint || '—')}`);
+  }
+  if (syms.length > 60) lines.push(dim(`  … and ${syms.length - 60} more`));
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** `/nets` — net names and pin attachments from the schematic. */
+export async function formatNetsInspect(repoRoot: string): Promise<string> {
+  const resolved = await resolveSchematic(repoRoot);
+  if ('message' in resolved) {
+    return ['', warn(`  nets: ${resolved.message}`), ''].join('\n');
+  }
+  const [names, pins] = await Promise.all([listNets(resolved.schPath), pinNets(resolved.schPath)]);
+  const byNet = new Map<string, string[]>();
+  for (const p of pins) {
+    const net = p.net ?? '(unconnected)';
+    const tag = p.pinName ? `${p.ref}.${p.pinName}` : `${p.ref}:${p.pinNumber}`;
+    const list = byNet.get(net) ?? [];
+    list.push(tag);
+    byNet.set(net, list);
+  }
+  const ordered = [...new Set([...names, ...byNet.keys()])].sort((a, b) => {
+    if (a === '(unconnected)') return 1;
+    if (b === '(unconnected)') return -1;
+    return a.localeCompare(b);
+  });
+  const lines = ['', copper('  Nets'), traceRule(10), '', dim(`  ${ordered.length} net(s)`), ''];
+  for (const net of ordered.slice(0, 40)) {
+    const attached = (byNet.get(net) ?? []).sort();
+    const preview = attached.slice(0, 8).join(', ');
+    const extra = attached.length > 8 ? dim(` +${attached.length - 8}`) : '';
+    lines.push(`  ${copper(net)}  ${dim(preview)}${extra}`);
+  }
+  if (ordered.length > 40) lines.push(dim(`  … and ${ordered.length - 40} more`));
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** `/bom` — parsed docs/BOM.md (inspect only; no export). */
+export async function formatBomInspect(repoRoot: string): Promise<string> {
+  const config = await loadConfig(repoRoot);
+  const bomPath = path.join(repoRoot, config.docs, 'BOM.md');
+  if (!existsSync(bomPath)) {
+    return ['', warn('  bom: docs/BOM.md not found'), ''].join('\n');
+  }
+  const rows = parseBomTable(await readFile(bomPath, 'utf8'));
+  if (!rows.length) {
+    return ['', dim('  bom: no parseable rows in BOM.md'), ''].join('\n');
+  }
+  const refW = Math.max(5, ...rows.map((r) => r.refdes.length));
+  const lines = ['', copper('  BOM'), traceRule(8), '', dim(`  ${rows.length} row(s) from ${shortPath(bomPath)}`), ''];
+  for (const r of rows.slice(0, 50)) {
+    const flags = r.flags.length ? dim(` [${r.flags.join(',')}]`) : '';
+    lines.push(
+      `  ${copper(r.refdes.padEnd(refW))}  ${r.value ?? '—'}  ${dim(r.footprint ?? '')}${flags}`,
+    );
+    if (r.mpn) lines.push(dim(`    mpn ${r.mpn}`));
+  }
+  if (rows.length > 50) lines.push(dim(`  … and ${rows.length - 50} more`));
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** `/openspec` — `openspec validate` summary (same gate as check). */
+export async function formatOpenSpecInspect(repoRoot: string): Promise<string> {
+  const cfgPath = path.join(repoRoot, 'openspec', 'config.yaml');
+  if (!existsSync(cfgPath)) {
+    return ['', dim('  openspec: no openspec/config.yaml in this repo'), ''].join('\n');
+  }
+  const res = await openspecValidate(repoRoot);
+  const headline = res.ok ? ok('  openspec: valid') : err('  openspec: validation failed');
+  const body = res.output
+    .trim()
+    .split('\n')
+    .slice(0, 30)
+    .map((l) => `  ${l}`)
+    .join('\n');
+  const lines = ['', copper('  OpenSpec'), traceRule(16), '', headline, ''];
+  if (body) lines.push(body, '');
+  return lines.join('\n');
+}
+
+/** `/last` — preview the newest run summary.md. */
+export async function formatLastInspect(repoRoot: string): Promise<string> {
+  const entries = await sortedRunIds(repoRoot);
+  if (!entries.length) {
+    return ['', dim('  last: no runs yet'), ''].join('\n');
+  }
+  const id = entries[0]!;
+  const runsDir = path.join(repoRoot, '.copperhead', 'runs');
+  const summaryPath = path.join(runsDir, id, 'summary.md');
+  const transcriptPath = path.join(runsDir, id, 'transcript.jsonl');
+  const lines = ['', copper('  Last run'), traceRule(14), '', meta('id', id), ''];
+  if (!existsSync(summaryPath)) {
+    lines.push(dim('  summary.md missing'), '');
+    return lines.join('\n');
+  }
+  const text = await readFile(summaryPath, 'utf8');
+  const preview = text.split('\n').slice(0, 40);
+  lines.push(dim(`  ${shortPath(summaryPath)}`));
+  if (existsSync(transcriptPath)) {
+    lines.push(dim(`  ${shortPath(transcriptPath)}`));
+  }
+  lines.push('');
+  for (const line of preview) lines.push(`  ${line}`);
+  if (text.split('\n').length > 40) lines.push(dim('  … truncated'));
+  lines.push('');
+  return lines.join('\n');
+}

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -1,0 +1,529 @@
+/**
+ * Interactive agent shell (Claude Code–style). Default when `copperhead` is
+ * invoked with no subcommand on a TTY: prompt → one `do`-equivalent run →
+ * prompt again until /quit.
+ */
+
+import path from 'node:path';
+import { existsSync } from 'node:fs';
+import type { ProgressRenderer } from '../agent/render.js';
+import { copper, dim, err, ok, warn } from '../agent/theme.js';
+import { logoLockup } from '../agent/logo.js';
+import { revealBanner, staggerWrite } from '../agent/animate.js';
+import { runAgentLoop, type BudgetExhaustedStats, type RunResult } from '../agent/loop.js';
+import type { ModelSource } from '../config.js';
+import { loadConfig } from '../config.js';
+import { branchName, headCommit, isDirty, isGitRepo, uncommittedCount } from '../util/git.js';
+import { shortPath } from '../util/paths.js';
+import type { SelectItem } from '../util/select.js';
+import { KeyReader, promptWithSlashHints } from '../util/live-prompt.js';
+import { runCheck } from './check.js';
+import { demoTourText } from './demo.js';
+import {
+  formatBomInspect,
+  formatConfigInspect,
+  formatConstraintsInspect,
+  formatDriftInspect,
+  formatGitInspect,
+  formatLastInspect,
+  formatNetsInspect,
+  formatOpenSpecInspect,
+  formatPartsInspect,
+  formatRunsInspect,
+  formatSyncInspect,
+} from './repl-inspect.js';
+
+export interface ReplOptions {
+  repoRoot: string;
+  model: string;
+  modelSource: ModelSource;
+  version: string;
+  kicadCliVersion: string;
+  maxTurns?: number;
+  /** When set, pause for proposal approval inside each run. */
+  interactive?: boolean;
+  /** Optional first request before the prompt loop. */
+  seed?: string;
+  renderer: ProgressRenderer;
+  log?: (line: string) => void;
+  confirm?: (q: string) => Promise<boolean>;
+  onBudgetExhausted?: (stats: BudgetExhaustedStats) => Promise<number>;
+  /** Override streams (tests). Defaults to stdin/stdout. */
+  input?: NodeJS.ReadableStream;
+  output?: NodeJS.WritableStream;
+  /** Injected runner (tests). Defaults to runAgentLoop. */
+  runRequest?: (request: string) => Promise<Pick<RunResult, 'outcome'>>;
+  /** Injected /check (tests). */
+  runCheckCmd?: () => Promise<void>;
+}
+
+const QUIT = new Set(['/quit', '/exit', '/q']);
+
+/** Slash commands shown in `/` dropdown, `/help`, and tab completion. */
+export const SLASH_COMMANDS: SelectItem[] = [
+  { value: '/demo', label: '/demo', description: 'what copperhead does + how to try it' },
+  { value: '/examples', label: '/examples', description: 'example change-request prompts' },
+  { value: '/status', label: '/status', description: 'repo, git, and config snapshot' },
+  { value: '/check', label: '/check', description: 'ERC + DRC + drift — no LLM' },
+  { value: '/parts', label: '/parts', description: 'refdes / value / footprint from schematic' },
+  { value: '/nets', label: '/nets', description: 'net names and pin attachments' },
+  { value: '/bom', label: '/bom', description: 'parsed docs/BOM.md (read-only)' },
+  { value: '/sync', label: '/sync', description: 'doc↔board inconsistency report (verify only)' },
+  { value: '/drift', label: '/drift', description: 'BOM/PINOUT vs schematic drift' },
+  { value: '/constraints', label: '/constraints', description: 'open constraint registry' },
+  { value: '/openspec', label: '/openspec', description: 'openspec validate (no LLM)' },
+  { value: '/config', label: '/config', description: 'resolved .copperhead/config.json' },
+  { value: '/git', label: '/git', description: 'branch + dirty file list' },
+  { value: '/runs', label: '/runs', description: 'recent .copperhead/runs/' },
+  { value: '/last', label: '/last', description: 'newest run summary preview' },
+  { value: '/model', label: '/model', description: 'show the active model' },
+  { value: '/version', label: '/version', description: 'copperhead / kicad-cli / node' },
+  { value: '/clear', label: '/clear', description: 'clear the screen' },
+  { value: '/help', label: '/help', description: 'list commands' },
+  { value: '/quit', label: '/quit', description: 'leave the shell' },
+];
+
+/** Bare words that must NOT start an agent run (common mistake: `clear` without `/`). */
+const BARE_ALIASES: Record<string, string> = {
+  quit: '/quit',
+  exit: '/quit',
+  q: '/quit',
+  clear: '/clear',
+  cls: '/clear',
+  help: '/help',
+  demo: '/demo',
+  examples: '/examples',
+  status: '/status',
+  check: '/check',
+  parts: '/parts',
+  nets: '/nets',
+  bom: '/bom',
+  sync: '/sync',
+  drift: '/drift',
+  constraints: '/constraints',
+  openspec: '/openspec',
+  config: '/config',
+  git: '/git',
+  runs: '/runs',
+  last: '/last',
+  model: '/model',
+  version: '/version',
+};
+
+/** Parse a slash command; returns null when the line is a normal request. */
+export function parseSlash(line: string): { cmd: string; args: string } | null {
+  const t = line.trim();
+  if (!t) return null;
+
+  // Bare aliases: `quit` / `clear` / … act like their slash forms so a typo
+  // does not kick off a multi-minute agent turn.
+  const bare = BARE_ALIASES[t.toLowerCase()];
+  if (bare) return { cmd: bare, args: '' };
+
+  if (!t.startsWith('/')) return null;
+  // Bare `/` opens the command dropdown.
+  if (t === '/') return { cmd: '/', args: '' };
+  const sp = t.indexOf(' ');
+  if (sp < 0) return { cmd: t.toLowerCase(), args: '' };
+  return { cmd: t.slice(0, sp).toLowerCase(), args: t.slice(sp + 1).trim() };
+}
+
+/** Tab-completion matches for a partial slash command. */
+export function completeSlash(partial: string): string[] {
+  const p = partial.trim().toLowerCase();
+  if (!p.startsWith('/')) return [];
+  return SLASH_COMMANDS.map((c) => c.value).filter((c) => c.startsWith(p));
+}
+
+export { shortPath };
+
+/** Exported for tests. */
+export function helpText(): string {
+  const rows: Array<[string, string]> = [
+    ['/', 'type `/` to see live command suggestions'],
+    ['<request>', 'run one gated agent change (same as `do`)'],
+    ...SLASH_COMMANDS.map((c) => [c.label, c.description ?? ''] as [string, string]),
+  ];
+  const width = Math.max(...rows.map(([cmd]) => cmd.length));
+  return [
+    '',
+    copper('  Commands'),
+    '',
+    ...rows.map(([cmd, desc]) => `  ${copper(cmd.padEnd(width))}  ${dim(desc)}`),
+    '',
+    dim('  Tip: type `/` to filter commands — ↑/↓ + Enter to pick, Tab to complete.'),
+    dim('  Tip: run `copperhead demo` outside the shell for the full USB-C create pipeline.'),
+    '',
+  ].join('\n');
+}
+
+export function examplesText(): string {
+  return [
+    '',
+    copper('  Example prompts'),
+    '',
+    dim('  Drop any of these at the prompt (or use `copperhead do "…"`):'),
+    '',
+    `  ${copper('▸')} add reverse-polarity protection on VIN`,
+    `  ${copper('▸')} rename net KEY_DAH to KEY_DASH`,
+    `  ${copper('▸')} add a power LED on the 3V3 rail`,
+    `  ${copper('▸')} move the key input to a different RTC-capable pin`,
+    `  ${copper('▸')} add ESD diodes on the USB data lines`,
+    '',
+    dim('  Full board-from-brief demo:'),
+    `  ${copper('copperhead demo')}  ${dim('— USB-C power breakout create pipeline')}`,
+    '',
+  ].join('\n');
+}
+
+function metaRow(label: string, value: string): string {
+  return `  ${dim(label.padEnd(10))} ${value}`;
+}
+
+/** Exported for tests. */
+export function banner(opts: ReplOptions): string[] {
+  const repo = shortPath(path.resolve(opts.repoRoot));
+  const cols = (opts.output as NodeJS.WriteStream | undefined)?.columns ?? process.stdout.columns ?? 80;
+  return [
+    ...logoLockup({ version: opts.version, tagline: 'interactive shell', columns: cols }),
+    metaRow('model', `${opts.model}  ${dim(`via ${opts.modelSource}`)}`),
+    metaRow('kicad-cli', opts.kicadCliVersion),
+    metaRow('repo', dim(repo)),
+    '',
+    dim('  Describe a board change in plain English.'),
+    dim('  Type `/` for commands · ↑/↓ to hover (description shows above the list)'),
+    dim('  /quit to leave · Ctrl+C interrupts a running turn'),
+    '',
+  ];
+}
+
+/** phase 1 = bright chevron (pulse peak). */
+function promptPrefix(phase = 0): string {
+  const chevron = phase === 1 ? copper('›') : dim('›');
+  return `${copper('copperhead')} ${chevron} `;
+}
+
+function isTtyStream(input: NodeJS.ReadableStream, output: NodeJS.WritableStream): boolean {
+  return Boolean((input as NodeJS.ReadStream).isTTY) && Boolean((output as NodeJS.WriteStream).isTTY);
+}
+
+async function statusText(opts: ReplOptions): Promise<string> {
+  const repo = path.resolve(opts.repoRoot);
+  const lines = [
+    '',
+    copper('  Status'),
+    '',
+    metaRow('repo', shortPath(repo)),
+    metaRow('model', `${opts.model}  ${dim(`via ${opts.modelSource}`)}`),
+    metaRow('kicad-cli', opts.kicadCliVersion),
+    metaRow('node', process.version),
+  ];
+
+  if (await isGitRepo(repo)) {
+    const [branch, commit, dirty, n] = await Promise.all([
+      branchName(repo).catch(() => 'unknown'),
+      headCommit(repo).catch(() => 'unknown'),
+      isDirty(repo).catch(() => null),
+      uncommittedCount(repo).catch(() => null),
+    ]);
+    const state =
+      dirty === null ? 'unknown' : dirty ? `dirty (${n ?? '?'} file(s))` : ok('clean');
+    lines.push(metaRow('git', `${branch}@${commit.slice(0, 7)}  ${state}`));
+  } else {
+    lines.push(metaRow('git', warn('not a git repository')));
+  }
+
+  try {
+    const config = await loadConfig(repo);
+    lines.push(metaRow('schematic', config.schematic ?? dim('null')));
+    lines.push(metaRow('board', config.board ?? dim('null')));
+    lines.push(metaRow('docs', config.docs));
+    lines.push(metaRow('maxTurns', String(opts.maxTurns ?? config.maxTurns)));
+  } catch {
+    lines.push(metaRow('config', dim('no .copperhead/config.json yet — try `copperhead init`')));
+  }
+
+  if (!existsSync(path.join(repo, '.copperhead'))) {
+    lines.push('');
+    lines.push(dim('  Hint: `copperhead init` scaffolds docs/ from an existing schematic.'));
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function defaultRunner(opts: ReplOptions, log: (l: string) => void) {
+  return (request: string) =>
+    runAgentLoop({
+      repoRoot: opts.repoRoot,
+      request,
+      model: opts.model,
+      ...(opts.maxTurns !== undefined ? { maxTurns: opts.maxTurns } : {}),
+      allowDirty: true,
+      interactive: opts.interactive ?? false,
+      confirm: opts.confirm,
+      ...(opts.onBudgetExhausted ? { onBudgetExhausted: opts.onBudgetExhausted } : {}),
+      renderer: opts.renderer,
+      log,
+      meta: {
+        command: 'repl',
+        modelSource: opts.modelSource,
+        version: opts.version,
+        kicadCliVersion: opts.kicadCliVersion,
+      },
+    });
+}
+
+/**
+ * Run the interactive shell. Resolves when the user quits.
+ * Returns ok:false when the shell could not start (non-TTY without a usable seed).
+ */
+export async function runRepl(opts: ReplOptions): Promise<{ ok: boolean; turns: number }> {
+  const log = opts.log ?? ((l: string) => console.log(l));
+  const input = opts.input ?? process.stdin;
+  const output = opts.output ?? process.stdout;
+  const seed = opts.seed?.trim() || undefined;
+  const tty = isTtyStream(input, output);
+
+  const runOne = opts.runRequest ?? defaultRunner(opts, log);
+  const checkCmd =
+    opts.runCheckCmd ??
+    (async () => {
+      const res = await runCheck(opts.repoRoot, log);
+      log(res.ok ? ok('check: all green') : warn('check: failures reported above'));
+    });
+
+  if (!tty) {
+    if (!seed) {
+      log(
+        err(
+          'copperhead: interactive shell requires a TTY. Use `copperhead do "<request>"` for one-shot runs.',
+        ),
+      );
+      return { ok: false, turns: 0 };
+    }
+    try {
+      const res = await runOne(seed);
+      return { ok: res.outcome !== 'failure', turns: 1 };
+    } catch (e) {
+      log(err((e as Error).message));
+      return { ok: false, turns: 0 };
+    }
+  }
+
+  await revealBanner(banner(opts), log, { out: output as NodeJS.WriteStream });
+
+  let turns = 0;
+  const handleRequest = async (request: string): Promise<void> => {
+    try {
+      const res = await runOne(request);
+      turns++;
+      if (res.outcome === 'failure') {
+        log(dim('(session continues — fix the issue or try another request)'));
+      }
+    } catch (e) {
+      log(err((e as Error).message));
+      log(dim('(session continues)'));
+    }
+  };
+
+  if (seed) {
+    log(`  ${copper('→')} ${seed}`);
+    log('');
+    await handleRequest(seed);
+  }
+
+  const runSlash = async (cmd: string): Promise<'quit' | 'continue'> => {
+    if (QUIT.has(cmd)) {
+      log('');
+      log(dim('  session ended'));
+      return 'quit';
+    }
+    if (cmd === '/help' || cmd === '/h' || cmd === '/?') {
+      await staggerWrite(helpText().split('\n'), log);
+      return 'continue';
+    }
+    if (cmd === '/demo') {
+      await staggerWrite(demoTourText().split('\n'), log);
+      return 'continue';
+    }
+    if (cmd === '/examples') {
+      await staggerWrite(examplesText().split('\n'), log);
+      return 'continue';
+    }
+    if (cmd === '/status') {
+      log(await statusText(opts));
+      return 'continue';
+    }
+    if (cmd === '/version') {
+      log('');
+      log(metaRow('copperhead', opts.version));
+      log(metaRow('kicad-cli', opts.kicadCliVersion));
+      log(metaRow('node', process.version));
+      log('');
+      return 'continue';
+    }
+    if (cmd === '/clear' || cmd === '/cls') {
+      (output as NodeJS.WritableStream).write('\x1b[2J\x1b[H');
+      await revealBanner(banner(opts), log, { out: output as NodeJS.WriteStream });
+      return 'continue';
+    }
+    if (cmd === '/model') {
+      log('');
+      log(metaRow('model', `${opts.model}  ${dim(`via ${opts.modelSource}`)}`));
+      log('');
+      return 'continue';
+    }
+    if (cmd === '/check') {
+      log('');
+      try {
+        await checkCmd();
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      log('');
+      return 'continue';
+    }
+    if (cmd === '/sync') {
+      try {
+        log(await formatSyncInspect(opts.repoRoot));
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      return 'continue';
+    }
+    if (cmd === '/drift') {
+      try {
+        log(await formatDriftInspect(opts.repoRoot));
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      return 'continue';
+    }
+    if (cmd === '/constraints') {
+      try {
+        log(await formatConstraintsInspect(opts.repoRoot));
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      return 'continue';
+    }
+    if (cmd === '/config') {
+      try {
+        log(await formatConfigInspect(opts.repoRoot));
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      return 'continue';
+    }
+    if (cmd === '/git') {
+      try {
+        log(await formatGitInspect(opts.repoRoot));
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      return 'continue';
+    }
+    if (cmd === '/runs') {
+      try {
+        log(await formatRunsInspect(opts.repoRoot));
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      return 'continue';
+    }
+    if (cmd === '/parts') {
+      try {
+        log(await formatPartsInspect(opts.repoRoot));
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      return 'continue';
+    }
+    if (cmd === '/nets') {
+      try {
+        log(await formatNetsInspect(opts.repoRoot));
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      return 'continue';
+    }
+    if (cmd === '/bom') {
+      try {
+        log(await formatBomInspect(opts.repoRoot));
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      return 'continue';
+    }
+    if (cmd === '/openspec') {
+      try {
+        log(await formatOpenSpecInspect(opts.repoRoot));
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      return 'continue';
+    }
+    if (cmd === '/last') {
+      try {
+        log(await formatLastInspect(opts.repoRoot));
+      } catch (e) {
+        log(err((e as Error).message));
+      }
+      return 'continue';
+    }
+    log(warn(`  unknown command ${cmd} — type / to see commands`));
+    return 'continue';
+  };
+
+  const keys = new KeyReader(input as NodeJS.ReadStream);
+  const ask = (): Promise<string | null> =>
+    promptWithSlashHints({
+      prompt: promptPrefix(),
+      promptFrame: (phase) => promptPrefix(phase),
+      commands: SLASH_COMMANDS,
+      output: output as NodeJS.WriteStream,
+      readKey: () => keys.next(),
+      drainPrintable: () => keys.drainPrintable(),
+    });
+
+  try {
+    for (;;) {
+      const raw = await ask();
+      if (raw === null) {
+        log('');
+        log(dim('  session ended'));
+        break;
+      }
+      const line = raw.trim();
+      if (!line) continue;
+
+      const slash = parseSlash(line);
+      if (slash) {
+        // Live prompt already resolves bare `/` to a concrete command via Enter.
+        if (slash.cmd === '/') continue;
+        // Echo again above command output so history stays readable after
+        // long tours (/demo) push the prompt line out of the first viewport.
+        log(dim(`  → ${slash.cmd}`));
+        const result = await runSlash(slash.cmd);
+        if (result === 'quit') break;
+        continue;
+      }
+
+      // Pause raw-mode so Ctrl+C is a real SIGINT during the agent turn.
+      log('');
+      log(dim('  (Ctrl+C to interrupt)'));
+      keys.pause();
+      try {
+        await handleRequest(line);
+      } finally {
+        keys.resume();
+      }
+      log('');
+    }
+  } finally {
+    keys.close();
+  }
+
+  return { ok: true, turns };
+}

--- a/src/kicad/cli.ts
+++ b/src/kicad/cli.ts
@@ -1,4 +1,5 @@
 import { execa, ExecaError } from 'execa';
+import { existsSync } from 'node:fs';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -13,6 +14,7 @@ export class KicadCliMissingError extends PreflightError {
       [
         'install KiCad ≥ 8: https://www.kicad.org/download/',
         'ensure the kicad-cli binary is on PATH (on macOS it ships inside KiCad.app/Contents/MacOS)',
+        'or set COPPERHEAD_KICAD_CLI=/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli',
         'confirm with "kicad-cli version", then rerun',
       ],
     );
@@ -20,12 +22,85 @@ export class KicadCliMissingError extends PreflightError {
   }
 }
 
+/** Well-known install locations when `kicad-cli` is not on PATH (macOS app bundle). */
+const FALLBACK_BINARIES = [
+  '/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli',
+  '/Applications/KiCad-10.0/KiCad.app/Contents/MacOS/kicad-cli',
+  '/Applications/KiCad-9.0/KiCad.app/Contents/MacOS/kicad-cli',
+  '/Applications/KiCad-8.0/KiCad.app/Contents/MacOS/kicad-cli',
+];
+
+let cachedBinary: string | null | undefined;
+
+/**
+ * Resolve the kicad-cli executable: `COPPERHEAD_KICAD_CLI` > PATH name
+ * (`kicad-cli`). On PATH miss, `runKicad` falls back to macOS KiCad.app paths.
+ */
+export function resolveKicadCli(): string {
+  if (cachedBinary !== undefined) {
+    if (cachedBinary === null) throw new KicadCliMissingError();
+    return cachedBinary;
+  }
+  const fromEnv = process.env.COPPERHEAD_KICAD_CLI?.trim();
+  if (fromEnv && existsSync(fromEnv)) {
+    cachedBinary = fromEnv;
+    return fromEnv;
+  }
+  cachedBinary = 'kicad-cli';
+  return cachedBinary;
+}
+
+/** After ENOENT on PATH, retry with a known macOS install path. */
+function fallbackAfterMissing(): string {
+  const fromEnv = process.env.COPPERHEAD_KICAD_CLI?.trim();
+  if (fromEnv && existsSync(fromEnv)) {
+    cachedBinary = fromEnv;
+    return fromEnv;
+  }
+  for (const candidate of FALLBACK_BINARIES) {
+    if (existsSync(candidate)) {
+      cachedBinary = candidate;
+      return candidate;
+    }
+  }
+  cachedBinary = null;
+  throw new KicadCliMissingError();
+}
+
+async function runKicad(args: string[], opts?: { reject?: boolean }): Promise<Awaited<ReturnType<typeof execa>>> {
+  let bin = resolveKicadCli();
+  let res = await execa(bin, args, { reject: false });
+  if (res.failed && (res as unknown as ExecaError).code === 'ENOENT') {
+    if (bin === 'kicad-cli') {
+      bin = fallbackAfterMissing();
+      res = await execa(bin, args, { reject: false });
+    } else {
+      throw new KicadCliMissingError();
+    }
+  }
+  if (opts?.reject === false) return res;
+  if (res.failed && (res as unknown as ExecaError).code === 'ENOENT') {
+    throw new KicadCliMissingError();
+  }
+  if (res.failed) {
+    throw Object.assign(new Error(res.stderr || res.stdout || `kicad-cli exited ${res.exitCode}`), res);
+  }
+  return res;
+}
+
+/** Test helper: clear the resolved-binary cache. */
+export function resetKicadCliCache(): void {
+  cachedBinary = undefined;
+}
+
 export async function kicadCliVersion(): Promise<string> {
   try {
-    const { stdout } = await execa('kicad-cli', ['version']);
-    return stdout.trim();
+    const res = await runKicad(['version']);
+    return String(res.stdout ?? '').trim();
   } catch (err) {
     if ((err as ExecaError).code === 'ENOENT') throw new KicadCliMissingError();
+    // runKicad already maps PATH ENOENT → fallback → KicadCliMissingError
+    if (err instanceof KicadCliMissingError) throw err;
     throw err;
   }
 }
@@ -39,8 +114,7 @@ async function runCheck(
   const out = path.join(dir, `${kind}.json`);
   const sub = kind === 'erc' ? ['sch', 'erc'] : ['pcb', 'drc'];
   try {
-    const res = await execa(
-      'kicad-cli',
+    const res = await runKicad(
       [...sub, '--format', 'json', '--exit-code-violations', '--output', out, ...extraArgs, filePath],
       { reject: false },
     );
@@ -94,7 +168,7 @@ export async function kicadLoadError(filePath: string): Promise<string | null> {
     ? ['sch', 'export', 'netlist', '--output', path.join(dir, 'probe.net'), filePath]
     : ['pcb', 'export', 'pos', '--output', path.join(dir, 'probe.pos'), filePath];
   try {
-    const res = await execa('kicad-cli', args, { reject: false });
+    const res = await runKicad(args, { reject: false });
     if (res.failed && (res as unknown as ExecaError).code === 'ENOENT') throw new KicadCliMissingError();
     if (res.exitCode === 0) return null;
     return [res.stderr, res.stdout].filter(Boolean).join('\n').trim() || `kicad-cli exited ${res.exitCode}`;
@@ -131,9 +205,10 @@ export async function exportFab(pcbPath: string, schPath: string | null, outDir:
   }
   for (const job of jobs) {
     try {
-      await execa('kicad-cli', job.args);
+      await runKicad(job.args);
       result.produced.push(job.artifact);
     } catch (err) {
+      if (err instanceof KicadCliMissingError) throw err;
       if ((err as ExecaError).code === 'ENOENT') throw new KicadCliMissingError();
       result.failed.push({ artifact: job.artifact, reason: String((err as ExecaError).stderr ?? (err as Error).message).slice(0, 200) });
     }
@@ -148,8 +223,9 @@ export async function exportSvg(kind: 'sch' | 'pcb', filePath: string, outDir: s
       ? ['sch', 'export', 'svg', '--output', outDir, filePath]
       : ['pcb', 'export', 'svg', '--output', path.join(outDir, 'board.svg'), '--layers', 'F.Cu,B.Cu,Edge.Cuts', filePath];
   try {
-    await execa('kicad-cli', args);
+    await runKicad(args);
   } catch (err) {
+    if (err instanceof KicadCliMissingError) throw err;
     if ((err as ExecaError).code === 'ENOENT') throw new KicadCliMissingError();
     throw err;
   }

--- a/src/util/live-prompt.ts
+++ b/src/util/live-prompt.ts
@@ -1,0 +1,404 @@
+/**
+ * TTY line prompt with live slash-command suggestions.
+ * Typing `/` immediately shows matching commands under the caret; ↑/↓ + Enter
+ * picks one — no need to press Enter on bare `/` first.
+ */
+
+import { copper, dim } from '../agent/theme.js';
+import { pulsePrompt } from '../agent/animate.js';
+import type { SelectItem } from './select.js';
+
+export interface LivePromptOptions {
+  prompt: string;
+  /** Optional pulsing prompt frames (phase 0..n). */
+  promptFrame?: (phase: number) => string;
+  commands: SelectItem[];
+  output?: NodeJS.WriteStream;
+  /** Next keypress; null means EOF. */
+  readKey: () => Promise<string | null>;
+  /**
+   * Sync drain of already-queued printable chars (paste coalescing).
+   * Without this, a long paste repaints once per character and wrap debris
+   * stacks into many fake prompt lines.
+   */
+  drainPrintable?: () => string;
+}
+
+const CLEAR_LINE = '\r\x1b[2K';
+const HIDE = '\x1b[?25l';
+const SHOW = '\x1b[?25h';
+/** Inverse video for the hovered dropdown row. */
+const INVERSE = '\x1b[7m';
+const RESET = '\x1b[0m';
+
+/** Visible width ignoring SGR; used for wrap-row accounting. */
+export function visibleLen(s: string): number {
+  return s.replace(/\x1b\[[0-9;]*m/g, '').length;
+}
+
+/** How many terminal rows `prompt + buffer` occupies at `cols` width. */
+export function inputRowRows(prompt: string, buffer: string, cols: number): number {
+  const w = Math.max(1, cols || 80);
+  return Math.max(1, Math.ceil(visibleLen(prompt + buffer) / w));
+}
+
+function matchesFor(buffer: string, commands: SelectItem[]): SelectItem[] {
+  if (!buffer.startsWith('/')) return [];
+  const p = buffer.toLowerCase();
+  if (p === '/') return commands;
+  return commands.filter((c) => c.value.startsWith(p));
+}
+
+/** Visible slash-menu lines (exported for tests). */
+export function suggestionLines(matches: SelectItem[], index: number): string[] {
+  if (!matches.length) return [dim('  (no matching commands)')];
+  const clamped = Math.max(0, Math.min(index, matches.length - 1));
+  const selected = matches[clamped]!;
+  const width = Math.max(...matches.map((m) => m.label.length), 8);
+
+  const detail: string[] = [];
+  if (selected.description) {
+    detail.push(dim('  ────────────────────────────────────────'));
+    detail.push(`  ${copper(selected.label)}  ${selected.description}`);
+  } else {
+    detail.push(`  ${copper(selected.label)}`);
+  }
+
+  return [
+    ...detail,
+    '',
+    dim('  ↑/↓ hover · Enter select · Esc dismiss'),
+    ...matches.map((item, i) => {
+      const hovered = i === clamped;
+      const cursor = hovered ? copper('❯') : ' ';
+      const label = item.label.padEnd(width);
+      if (hovered) {
+        return `  ${cursor} ${INVERSE}${copper(label)}${RESET}`;
+      }
+      return `  ${cursor} ${dim(label)}`;
+    }),
+  ];
+}
+
+/** Normalize arrow key aliases (CSI + SS3) to a small set. */
+export function normalizeNavKey(key: string): string {
+  // CSI: \x1b[A  SS3: \x1bOA  (common across terminals / tmux)
+  if (key === '\x1b[A' || key === '\x1bOA' || key === '\x1b[1;2A') return 'up';
+  if (key === '\x1b[B' || key === '\x1bOB' || key === '\x1b[1;2B') return 'down';
+  if (key === '\x1b[C' || key === '\x1bOC') return 'right';
+  if (key === '\x1b[D' || key === '\x1bOD') return 'left';
+  return key;
+}
+
+/**
+ * Push bytes through an escape-sequence assembler. Handles arrows that arrive
+ * split across reads (`\x1b` then `[A`) — otherwise a lone ESC clears the menu.
+ */
+export function pushKeys(pending: { buf: string }, chunk: string, emit: (key: string) => void): void {
+  pending.buf += chunk;
+  while (pending.buf.length) {
+    const s = pending.buf;
+    if (s[0] !== '\x1b') {
+      emit(s[0]!);
+      pending.buf = s.slice(1);
+      continue;
+    }
+    // Incomplete ESC — wait for more bytes.
+    if (s.length === 1) return;
+
+    // SS3: ESC O A/B/C/D
+    if (s[1] === 'O') {
+      if (s.length < 3) return;
+      emit(s.slice(0, 3));
+      pending.buf = s.slice(3);
+      continue;
+    }
+
+    // CSI: ESC [ … letter
+    if (s[1] === '[') {
+      // Need at least ESC [ X
+      if (s.length < 3) return;
+      // Consume until a final byte (@-~) for longer sequences (e.g. \x1b[1;2A)
+      let j = 2;
+      while (j < s.length && s.charCodeAt(j) >= 0x20 && s.charCodeAt(j) < 0x40) j++;
+      if (j >= s.length) return; // incomplete
+      emit(s.slice(0, j + 1));
+      pending.buf = s.slice(j + 1);
+      continue;
+    }
+
+    // Lone ESC (or ESC + non-CSI) — emit Esc
+    emit('\x1b');
+    pending.buf = s.slice(1);
+  }
+}
+
+/**
+ * Session-long key reader. Keeps the stream alive across many prompts
+ * (unlike `for await` of a Readable, which destroys it on exit).
+ */
+export class KeyReader {
+  private readonly queue: string[] = [];
+  private readonly waiters: Array<(v: string | null) => void> = [];
+  private ended = false;
+  private paused = false;
+  private readonly wasRaw: boolean | undefined;
+  private readonly pending = { buf: '' };
+  private readonly onData: (c: string | Buffer) => void;
+  private readonly onEnd: () => void;
+
+  constructor(private readonly input: NodeJS.ReadStream) {
+    this.wasRaw = input.isRaw;
+    if (typeof input.setRawMode === 'function') input.setRawMode(true);
+    input.resume();
+    input.setEncoding('utf8');
+
+    this.onData = (c: string | Buffer): void => {
+      // While paused (agent run in flight), let the OS deliver Ctrl+C as SIGINT
+      // instead of queuing \x03 — otherwise the user cannot interrupt a turn.
+      if (this.paused) return;
+      pushKeys(this.pending, String(c), (key) => {
+        const waiter = this.waiters.shift();
+        if (waiter) waiter(key);
+        else this.queue.push(key);
+      });
+    };
+    this.onEnd = (): void => {
+      // Flush a dangling ESC if the stream ends mid-sequence.
+      if (this.pending.buf) {
+        for (const ch of this.pending.buf) {
+          const waiter = this.waiters.shift();
+          if (waiter) waiter(ch);
+          else this.queue.push(ch);
+        }
+        this.pending.buf = '';
+      }
+      this.ended = true;
+      while (this.waiters.length) this.waiters.shift()!(null);
+    };
+
+    input.on('data', this.onData);
+    input.on('end', this.onEnd);
+  }
+
+  async next(): Promise<string | null> {
+    if (this.queue.length) return this.queue.shift()!;
+    if (this.ended) return null;
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+
+  /** Sync: pull every already-queued printable character (paste batch). */
+  drainPrintable(): string {
+    let out = '';
+    while (this.queue.length) {
+      const k = this.queue[0]!;
+      if (k.length === 1 && k >= ' ') {
+        out += this.queue.shift();
+      } else {
+        break;
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Release raw mode so Ctrl+C becomes SIGINT again (needed while an agent
+   * turn owns the terminal). Drop any typed-ahead keys.
+   */
+  pause(): void {
+    this.paused = true;
+    this.queue.length = 0;
+    this.pending.buf = '';
+    if (typeof this.input.setRawMode === 'function') this.input.setRawMode(false);
+  }
+
+  /** Re-enter raw mode for the next prompt. */
+  resume(): void {
+    this.paused = false;
+    if (typeof this.input.setRawMode === 'function') this.input.setRawMode(true);
+    this.input.resume();
+  }
+
+  close(): void {
+    this.input.off('data', this.onData);
+    this.input.off('end', this.onEnd);
+    this.ended = true;
+    this.paused = true;
+    while (this.waiters.length) this.waiters.shift()!(null);
+    if (typeof this.input.setRawMode === 'function') {
+      this.input.setRawMode(this.wasRaw ?? false);
+    }
+  }
+}
+
+/** Tiny key source for unit tests. */
+export function keySequence(keys: string[]): () => Promise<string | null> {
+  let i = 0;
+  return async () => (i < keys.length ? keys[i++]! : null);
+}
+
+/**
+ * Read one line. When the buffer starts with `/`, live suggestions appear
+ * underneath. Returns the submitted line, a selected slash command, or null
+ * on Ctrl+C / EOF.
+ */
+export async function promptWithSlashHints(opts: LivePromptOptions): Promise<string | null> {
+  const output = opts.output ?? process.stdout;
+  let buffer = '';
+  let index = 0;
+  let paintedExtra = 0;
+  /** Rows occupied by the prompt+buffer (terminal wrap). */
+  let paintedInputRows = 1;
+
+  const cols = (): number =>
+    typeof (output as NodeJS.WriteStream).columns === 'number' && (output as NodeJS.WriteStream).columns!
+      ? (output as NodeJS.WriteStream).columns!
+      : 80;
+
+  const eraseExtra = (): void => {
+    if (paintedExtra <= 0) return;
+    for (let i = 0; i < paintedExtra; i++) output.write('\n' + CLEAR_LINE);
+    output.write(`\x1b[${paintedExtra}A`);
+    paintedExtra = 0;
+  };
+
+  /** Clear prompt+buffer including soft-wrapped continuation rows. */
+  const clearInputSurface = (): void => {
+    if (paintedInputRows > 1) output.write(`\x1b[${paintedInputRows - 1}A`);
+    for (let i = 0; i < paintedInputRows; i++) {
+      output.write(CLEAR_LINE);
+      if (i < paintedInputRows - 1) output.write('\n');
+    }
+    if (paintedInputRows > 1) output.write(`\x1b[${paintedInputRows - 1}A`);
+  };
+
+  const writeInput = (): void => {
+    const text = opts.prompt + buffer;
+    output.write(CLEAR_LINE + text + SHOW);
+    paintedInputRows = inputRowRows(opts.prompt, buffer, cols());
+  };
+
+  const paint = (): void => {
+    const matches = matchesFor(buffer, opts.commands);
+    if (index >= matches.length) index = Math.max(0, matches.length - 1);
+
+    eraseExtra();
+    clearInputSurface();
+    writeInput();
+
+    if (buffer.startsWith('/')) {
+      const lines = suggestionLines(matches, index);
+      output.write(HIDE);
+      for (const line of lines) output.write('\n' + CLEAR_LINE + line);
+      paintedExtra = lines.length;
+      // Back to the last physical row of the input (immediately above suggestions).
+      output.write(`\x1b[${paintedExtra}A`);
+      clearInputSurface();
+      writeInput();
+    }
+  };
+
+  const finish = (value: string | null): string | null => {
+    eraseExtra();
+    clearInputSurface();
+    // Commit the final value onto the prompt line so scrollback shows what
+    // actually ran (e.g. `/demo` after picking from the bare-`/` dropdown),
+    // not just the typed prefix.
+    if (value !== null) {
+      output.write(CLEAR_LINE + opts.prompt + value);
+    }
+    output.write('\n' + SHOW);
+    return value;
+  };
+
+  paint();
+
+  try {
+    for (;;) {
+      // Pulse the chevron while idle at an empty prompt (no dropdown open).
+      let stopPulse: (() => void) | null = null;
+      if (buffer === '' && opts.promptFrame) {
+        const frameOf = opts.promptFrame;
+        stopPulse = pulsePrompt(output, (phase) => frameOf(phase));
+      }
+      const raw = await opts.readKey();
+      stopPulse?.();
+      if (raw === null) return finish(null);
+      const key = normalizeNavKey(raw);
+
+      if (key === '\x03') return finish(null);
+      if (key === '\x04' && buffer === '') return finish(null);
+
+      if (key === '\r' || key === '\n') {
+        const matches = matchesFor(buffer, opts.commands);
+        if (buffer.startsWith('/') && matches.length > 0) {
+          return finish(matches[index]!.value);
+        }
+        return finish(buffer);
+      }
+
+      if (key === '\x1b') {
+        if (buffer.startsWith('/')) {
+          buffer = '';
+          index = 0;
+          paint();
+        }
+        continue;
+      }
+
+      // Arrows (and j/k while the dropdown is open) move the hover highlight.
+      const navUp =
+        key === 'up' || key === 'left' || (buffer.startsWith('/') && raw === 'k');
+      const navDown =
+        key === 'down' || key === 'right' || (buffer.startsWith('/') && raw === 'j');
+      if (navUp || navDown) {
+        const matches = matchesFor(buffer, opts.commands);
+        if (matches.length) {
+          index = navUp
+            ? (index - 1 + matches.length) % matches.length
+            : (index + 1) % matches.length;
+          paint();
+        }
+        continue;
+      }
+
+      if (key === '\t') {
+        const matches = matchesFor(buffer, opts.commands);
+        if (matches.length >= 1) {
+          buffer = matches[index]!.value;
+          paint();
+        }
+        continue;
+      }
+
+      if (key === '\x7f' || key === '\b') {
+        if (buffer.length) {
+          buffer = buffer.slice(0, -1);
+          index = 0;
+          paint();
+        }
+        continue;
+      }
+
+      if (key === '\x15') {
+        buffer = '';
+        index = 0;
+        paint();
+        continue;
+      }
+
+      // When suggestions are open, j/k navigate (already normalized). Printable
+      // letters that aren't nav still type into the filter. Coalesce paste so
+      // we paint once per burst instead of once per character.
+      if (key.length === 1 && key >= ' ') {
+        buffer += key;
+        if (opts.drainPrintable) buffer += opts.drainPrintable();
+        index = 0;
+        paint();
+      }
+    }
+  } finally {
+    eraseExtra();
+    output.write(SHOW);
+  }
+}

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import os from 'node:os';
 
 export class SandboxError extends Error {
   constructor(public readonly attempted: string) {
@@ -22,4 +23,13 @@ export function resolveInRepo(repoRoot: string, p: string): string {
 
 export function isKicadFile(p: string): boolean {
   return /\.(kicad_sch|kicad_pcb|kicad_pro|kicad_sym|kicad_mod)$/.test(p);
+}
+
+/** Shorten absolute paths for TTY chrome: `$HOME/…` → `~/…`. */
+export function shortPath(p: string): string {
+  const home = os.homedir();
+  if (home && (p === home || p.startsWith(home + path.sep))) {
+    return '~' + p.slice(home.length);
+  }
+  return p;
 }

--- a/src/util/select.ts
+++ b/src/util/select.ts
@@ -1,0 +1,147 @@
+/**
+ * Minimal arrow-key select menu for TTY prompts (no extra deps).
+ * Renders an in-place "dropdown" navigable with ↑/↓ + Enter.
+ */
+
+import { copper, dim } from '../agent/theme.js';
+
+export interface SelectItem {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface SelectOptions {
+  title?: string;
+  items: SelectItem[];
+  input?: NodeJS.ReadStream;
+  output?: NodeJS.WriteStream;
+  /** Injected key stream for tests. */
+  keys?: AsyncIterable<string>;
+}
+
+const HIDE = '\x1b[?25l';
+const SHOW = '\x1b[?25h';
+const CLEAR_LINE = '\r\x1b[2K';
+
+function menuLines(title: string, items: SelectItem[], index: number): string[] {
+  const width = Math.max(...items.map((i) => i.label.length), 8);
+  return [
+    copper(`  ${title}`),
+    dim('  ↑/↓ move · Enter select · Esc cancel'),
+    '',
+    ...items.map((item, i) => {
+      const cursor = i === index ? copper('❯') : ' ';
+      const label = i === index ? copper(item.label.padEnd(width)) : dim(item.label.padEnd(width));
+      const desc = item.description ? dim(`  ${item.description}`) : '';
+      return `  ${cursor} ${label}${desc}`;
+    }),
+    '',
+  ];
+}
+
+async function* stdinKeys(input: NodeJS.ReadStream): AsyncGenerator<string> {
+  const wasRaw = input.isRaw;
+  if (typeof input.setRawMode === 'function') input.setRawMode(true);
+  input.resume();
+  input.setEncoding('utf8');
+  try {
+    for await (const chunk of input) {
+      const s = String(chunk);
+      let i = 0;
+      while (i < s.length) {
+        if (s[i] === '\x1b' && s[i + 1] === '[') {
+          yield s.slice(i, i + 3);
+          i += 3;
+          continue;
+        }
+        // Lone Esc
+        if (s[i] === '\x1b') {
+          yield '\x1b';
+          i += 1;
+          continue;
+        }
+        yield s[i]!;
+        i += 1;
+      }
+    }
+  } finally {
+    if (typeof input.setRawMode === 'function') input.setRawMode(wasRaw ?? false);
+  }
+}
+
+/**
+ * Show a selectable list. Resolves to the chosen value, or null if cancelled.
+ */
+export async function selectMenu(opts: SelectOptions): Promise<string | null> {
+  const items = opts.items;
+  if (!items.length) return null;
+
+  const input = opts.input ?? process.stdin;
+  const output = opts.output ?? process.stdout;
+  const title = opts.title ?? 'Select';
+  let index = 0;
+  let lineCount = 0;
+
+  const paint = (): void => {
+    const lines = menuLines(title, items, index);
+    if (lineCount > 0) {
+      // Move to the first line of the previous paint and rewrite in place.
+      output.write(`\x1b[${lineCount}A`);
+    }
+    output.write(HIDE);
+    for (const line of lines) {
+      output.write(CLEAR_LINE + line + '\n');
+    }
+    lineCount = lines.length;
+  };
+
+  const erase = (): void => {
+    if (lineCount <= 0) {
+      output.write(SHOW);
+      return;
+    }
+    output.write(`\x1b[${lineCount}A`);
+    for (let i = 0; i < lineCount; i++) output.write(CLEAR_LINE + (i < lineCount - 1 ? '\n' : ''));
+    if (lineCount > 1) output.write(`\x1b[${lineCount - 1}A`);
+    output.write('\r' + SHOW);
+    lineCount = 0;
+  };
+
+  paint();
+
+  const keys = opts.keys ?? stdinKeys(input);
+  try {
+    for await (const key of keys) {
+      if (key === '\x03' || key === '\x1b') {
+        erase();
+        return null;
+      }
+      if (key === '\r' || key === '\n') {
+        const chosen = items[index]!.value;
+        erase();
+        return chosen;
+      }
+      if (key === '\x1b[A' || key === 'k') {
+        index = (index - 1 + items.length) % items.length;
+        paint();
+        continue;
+      }
+      if (key === '\x1b[B' || key === 'j') {
+        index = (index + 1) % items.length;
+        paint();
+        continue;
+      }
+      if (key >= '1' && key <= '9') {
+        const n = Number(key) - 1;
+        if (n >= 0 && n < items.length) {
+          index = n;
+          paint();
+        }
+      }
+    }
+  } finally {
+    erase();
+  }
+  return null;
+}

--- a/test/observability.test.ts
+++ b/test/observability.test.ts
@@ -5,6 +5,7 @@ import { execa } from 'execa';
 import { runAgentLoop, type RunOptions } from '../src/agent/loop.js';
 import type { ChatOpts, Provider, Turn } from '../src/agent/types.js';
 import { InteractiveRenderer, makeRenderer, plainRenderer } from '../src/agent/render.js';
+import { isColorEnabled, setColorEnabled, stageLine, toolLine } from '../src/agent/theme.js';
 import { tempFixtureRepo } from './helpers.js';
 
 /** Replays a fixed script of turns; the last turn repeats forever. */
@@ -349,5 +350,46 @@ describe('--json routes progress to stderr (AC-2.4/8.9)', () => {
       err.mockRestore();
       log.mockRestore();
     }
+  });
+});
+
+describe('interactive chrome theme (AC-8.8/8.9)', () => {
+  it('plain helpers emit zero SGR when color is off', () => {
+    setColorEnabled(false);
+    expect(toolLine('run_erc', 'clean')).toBe('  ✓ run_erc  clean');
+    expect(toolLine('edit_file', 'replaced 1 region')).toBe('  ▸ edit_file  replaced 1 region');
+    expect(stageLine('spec-seed', 'running')).toBe('stage spec-seed: running');
+    expect(toolLine('run_erc', 'clean')).not.toContain('\x1b');
+  });
+
+  it('interactive tool lines pick ✓ for clean results when color is on', () => {
+    setColorEnabled(true);
+    try {
+      const line = toolLine('run_erc', 'ERC clean');
+      expect(line).toContain('run_erc');
+      expect(line).toContain('✓');
+      expect(line).toContain('\x1b');
+    } finally {
+      setColorEnabled(false);
+    }
+  });
+
+  it('makeRenderer(--plain) disables color so later stage lines stay zero-ANSI', () => {
+    setColorEnabled(true);
+    makeRenderer({ json: false, plain: true });
+    expect(isColorEnabled()).toBe(false);
+    expect(stageLine('layout', 'running')).toBe('stage layout: running');
+  });
+
+  it('interactive renderer toolResult uses the glyph form', () => {
+    setColorEnabled(false);
+    let written = '';
+    const fake = { write: (c: string) => (written += c), columns: 120 };
+    const r = new InteractiveRenderer(fake);
+    r.turnStart(1, 10, 0, 0);
+    r.toolResult('edit_file', 'replaced 1 region');
+    expect(written).toContain('▸ edit_file');
+    expect(written).not.toContain('[edit_file]');
+    r.finish('done');
   });
 });

--- a/test/repl-inspect.test.ts
+++ b/test/repl-inspect.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { setColorEnabled } from '../src/agent/theme.js';
+import {
+  formatConfigInspect,
+  formatConstraintsInspect,
+  formatLastInspect,
+  formatNetsInspect,
+  formatPartsInspect,
+  formatRunsInspect,
+} from '../src/commands/repl-inspect.js';
+import { tempFixtureRepo } from './helpers.js';
+
+describe('repl inspect formatters', () => {
+  let root: string;
+
+  beforeAll(async () => {
+    setColorEnabled(false);
+    root = await mkdtemp(path.join(tmpdir(), 'copperhead-repl-inspect-'));
+    await mkdir(path.join(root, '.copperhead', 'runs', '20260101T120000Z'), { recursive: true });
+    await writeFile(
+      path.join(root, '.copperhead', 'config.json'),
+      JSON.stringify({ schematic: 'hw/board.kicad_sch', docs: 'docs/', maxTurns: 12 }, null, 2),
+    );
+    await writeFile(
+      path.join(root, '.copperhead', 'constraints.json'),
+      JSON.stringify(
+        {
+          '3v3.max_current_ma': {
+            max: 500,
+            source: 'BRIEF.md',
+            affects: ['schematic', 'bom'],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFile(
+      path.join(root, '.copperhead', 'runs', '20260101T120000Z', 'summary.md'),
+      '## Run stats\n\n- **Exit path:** `done`\n',
+    );
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('formats resolved config', async () => {
+    const text = await formatConfigInspect(root);
+    expect(text).toContain('Config');
+    expect(text).toContain('hw/board.kicad_sch');
+    expect(text).toContain('12');
+  });
+
+  it('formats constraints registry', async () => {
+    const text = await formatConstraintsInspect(root);
+    expect(text).toContain('3v3.max_current_ma');
+    expect(text).toContain('max 500');
+  });
+
+  it('lists recent runs with exit path', async () => {
+    const text = await formatRunsInspect(root);
+    expect(text).toContain('20260101T120000Z');
+    expect(text).toContain('done');
+  });
+});
+
+describe('repl board inspect (open-key fixture)', () => {
+  let repo: string;
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    setColorEnabled(false);
+    ({ repo, cleanup } = await tempFixtureRepo());
+    await mkdir(path.join(repo, '.copperhead'), { recursive: true });
+    await writeFile(
+      path.join(repo, '.copperhead', 'config.json'),
+      JSON.stringify({ schematic: 'hardware/open-key.kicad_sch', board: 'hardware/open-key.kicad_pcb', docs: 'docs/' }),
+    );
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it('lists parts from schematic', async () => {
+    const text = await formatPartsInspect(repo);
+    expect(text).toContain('R1');
+    expect(text).toContain('10k');
+    expect(text).toContain('U1');
+  });
+
+  it('lists nets and attachments', async () => {
+    const text = await formatNetsInspect(repo);
+    expect(text).toContain('KEY_DAH');
+    expect(text).toContain('3V3');
+  });
+});
+
+describe('repl last run preview', () => {
+  let root: string;
+
+  beforeAll(async () => {
+    setColorEnabled(false);
+    root = await mkdtemp(path.join(tmpdir(), 'copperhead-repl-last-'));
+    await mkdir(path.join(root, '.copperhead', 'runs', '20260101T120000Z'), { recursive: true });
+    await writeFile(
+      path.join(root, '.copperhead', 'runs', '20260101T120000Z', 'summary.md'),
+      '## Run stats\n\n- **Exit path:** `done`\n',
+    );
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('previews last run summary', async () => {
+    const text = await formatLastInspect(root);
+    expect(text).toContain('Last run');
+    expect(text).toContain('Exit path');
+  });
+});
+
+describe('repl board inspect (open-key fixture)', () => {
+  let repo: string;
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    setColorEnabled(false);
+    ({ repo, cleanup } = await tempFixtureRepo());
+    await mkdir(path.join(repo, '.copperhead'), { recursive: true });
+    await writeFile(
+      path.join(repo, '.copperhead', 'config.json'),
+      JSON.stringify({ schematic: 'hardware/open-key.kicad_sch', board: 'hardware/open-key.kicad_pcb', docs: 'docs/' }),
+    );
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it('lists parts from schematic', async () => {
+    const text = await formatPartsInspect(repo);
+    expect(text).toContain('R1');
+    expect(text).toContain('10k');
+    expect(text).toContain('U1');
+  });
+
+  it('lists nets and attachments', async () => {
+    const text = await formatNetsInspect(repo);
+    expect(text).toContain('KEY_DAH');
+    expect(text).toContain('3V3');
+  });
+});
+
+describe('repl last run preview', () => {
+  let root: string;
+
+  beforeAll(async () => {
+    setColorEnabled(false);
+    root = await mkdtemp(path.join(tmpdir(), 'copperhead-repl-last-'));
+    await mkdir(path.join(root, '.copperhead', 'runs', '20260101T120000Z'), { recursive: true });
+    await writeFile(
+      path.join(root, '.copperhead', 'runs', '20260101T120000Z', 'summary.md'),
+      '## Run stats\n\n- **Exit path:** `done`\n',
+    );
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('previews last run summary', async () => {
+    const text = await formatLastInspect(root);
+    expect(text).toContain('Last run');
+    expect(text).toContain('Exit path');
+  });
+});

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import {
+  parseSlash,
+  runRepl,
+  shortPath,
+  helpText,
+  banner,
+  examplesText,
+  completeSlash,
+} from '../src/commands/repl.js';
+import { demoTourText, scaffoldDemoRepo, defaultBriefPath } from '../src/commands/demo.js';
+import { selectMenu } from '../src/util/select.js';
+import {
+  keySequence,
+  inputRowRows,
+  promptWithSlashHints,
+  pushKeys,
+  suggestionLines,
+} from '../src/util/live-prompt.js';
+import { fiducialBootFrames, prefersAnimation } from '../src/agent/animate.js';
+import { plainRenderer } from '../src/agent/render.js';
+import { setColorEnabled } from '../src/agent/theme.js';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { existsSync } from 'node:fs';
+import { PassThrough as NodePassThrough } from 'node:stream';
+import { SLASH_COMMANDS } from '../src/commands/repl.js';
+
+function fakeTty(): { input: PassThrough; output: PassThrough; lines: string[] } {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  (input as unknown as { isTTY: boolean }).isTTY = true;
+  (output as unknown as { isTTY: boolean }).isTTY = true;
+  const lines: string[] = [];
+  return { input, output, lines };
+}
+
+function baseOpts(extra: Partial<Parameters<typeof runRepl>[0]> = {}) {
+  const { input, output, lines } = fakeTty();
+  return {
+    input,
+    output,
+    lines,
+    opts: {
+      repoRoot: '/tmp/repo',
+      model: 'gpt-5',
+      modelSource: 'flag' as const,
+      version: '0.7.0',
+      kicadCliVersion: '9.0.0',
+      renderer: plainRenderer((l) => lines.push(l)),
+      log: (l: string) => lines.push(l),
+      input,
+      output,
+      runRequest: vi.fn(async () => ({ outcome: 'success' as const })),
+      runCheckCmd: vi.fn(async () => {
+        lines.push('check ok');
+      }),
+      ...extra,
+    },
+  };
+}
+
+describe('parseSlash', () => {
+  it('detects slash commands and leaves normal requests alone', () => {
+    expect(parseSlash('add an LED')).toBeNull();
+    expect(parseSlash('/')).toEqual({ cmd: '/', args: '' });
+    expect(parseSlash('/quit')).toEqual({ cmd: '/quit', args: '' });
+    expect(parseSlash('/help me')).toEqual({ cmd: '/help', args: 'me' });
+  });
+
+  it('maps bare quit/clear/help so they never start an agent run', () => {
+    expect(parseSlash('quit')).toEqual({ cmd: '/quit', args: '' });
+    expect(parseSlash('clear')).toEqual({ cmd: '/clear', args: '' });
+    expect(parseSlash('help')).toEqual({ cmd: '/help', args: '' });
+    expect(parseSlash('EXIT')).toEqual({ cmd: '/quit', args: '' });
+  });
+
+  it('maps bare quit/clear/help so they never start an agent run', () => {
+    expect(parseSlash('quit')).toEqual({ cmd: '/quit', args: '' });
+    expect(parseSlash('clear')).toEqual({ cmd: '/clear', args: '' });
+    expect(parseSlash('help')).toEqual({ cmd: '/help', args: '' });
+    expect(parseSlash('EXIT')).toEqual({ cmd: '/quit', args: '' });
+  });
+
+  it('tab-completes slash commands', () => {
+    expect(completeSlash('/d')).toContain('/demo');
+    expect(completeSlash('/d')).toContain('/drift');
+    expect(completeSlash('/st')).toEqual(['/status']);
+    expect(completeSlash('/sy')).toEqual(['/sync']);
+    expect(completeSlash('/con')).toEqual(expect.arrayContaining(['/config', '/constraints']));
+    expect(completeSlash('add')).toEqual([]);
+  });
+
+  it('lists the new inspect slash commands', () => {
+    const values = SLASH_COMMANDS.map((c) => c.value);
+    for (const cmd of [
+      '/sync',
+      '/drift',
+      '/constraints',
+      '/config',
+      '/git',
+      '/runs',
+      '/parts',
+      '/nets',
+      '/bom',
+      '/openspec',
+      '/last',
+    ]) {
+      expect(values).toContain(cmd);
+      expect(helpText()).toContain(cmd);
+    }
+  });
+});
+
+describe('selectMenu', () => {
+  it('returns the item selected with Enter after ↓', async () => {
+    setColorEnabled(false);
+    const output = new NodePassThrough();
+    async function* keys() {
+      yield '\x1b[B'; // down
+      yield '\r';
+    }
+    const chosen = await selectMenu({
+      title: 'Commands',
+      items: [
+        { value: '/demo', label: '/demo' },
+        { value: '/quit', label: '/quit' },
+      ],
+      output: output as unknown as NodeJS.WriteStream,
+      keys: keys(),
+    });
+    expect(chosen).toBe('/quit');
+  });
+
+  it('cancels on Esc', async () => {
+    setColorEnabled(false);
+    const output = new NodePassThrough();
+    async function* keys() {
+      yield '\x1b';
+    }
+    const chosen = await selectMenu({
+      title: 'Commands',
+      items: [{ value: '/demo', label: '/demo' }],
+      output: output as unknown as NodeJS.WriteStream,
+      keys: keys(),
+    });
+    expect(chosen).toBeNull();
+  });
+});
+
+describe('animation helpers', () => {
+  it('fiducial boot has growing frames and respects NO_ANIM', () => {
+    setColorEnabled(true);
+    const prev = process.env.COPPERHEAD_NO_ANIM;
+    process.env.COPPERHEAD_NO_ANIM = '1';
+    expect(prefersAnimation()).toBe(false);
+    if (prev === undefined) delete process.env.COPPERHEAD_NO_ANIM;
+    else process.env.COPPERHEAD_NO_ANIM = prev;
+    const frames = fiducialBootFrames();
+    expect(frames.length).toBeGreaterThanOrEqual(3);
+    expect(frames[frames.length - 1]!.join('\n')).toContain('◯');
+    setColorEnabled(false);
+  });
+});
+
+describe('repl chrome', () => {
+  it('shortens home paths and keeps banner / help readable', () => {
+    setColorEnabled(false);
+    process.env.COPPERHEAD_NO_ANIM = '1';
+    expect(shortPath(`${process.env.HOME}/OpenSource/circuits/copperhead`)).toMatch(/^~/);
+    const text = banner({
+      repoRoot: '/tmp/demo-board',
+      model: 'cursor',
+      modelSource: 'flag',
+      version: '0.7.0',
+      kicadCliVersion: '10.0.5',
+      renderer: plainRenderer(() => {}),
+    }).join('\n');
+    expect(text).toContain('copperhead');
+    expect(text).toContain('interactive shell');
+    expect(text).toContain('────◯────'); // brand fiducial from docs.copperhead.sh
+    expect(text).toContain('cursor');
+    expect(text).toContain('kicad-cli');
+    expect(helpText()).toContain('/check');
+    expect(helpText()).toContain('/demo');
+    expect(helpText()).toContain('/status');
+    expect(helpText()).toContain('live command');
+    expect(helpText()).toContain('<request>');
+    expect(demoTourText()).toContain('What copperhead does');
+    expect(examplesText()).toContain('add reverse-polarity');
+  });
+});
+
+describe('promptWithSlashHints', () => {
+  it('shows hovered command description above the list', () => {
+    setColorEnabled(false);
+    const lines = suggestionLines(
+      [
+        { value: '/demo', label: '/demo', description: 'tour text' },
+        { value: '/quit', label: '/quit', description: 'leave the shell' },
+      ],
+      1,
+    );
+    const joined = lines.join('\n');
+    expect(joined).toContain('/quit');
+    expect(joined).toContain('leave the shell');
+  });
+
+  it('counts wrap rows for long pasted lines', () => {
+    expect(inputRowRows('> ', 'x'.repeat(20), 10)).toBeGreaterThan(1);
+  });
+
+  it('coalesces paste via drainPrintable', async () => {
+    setColorEnabled(false);
+    const output = new NodePassThrough();
+    (output as unknown as { columns: number }).columns = 40;
+    const queued = ['p', 'p', 'e', 'n', 'd'];
+    let i = 0;
+    const seq = ['A', ...queued, '\r'];
+    const line = await promptWithSlashHints({
+      prompt: '> ',
+      commands: SLASH_COMMANDS,
+      output: output as unknown as NodeJS.WriteStream,
+      readKey: async () => (i < seq.length ? seq[i++]! : null),
+      drainPrintable: () => {
+        let out = '';
+        while (queued.length) out += queued.shift()!;
+        i += out.length; // skip drained keys in readKey sequence
+        return out;
+      },
+    });
+    expect(line).toBe('Append');
+  });
+
+  it('shows matches as soon as / is typed and Enter picks the highlight', async () => {
+    setColorEnabled(false);
+    const output = new NodePassThrough();
+    let painted = '';
+    output.on('data', (c) => {
+      painted += String(c);
+    });
+    const line = await promptWithSlashHints({
+      prompt: '> ',
+      commands: SLASH_COMMANDS,
+      output: output as unknown as NodeJS.WriteStream,
+      readKey: keySequence(['/', 'd', '\r']),
+    });
+    expect(line).toBe('/demo');
+    expect(painted).toContain('/demo');
+    // Final committed line in scrollback must show the selected command.
+    expect(painted).toMatch(/> \/demo\n/);
+  });
+
+  it('↓ moves the highlight before Enter', async () => {
+    setColorEnabled(false);
+    const output = new NodePassThrough();
+    let painted = '';
+    output.on('data', (c) => {
+      painted += String(c);
+    });
+    const line = await promptWithSlashHints({
+      prompt: '> ',
+      commands: SLASH_COMMANDS,
+      output: output as unknown as NodeJS.WriteStream,
+      readKey: keySequence(['/', '\x1b[B', '\r']),
+    });
+    expect(line).toBe('/examples');
+    expect(painted).toContain('example change-request prompts');
+  });
+
+  it('assembles arrow keys that arrive split across chunks', () => {
+    const pending = { buf: '' };
+    const keys: string[] = [];
+    pushKeys(pending, '\x1b', (k) => keys.push(k));
+    expect(keys).toEqual([]); // wait for rest of sequence
+    pushKeys(pending, '[B', (k) => keys.push(k));
+    expect(keys).toEqual(['\x1b[B']);
+  });
+
+  it('SS3 arrow sequences work (\\x1bOA)', async () => {
+    setColorEnabled(false);
+    const output = new NodePassThrough();
+    const line = await promptWithSlashHints({
+      prompt: '> ',
+      commands: SLASH_COMMANDS,
+      output: output as unknown as NodeJS.WriteStream,
+      readKey: keySequence(['/', '\x1bOB', '\x1bOB', '\r']),
+    });
+    // /demo → /examples → /status
+    expect(line).toBe('/status');
+  });
+});
+
+describe('demo scaffold', () => {
+  it('creates a git repo with config ready for create', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'copperhead-demo-'));
+    try {
+      await scaffoldDemoRepo(dir);
+      expect(existsSync(path.join(dir, '.git'))).toBe(true);
+      expect(existsSync(path.join(dir, '.copperhead/config.json'))).toBe(true);
+      expect(existsSync(defaultBriefPath())).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runRepl', () => {
+  it('refuses a non-TTY shell without a seed', async () => {
+    setColorEnabled(false);
+    const lines: string[] = [];
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const res = await runRepl({
+      repoRoot: '/tmp/repo',
+      model: 'gpt-5',
+      modelSource: 'flag',
+      version: '0.7.0',
+      kicadCliVersion: '9.0.0',
+      renderer: plainRenderer(() => {}),
+      log: (l) => lines.push(l),
+      input,
+      output,
+    });
+    expect(res.ok).toBe(false);
+    expect(lines.join('\n')).toContain('requires a TTY');
+  });
+
+  it('runs a seed on non-TTY as a one-shot', async () => {
+    setColorEnabled(false);
+    const lines: string[] = [];
+    const runRequest = vi.fn(async () => ({ outcome: 'success' as const }));
+    const res = await runRepl({
+      repoRoot: '/tmp/repo',
+      model: 'gpt-5',
+      modelSource: 'flag',
+      version: '0.7.0',
+      kicadCliVersion: '9.0.0',
+      seed: 'add ESD diodes',
+      renderer: plainRenderer(() => {}),
+      log: (l) => lines.push(l),
+      input: new PassThrough(),
+      output: new PassThrough(),
+      runRequest,
+    });
+    expect(res).toEqual({ ok: true, turns: 1 });
+    expect(runRequest).toHaveBeenCalledWith('add ESD diodes');
+  });
+
+  it('handles /help /demo /examples /model /check /quit on a TTY', async () => {
+    setColorEnabled(false);
+    const { input, output, lines, opts } = baseOpts();
+    const done = runRepl(opts);
+
+    // Drive the prompt after the banner is written.
+    await new Promise((r) => setTimeout(r, 20));
+    input.write('/help\n');
+    await new Promise((r) => setTimeout(r, 20));
+    input.write('/demo\n');
+    await new Promise((r) => setTimeout(r, 20));
+    input.write('/examples\n');
+    await new Promise((r) => setTimeout(r, 20));
+    input.write('/model\n');
+    await new Promise((r) => setTimeout(r, 20));
+    input.write('/check\n');
+    await new Promise((r) => setTimeout(r, 20));
+    input.write('/quit\n');
+
+    const res = await done;
+    expect(res.ok).toBe(true);
+    expect(res.turns).toBe(0);
+    expect(lines.join('\n')).toContain('interactive shell');
+    expect(lines.join('\n')).toContain('/quit');
+    expect(lines.join('\n')).toContain('What copperhead does');
+    expect(lines.join('\n')).toContain('Example prompts');
+    expect(lines.join('\n')).toContain('gpt-5');
+    expect(lines.join('\n')).toContain('via flag');
+    expect(lines).toContain('check ok');
+    expect(lines.join('\n')).toContain('session ended');
+    expect(opts.runRequest).not.toHaveBeenCalled();
+  });
+
+  it('typing /demo via live hints then /quit works end-to-end', async () => {
+    setColorEnabled(false);
+    const { input, lines, opts } = baseOpts();
+    const done = runRepl(opts);
+
+    await new Promise((r) => setTimeout(r, 30));
+    input.write('/demo\n');
+    await new Promise((r) => setTimeout(r, 40));
+    input.write('/quit\n');
+
+    const res = await done;
+    expect(res.ok).toBe(true);
+    expect(lines.join('\n')).toContain('What copperhead does');
+    expect(lines.join('\n')).toContain('session ended');
+  });
+
+
+  it('runs a natural-language request then continues until /quit', async () => {
+    setColorEnabled(false);
+    const { input, output, lines, opts } = baseOpts();
+    const done = runRepl(opts);
+
+    await new Promise((r) => setTimeout(r, 20));
+    input.write('rename net KEY_DAH to KEY_DASH\n');
+    await new Promise((r) => setTimeout(r, 20));
+    input.write('/quit\n');
+
+    const res = await done;
+    expect(res).toEqual({ ok: true, turns: 1 });
+    expect(opts.runRequest).toHaveBeenCalledWith('rename net KEY_DAH to KEY_DASH');
+    expect(lines.join('\n')).toContain('session ended');
+    void output; // keep stream alive for typing
+  });
+});


### PR DESCRIPTION
```markdown
## What

`copperhead` with no subcommand is now a Claude Code–style interactive shell: live `/` command menu with hover descriptions, copper-themed chrome, and read-only board inspect slash commands. `copperhead demo` and `kicad-cli` PATH fallbacks land in the same UX pass.

## Why

The CLI was one-shot (`do` / `create`) with dense, hard-to-scan terminal output. Operators needed a persistent prompt, discoverable commands, and fast inspect paths that do not start an LLM turn.

## Design

- Default command is `repl` in [cli.ts](src/cli.ts): each natural-language line runs one gated `do`-equivalent turn via [loop.ts](src/agent/loop.ts), then returns to the prompt. Slash commands never unlock `edit_file` / `write_file` by themselves.
- Live prompt in [live-prompt.ts](src/util/live-prompt.ts): typing `/` shows matches; ↑/↓ hover updates a description strip above the list; Enter selects; paste coalescing + wrap-aware clear avoid stacked prompt lines.
- Inspect formatters in [repl-inspect.ts](src/commands/repl-inspect.ts) reuse existing helpers (`listSymbols`, `syncVerify`, `checkDrift`, `openspecValidate`, etc.). Verify-only: no sync-resolve, create, or export from the shell.
- Theme / chrome in [theme.ts](src/agent/theme.ts), [render.ts](src/agent/render.ts), [animate.ts](src/agent/animate.ts), [logo.ts](src/agent/logo.ts). Color is TTY-only; `--plain` / `--json` stay zero-ANSI (AC-8.8 / AC-8.9).
- [kicad/cli.ts](src/kicad/cli.ts): PATH → macOS KiCad.app fallbacks → `COPPERHEAD_KICAD_CLI`.

Agent-loop safety gates are unchanged: REPL agent turns still go through the same loop, snapshot, and verification path as `do`.

## Spec / OpenSpec

- Updated [openspec/specs/SPEC.md](openspec/specs/SPEC.md) §3: `copperhead [repl]` surface and slash-command list; AC-8.8 note that interactive chrome may use muted SGR color.
- No new OpenSpec change folder; CLI surface + observability wording only (no delta specs / `tasks.md` for a separate change).

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | pass (380 passed, 17 skipped) |
| Live-LLM (opt-in) | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `COPPERHEAD_TEST_CODEX=1` | skip (not run for this PR) |

New / changed tests: [test/repl.test.ts](test/repl.test.ts), [test/repl-inspect.test.ts](test/repl-inspect.test.ts), [test/observability.test.ts](test/observability.test.ts).

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): `edit` (`manual-tests/runs/edit`)
- Commands run and outcome:

```text
$ cd manual-tests/runs/edit && copperhead --model cursor
# REPL banner + prompt; / menu shows new inspect commands with hover descriptions

$ /parts
# listed R1/R2/U1 from open-key schematic

$ /check
# deterministic ERC/DRC/drift path (no LLM)

$ Append one line to docs/DECISIONS.md ...
# agent turn started; --model cursor stalled (provider plan-mode / no tool calls).
# Not a regression of REPL wiring: same gates as `do`. Retry with claude / gpt-5 / claude-code for a finishing demo.
```

## Docs

- [README.md](README.md): REPL / `demo` entry points
- [docs/src/content/docs/reference/cli.md](docs/src/content/docs/reference/cli.md): slash-command list
- [docs/src/content/docs/getting-started/demo.md](docs/src/content/docs/getting-started/demo.md): demo notes
- [openspec/specs/SPEC.md](openspec/specs/SPEC.md): §3 CLI surface

---

## Invariant checklist

- [x] **Spec-gated in**: N/A for inspect slash commands (no edit tools). REPL agent turns still call [loop.ts](src/agent/loop.ts) unchanged; edit tools remain absent until validate.
- [x] **Verification-gated out**: N/A for inspect-only slash path. Agent turns from the REPL still use the existing verify/repair/rollback path.
- [x] **`check`/`verify` stays LLM-free and network-free**: `/check` calls [check.ts](src/commands/check.ts) only; no provider import added to the check module graph.
- [x] **No sexp serialization**: inspect uses `listSymbols` / `listNets` / `pinNets` read-only; no sexp write path added.
- [x] **Sync-obligations ledger**: N/A (no new commit path). `/sync` is verify-only via `syncVerify`, not `syncResolve`.
- [x] **Secrets**: no change to redaction or `.gitignore`; runs still under `.copperhead/runs/`.
- [x] **Spec coherence**: SPEC.md §3 + AC-8.8 color note updated with the CLI docs; no separate change archive required for this surface extension.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive REPL that launches by default with `copperhead`, including slash commands, autocomplete, repository inspections, and one-shot non-interactive execution.
  * Added `copperhead demo` with guided tours, model selection, custom output directories, and USB-C breakout demo setup.
  * Improved interactive terminal presentation with banners, colors, animations, status details, and prompt suggestions.

* **Bug Fixes**
  * Improved KiCad CLI discovery, including macOS fallback locations and clearer missing-tool guidance.

* **Documentation**
  * Updated quick-start, demo, and CLI documentation with the new workflows and commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->