### PR TITLE
fix(recovery): read the verdict past a stray brace or a preamble object

### DIFF
--- a/src/agent/recovery.ts
+++ b/src/agent/recovery.ts
@@ -48,13 +48,51 @@ export interface StageDiagnosis {
   usage?: { inputTokens: number; outputTokens: number };
 }
 
-/** Extract the first brace-balanced JSON object from text, tolerating quoting and
- * escaping, and interpret it as a StageDiagnosis. Anything unparseable is treated
- * as "abort" so an ambiguous diagnosis never loops the pipeline forever. */
+/**
+ * Interpret a diagnosis turn as a StageDiagnosis. Anything unparseable is
+ * treated as "abort" so an ambiguous diagnosis never loops the pipeline forever.
+ *
+ * Every brace-balanced object in the text is tried, not just the first one, and
+ * the first that actually carries a `verdict` wins. Scanning only the first
+ * candidate made a *correct* diagnosis abort the whole run in two shapes seen
+ * from real models: an unbalanced brace in prose ahead of the JSON ("the stage
+ * emitted a literal {"), which consumed the real object as part of one
+ * never-closing candidate; and a preamble object such as `{"note":"thinking"}`,
+ * which parsed, lacked a verdict, and was accepted as an abort. Both cost a
+ * retry that the model had just asked for, and an aborted stage ends the run.
+ */
 export function parseDiagnosis(text: string | null): StageDiagnosis {
   if (!text) return { verdict: 'abort', reason: 'no diagnosis produced' };
-  const start = text.indexOf('{');
-  if (start >= 0) {
+  for (const candidate of balancedJsonObjects(text)) {
+    let o: Partial<StageDiagnosis>;
+    try {
+      o = JSON.parse(candidate) as Partial<StageDiagnosis>;
+    } catch {
+      continue; // brace-balanced but not JSON (e.g. prose in braces)
+    }
+    // A parsed object with no verdict is not the diagnosis: keep looking rather
+    // than reading it as an abort.
+    if (o.verdict !== 'retry' && o.verdict !== 'abort') continue;
+    return {
+      verdict: o.verdict,
+      reason: typeof o.reason === 'string' ? o.reason : 'no reason given',
+      ...(o.verdict === 'retry' && typeof o.guidance === 'string' && o.guidance.trim()
+        ? { guidance: o.guidance.trim() }
+        : {}),
+    };
+  }
+  return { verdict: 'abort', reason: 'diagnosis was not valid JSON' };
+}
+
+/**
+ * Every brace-balanced substring of `text`, starting at each `{` in order.
+ * String literals (and their escapes) are respected, so a brace inside a JSON
+ * string does not affect depth. A `{` that never closes yields nothing and the
+ * scan moves on to the next one, which is what keeps a stray brace in prose
+ * from swallowing the object that follows it.
+ */
+function* balancedJsonObjects(text: string): Generator<string> {
+  for (let start = text.indexOf('{'); start >= 0; start = text.indexOf('{', start + 1)) {
     let depth = 0;
     let inStr = false;
     let esc = false;
@@ -69,23 +107,11 @@ export function parseDiagnosis(text: string | null): StageDiagnosis {
       if (ch === '"') inStr = true;
       else if (ch === '{') depth++;
       else if (ch === '}' && --depth === 0) {
-        try {
-          const o = JSON.parse(text.slice(start, i + 1)) as Partial<StageDiagnosis>;
-          const verdict = o.verdict === 'retry' ? 'retry' : 'abort';
-          return {
-            verdict,
-            reason: typeof o.reason === 'string' ? o.reason : 'no reason given',
-            ...(verdict === 'retry' && typeof o.guidance === 'string' && o.guidance.trim()
-              ? { guidance: o.guidance.trim() }
-              : {}),
-          };
-        } catch {
-          break;
-        }
+        yield text.slice(start, i + 1);
+        break;
       }
     }
   }
-  return { verdict: 'abort', reason: 'diagnosis was not valid JSON' };
 }
 
 /** Compact, most-recent-last excerpt of a run's transcript for the diagnostician:

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -60,6 +60,36 @@ describe('parseDiagnosis', () => {
     expect(parseDiagnosis(null).verdict).toBe('abort');
     expect(parseDiagnosis('{"reason":"x"}').verdict).toBe('abort');
   });
+
+  // An aborted stage ends the run, so reading a retry as an abort is not a
+  // parsing nit: it discards a recovery the model just asked for.
+  it('finds the verdict past an unbalanced brace in the prose', () => {
+    const d = parseDiagnosis(
+      'The stage emitted a literal { in its output.\n' +
+        '{"verdict":"retry","reason":"dropped edit","guidance":"apply the edit"}',
+    );
+    expect(d.verdict).toBe('retry');
+    expect(d.reason).toBe('dropped edit');
+    expect(d.guidance).toBe('apply the edit');
+  });
+
+  it('skips a preamble object that carries no verdict', () => {
+    const d = parseDiagnosis('{"note":"thinking"}\n{"verdict":"retry","reason":"real reason"}');
+    expect(d.verdict).toBe('retry');
+    expect(d.reason).toBe('real reason');
+  });
+
+  it('still aborts when no object anywhere carries a verdict', () => {
+    const d = parseDiagnosis('{"note":"thinking"}\n{"reason":"still no verdict"}');
+    expect(d.verdict).toBe('abort');
+    expect(d.reason).toBe('diagnosis was not valid JSON');
+  });
+
+  it('does not treat a brace inside a JSON string as structure', () => {
+    const d = parseDiagnosis('{"verdict":"retry","reason":"x","guidance":"call it with {\\"path\\": \\"a.md\\"}"}');
+    expect(d.verdict).toBe('retry');
+    expect(d.guidance).toBe('call it with {"path": "a.md"}');
+  });
 });
 
 describe('diagnoseStageFailure', () => {


### PR DESCRIPTION
## What

The stage-recovery diagnostician's verdict is now read correctly when the model puts a brace, or a second JSON object, in front of the one that matters. A `retry` verdict is no longer silently turned into an `abort`.

## Why

Closes #101.

`parseDiagnosis` scanned only the first `{` in the text. Two shapes models actually produce defeated it, and `create.ts` treats `abort` as terminal, so each one ended the run instead of running the retry the model had just asked for.

**A brace in the prose ahead of the JSON.** Depth never returns to zero, so the real object is consumed as part of that one never-closing candidate:

```text
in:  The stage emitted a literal { in its output.
     {"verdict":"retry","reason":"dropped edit","guidance":"apply the edit"}
out: {"verdict":"abort","reason":"diagnosis was not valid JSON"}
```

This is not an exotic input. The diagnostician is describing a failing pipeline stage, and stage failures are often about JSON, tool arguments, or s-expressions, so braces show up in the explanation.

**A preamble object with no verdict.** It parses, so the function returns from it:

```text
in:  {"note":"thinking"}
     {"verdict":"retry","reason":"real reason"}
out: {"verdict":"abort","reason":"no reason given"}
```

`const verdict = o.verdict === 'retry' ? 'retry' : 'abort'` reads "this object has no verdict" as "this object says abort".

The fail-safe-to-abort rule is right, but it is meant for an *ambiguous* diagnosis. Neither of these is ambiguous: the model returned a well-formed verdict and the parser discarded it.

## Design

The brace scan is split out as `balancedJsonObjects`, a generator that yields every balanced object starting at each `{` in order (string literals and escapes still respected, so a brace inside a JSON string does not affect depth). A `{` that never closes yields nothing and the scan moves to the next one, which is what stops a stray brace from swallowing what follows it.

`parseDiagnosis` then takes the first candidate that **carries a verdict**, rather than the first that parses. That single rule covers both shapes, and it keeps the fail-safe intact: text with no verdict anywhere still aborts.

One message changes as a result. A genuinely verdictless diagnosis used to abort with `no reason given`, which reads like the model gave a bad reason; it now aborts with `diagnosis was not valid JSON`, which is what actually happened.

No change to the caller, the prompt, or the shape of `StageDiagnosis`.

## Spec / OpenSpec

No spec-level behavior change: this makes the existing recovery contract hold for inputs it already intended to accept.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | 341 passed, 8 failed, 17 skipped |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY` | n/a (parseDiagnosis is pure; the provider call around it is already covered by the existing `diagnoseStageFailure` tests with a stub provider) |

The 8 failures are `kicad-cli not found on PATH` in my environment and are pre-existing. Both sides run, rather than assumed:

```text
main                8 failed | 337 passed | 17 skipped
this branch         8 failed | 341 passed | 17 skipped
```

Same 8, and +4 passed is exactly the four tests added here. The branch is based on `main`, not on my other open PR (#100).

**New tests** (test/recovery.test.ts): the unbalanced-brace shape, the preamble-object shape, the no-verdict-anywhere case, and a brace inside a JSON string.

I checked they fail without the fix, against `main`'s `parseDiagnosis` with the new tests applied:

```text
 × finds the verdict past an unbalanced brace in the prose
     expected 'abort' to be 'retry'
 × skips a preamble object that carries no verdict
     expected 'abort' to be 'retry'
 × still aborts when no object anywhere carries a verdict
     expected 'no reason given' to be 'diagnosis was not valid JSON'
```

The third one is worth reading carefully: the verdict is already correct there, so only the reason string moves. I kept it as a test because it is what proves the fail-safe was not weakened while making the parser more forgiving.

The brace-inside-a-string test passes on both sides. It is a characterization test, not a regression one: that behavior is load-bearing for the new scan and was previously untested.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a. `parseDiagnosis` is a pure function on the model's diagnosis text, and reaching it through the CLI requires a real stage failure inside `copperhead create`, which needs both `kicad-cli` and a provider. Exercising it by hand would mean staging an artificial failure, which tests my staging rather than the parser. It is exercised directly instead:

```text
$ npx vitest run test/recovery.test.ts
 ✓ test/recovery.test.ts (14 tests) 36ms
```

## Docs

None needed: no flag, prompt, or documented behavior changes. The reasoning lives in the doc comments on `parseDiagnosis` and `balancedJsonObjects`, including the two failing shapes, so the next person to touch the scan knows what the ordering rule is for.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, the agent tool list is untouched.
- [x] **Verification-gated out**: preserved, and this is the invariant the bug was eroding from the other side. ERC/DRC gating and the rollback path are unchanged; what changes is that a stage the model judged retryable now actually gets its retry instead of aborting the run. A stage that reaches `maxRepairCycles` still rolls back exactly as before.
- [x] **`check`/`verify` stays LLM-free and network-free**: unchanged. `src/agent/recovery.ts` is not reachable from `src/commands/check`, and no import was added here.
- [ ] **No sexp serialization**: N/A, no KiCad file is read or written on this path.
- [ ] **Sync-obligations ledger**: N/A, the ledger is not touched.
- [ ] **Secrets**: N/A. The diagnosis text is model output that is parsed, not written; transcript redaction is unchanged.
- [ ] **Spec coherence**: N/A, no spec-level behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnosis handling to find valid retry or abort verdicts even when responses contain extra text, multiple JSON objects, or unmatched braces.
  * Correctly handles braces inside quoted text.
  * Provides clearer fallback behavior when a diagnosis is missing or invalid.
  * Omits empty retry guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->