### PR TITLE
fix(export): stop at the end of the parts table in BOM.md

### DIFF
--- a/src/kicad/bom-export.ts
+++ b/src/kicad/bom-export.ts
@@ -1,4 +1,4 @@
-import { parseMarkdownTables, type TableRow } from '../memory/bom-table.js';
+import { groupPipeTables, type TableRow } from '../memory/bom-table.js';
 
 /**
  * Supplier-format BOM export (capability supplier-bom-export). Deterministic,
@@ -73,8 +73,15 @@ const UNVERIFIED_RE = /\bUNVERIFIED\b/i;
 
 /**
  * Parse BOM.md into rows by column header, tolerating extra/reordered columns.
- * Only the header row and data rows of the first parts table are used; a table
- * without a recognizable Refdes header yields no rows.
+ * Only the header row and data rows of the first parts table are used; a
+ * document without a recognizable Refdes header yields no rows.
+ *
+ * Tables are grouped before the header is located (`groupPipeTables`), so the
+ * parts table ends where its markdown table ends. Reading a flat row list
+ * instead would let every later table in the file spill into the export: a
+ * supporting roll-up's own header row becomes an order line (the literal cell
+ * `MPN` shipped as a part number) and its data rows become parts, all of them
+ * ordered from a supplier for a board that has no such components.
  *
  * NOTE: the drift gate this exporter runs behind (checkDrift in
  * ../memory/drift.ts) reads Refdes|Value|Footprint *by position*, not by header.
@@ -83,10 +90,10 @@ const UNVERIFIED_RE = /\bUNVERIFIED\b/i;
  * drift message. Keep the base three columns first and in order; only append.
  */
 export function parseBom(md: string): BomRow[] {
-  const tableRows = parseMarkdownTables(md);
-  const headerIdx = tableRows.findIndex((r) => r.cells.some((c) => HEADER_ALIASES[norm(c)] === 'refdes'));
-  const header = headerIdx === -1 ? undefined : tableRows[headerIdx];
-  if (!header) return [];
+  const isPartsHeader = (r: TableRow): boolean => r.cells.some((c) => HEADER_ALIASES[norm(c)] === 'refdes');
+  const table = groupPipeTables(md).find((g) => g.length > 0 && isPartsHeader(g[0]!));
+  if (!table) return [];
+  const header = table[0]!;
   const col: Partial<Record<keyof BomRow, number>> = {};
   header.cells.forEach((c, i) => {
     const field = HEADER_ALIASES[norm(c)];
@@ -100,7 +107,7 @@ export function parseBom(md: string): BomRow[] {
   };
 
   const rows: BomRow[] = [];
-  for (const row of tableRows.slice(headerIdx + 1)) {
+  for (const row of table.slice(1)) {
     const refdes = at(row, 'refdes');
     if (!refdes) continue; // blank line / stray row
     const mpn = at(row, 'mpn');

--- a/src/memory/bom-table.ts
+++ b/src/memory/bom-table.ts
@@ -56,17 +56,18 @@ export interface TableRow {
   }
 
   /**
-   * Like parseCanonicalRows, but keeps each kept table's header row so a caller
-   * can resolve columns by *name* instead of a fixed position. PINOUT.md's
-   * column count is not fixed in practice: the scaffold writes
-   * `Refdes | Pin | Name | Net | Notes`, but a hand- or LLM-authored table may
-   * legitimately drop the optional Name/Notes columns and write
-   * `Refdes | Pin | Net`. A fixed positional net index then reads the wrong cell
-   * and reports every pin as net "NC" against a doc that is in fact correct —
-   * a false drift the agent cannot diagnose (the doc plainly shows the net), so
-   * it loops on finish forever. Resolving by header name fixes that.
+   * Group a document's pipe-rows into tables without deciding which of them is
+   * canonical: a run of pipe-rows is one table, and any non-pipe line (blank or
+   * prose) ends it. Separator rows stay inside their table.
+   *
+   * `parseCanonicalTables` is this plus the Refdes/Pin `isHeader` test. It is
+   * exported separately because a caller can recognize a header this module
+   * does not: the supplier exporter accepts `Ref`/`Designator`/`Reference` as
+   * well as `Refdes`. Such a caller still needs the grouping — without it, the
+   * only alternative is the flat `parseMarkdownTables`, which merges every
+   * table in the file and turns a supporting table's rows into parts.
    */
-  export function parseCanonicalTables(md: string): Array<{ header: TableRow; rows: TableRow[] }> {
+  export function groupPipeTables(md: string): TableRow[][] {
     const groups: TableRow[][] = [];
     let current: TableRow[] | null = null;
     for (const line of md.split('\n')) {
@@ -86,8 +87,23 @@ export interface TableRow {
       }
       current.push({ cells });
     }
+    return groups;
+  }
+
+  /**
+   * Like parseCanonicalRows, but keeps each kept table's header row so a caller
+   * can resolve columns by *name* instead of a fixed position. PINOUT.md's
+   * column count is not fixed in practice: the scaffold writes
+   * `Refdes | Pin | Name | Net | Notes`, but a hand- or LLM-authored table may
+   * legitimately drop the optional Name/Notes columns and write
+   * `Refdes | Pin | Net`. A fixed positional net index then reads the wrong cell
+   * and reports every pin as net "NC" against a doc that is in fact correct —
+   * a false drift the agent cannot diagnose (the doc plainly shows the net), so
+   * it loops on finish forever. Resolving by header name fixes that.
+   */
+  export function parseCanonicalTables(md: string): Array<{ header: TableRow; rows: TableRow[] }> {
     const tables: Array<{ header: TableRow; rows: TableRow[] }> = [];
-    for (const g of groups) {
+    for (const g of groupPipeTables(md)) {
       if (g.length && isHeader(g[0]!)) tables.push({ header: g[0]!, rows: g.slice(1) });
     }
     return tables;

--- a/test/bom-export.test.ts
+++ b/test/bom-export.test.ts
@@ -53,6 +53,57 @@ describe('BOM parsing (supplier-bom-export)', () => {
   it('returns no rows when there is no Refdes-headed table', () => {
     expect(parseBom('# nothing here\n\njust prose\n')).toEqual([]);
   });
+
+  // I5 taught the drift gate that BOM.md legitimately carries supporting
+  // tables (a quiescent-current roll-up, a cost summary). The exporter read a
+  // flat row list, so those rows became parts and their header row became one
+  // too — the literal cell "MPN" ordered as a part number.
+  const BOM_WITH_ROLLUP = `# Bill of Materials
+
+| Refdes | Value | Footprint | MPN | Manufacturer |
+|---|---|---|---|---|
+| R1 | 5.1k | Resistor_SMD:R_0603_1608Metric | RC0603FR-075K1L | Yageo |
+
+## Quiescent-current roll-up
+
+| Item | Current | Notes | MPN | Manufacturer |
+|---|---|---|---|---|
+| LED branch | 0.9 mA | at 5 V | ROLLUP-NOT-A-PART | n/a |
+| Total | 0.9 mA | | ROLLUP-NOT-A-PART | n/a |
+`;
+
+  it('stops at the end of the parts table, ignoring a supporting table (I5)', () => {
+    expect(parseBom(BOM_WITH_ROLLUP).map((r) => r.refdes)).toEqual(['R1']);
+  });
+
+  it('never lets a supporting table reach a supplier cart', () => {
+    const rows = parseBom(BOM_WITH_ROLLUP);
+    const { csv } = buildExport(rows, 'digikey', { boards: 1, spares: 10, includeUnverified: false });
+    expect(csv).toBe(
+      'Manufacturer Part Number,Manufacturer,Quantity,Customer Reference\n' +
+        'RC0603FR-075K1L,Yageo,3,R1\n',
+    );
+    // The two failure shapes specifically: the roll-up's own header row read as
+    // a part, and its data rows read as parts.
+    expect(csv).not.toContain('MPN,Manufacturer,2,Item');
+    expect(csv).not.toContain('ROLLUP-NOT-A-PART');
+  });
+
+  it('reads the parts table when a supporting table comes first', () => {
+    const md = `## Cost summary
+
+| Item | Cost |
+|---|---|
+| Total | $4.20 |
+
+## Parts
+
+| Refdes | Value | Footprint | MPN |
+|---|---|---|---|
+| C1 | 10uF | Capacitor_SMD:C_0603_1608Metric | GRM188R61A106KE69D |
+`;
+    expect(parseBom(md).map((r) => r.refdes)).toEqual(['C1']);
+  });
 });
 
 describe('quantity arithmetic (supplier-bom-export)', () => {


### PR DESCRIPTION
## What

`copperhead export bom` no longer emits parts that are not on the board. It reads the parts table in BOM.md and stops where that table ends, instead of running to the end of the document.

## Why

Closes #99.

BOM.md legitimately carries supporting tables (a quiescent-current roll-up, a cost summary). `parseBom` read a flat list of every pipe-row in the file, found the Refdes header, and then took `slice(headerIdx + 1)` to the end. Everything after the parts table became a part, including the supporting table's own header row.

Against a BOM.md in exactly the shape I5 taught the drift gate to accept, on `main`:

```text
$ npm run dev -- --repo manual-tests/runs/edit export bom --supplier digikey
wrote outputs/digikey-bom.csv (5 part(s), 0 excluded)

Manufacturer Part Number,Manufacturer,Quantity,Customer Reference
LTST-C191KRKT,Lite-On,2,D1
MPN,Manufacturer,2,Item                          <- the roll-up's HEADER row
ROLLUP-NOT-A-PART,n/a,3,"LED branch,Total"       <- the roll-up's data rows
RC0603FR-075K1L,Yageo,3,R1
```

Three of five order lines are not components. The literal cell `MPN` is being sent to DigiKey as a manufacturer part number.

Two things make this worth more than a parsing nit:

1. **The gate is green while the file is wrong.** `export bom` refuses on drift, and after I5 the drift gate correctly ignores the roll-up. So the user sees a passing check and a bad CSV, with nothing pointing at the discrepancy.
2. **The output is an ordering document.** I5's version of this bug produced a false drift message a human reads and dismisses. This one produces a file the user uploads to a supplier to buy parts with.

## Design

`src/memory/bom-table.ts` already groups tables correctly for the drift gate ([parseCanonicalTables](src/memory/bom-table.ts)), but the exporter cannot call it: `isHeader` tests for exactly `refdes` or `pin`, while the exporter accepts `Ref`, `Designator` and `Reference` through `HEADER_ALIASES`. Calling it would silently drop BOMs whose header says `Designator`.

So the grouping is split from the header test:

- `groupPipeTables(md)` returns table boundaries and nothing else: a run of pipe-rows is one table, any non-pipe line ends it, separator rows stay inside. This is the exact body lifted out of `parseCanonicalTables`, which now calls it, so the two paths cannot drift apart.
- `parseBom` selects the first group whose header it recognizes and reads only that group's rows.

No behavior change for a single-table BOM.md, which is what every existing test and the `init` scaffold produce.

I kept `parseMarkdownTables` as is: it is still the right primitive for a caller that genuinely wants every row, and narrowing it would be a wider blast radius than this bug justifies.

## Spec / OpenSpec

No spec-level behavior change. The capability requirement ("BOM.md is the sole input") is unchanged; this makes the parser honor the fixed-column contract it already claimed.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | 340 passed, 8 failed, 17 skipped |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY` | n/a (no provider is reachable from this path by design) |

The 8 failures are `kicad-cli not found on PATH` in my environment, and are pre-existing. I ran both sides rather than asserting it:

```text
main                8 failed | 337 passed | 17 skipped
this branch         8 failed | 340 passed | 17 skipped
```

Same 8, and +3 passed is exactly the three tests added here.

**New tests** (test/bom-export.test.ts): parts table followed by a supporting table, the resulting CSV, and a supporting table placed *before* the parts table.

I checked they actually fail without the fix, by reverting `parseBom` to the flat read and keeping everything else:

```text
 × stops at the end of the parts table, ignoring a supporting table (I5)
 × never lets a supporting table reach a supplier cart
   - Expected
   + Received
   + MPN,Manufacturer,2,Item
   + ROLLUP-NOT-A-PART,n/a,3,"LED branch,Total"
```

Only those two, and for the stated reason.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): `edit`, with a hand-written BOM.md carrying a roll-up table. `kicad-cli` is not on my PATH, so `init` cannot run here; `export bom` does not need it (it is LLM-free and network-free, and skips the drift gate when no schematic is configured), so the export path itself is fully exercised.
- Commands run and outcome:

```text
$ ./manual-tests/setup.sh edit
$ cat > manual-tests/runs/edit/docs/BOM.md   # parts table + quiescent-current roll-up

# on main
$ npm run dev -- --repo manual-tests/runs/edit export bom --supplier digikey
wrote outputs/digikey-bom.csv (5 part(s), 0 excluded)
Manufacturer Part Number,Manufacturer,Quantity,Customer Reference
LTST-C191KRKT,Lite-On,2,D1
MPN,Manufacturer,2,Item
ROLLUP-NOT-A-PART,n/a,3,"LED branch,Total"
RC0603FR-075K1L,Yageo,3,R1

# on this branch
$ npm run dev -- --repo manual-tests/runs/edit export bom --supplier digikey
wrote outputs/digikey-bom.csv (2 part(s), 0 excluded)
Manufacturer Part Number,Manufacturer,Quantity,Customer Reference
LTST-C191KRKT,Lite-On,2,D1
RC0603FR-075K1L,Yageo,3,R1

$ npm run dev -- --repo manual-tests/runs/edit export bom --supplier jlcpcb
NOTE: no LCSC part # for R1, D1 (JLCPCB accepts the upload but needs manual matching for these)
wrote outputs/jlcpcb-bom.csv (2 part(s), 0 excluded)
Comment,Designator,Footprint,LCSC Part #
Red,D1,LED_SMD:LED_0603_1608Metric,
5.1k,R1,Resistor_SMD:R_0603_1608Metric,
```

The part count in the CLI's own summary line (5 to 2) is the same fact the CSV shows.

## Docs

None needed: no flag, format, or documented behavior changes. The two parsing functions carry doc comments explaining the split and why the exporter cannot reuse `parseCanonicalTables`.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, no change to the agent tool list.
- [ ] **Verification-gated out**: N/A, this path performs no mutation.
- [x] **`check`/`verify` stays LLM-free and network-free**: `export bom` shares the drift gate with `check`. This change touches only markdown parsing in `src/memory/bom-table.ts` and `src/kicad/bom-export.ts`; neither imports a provider, and no import was added.
- [x] **No sexp serialization**: N/A in effect, and preserved: nothing here touches `src/kicad/sexp.ts` or writes a KiCad file. The only file written is `outputs/<supplier>-bom.csv`.
- [ ] **Sync-obligations ledger**: N/A, not reachable from the export path.
- [ ] **Secrets**: N/A, no transcript or summary is written.
- [ ] **Spec coherence**: N/A, no spec-level behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BOM parsing to identify the correct parts table in Markdown documents.
  * Prevented supporting tables, such as cost or roll-up sections, from being incorrectly included as component rows.
  * BOM exports now handle supporting sections appearing before or after the parts table correctly.

* **Tests**
  * Added coverage for multiple-table BOM documents and export accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->