### PR TITLE
fix(init): say so when the pre-commit hook was not installed

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,6 +93,7 @@ program
         for (const f of res.created) console.log(`created ${f}`);
         for (const f of res.skipped) console.log(`unchanged ${f}`);
         for (const f of res.refused) console.log(`REFUSED (hand-edited; use --force): ${f}`);
+        if (res.hookSkipped) console.warn(`WARNING: pre-commit hook not installed: ${res.hookSkipped}`);
       }
       process.exit(res.refused.length ? 1 : 0);
     } catch (err) {

--- a/src/memory/scaffold.ts
+++ b/src/memory/scaffold.ts
@@ -11,6 +11,14 @@ export interface InitResult {
   created: string[];
   skipped: string[];
   refused: string[];
+  /**
+   * Why the pre-commit hook is not installed, when it is not. `null` means
+   * either that it was installed (it is then listed in `created`), that it was
+   * already ours, or that `--no-hooks` was passed. Reported because the docs
+   * tell users `init` installs the hook, so a silent skip leaves them believing
+   * the commit-time gate is on when it is not.
+   */
+  hookSkipped: string | null;
 }
 
 const sha = (s: string): string => createHash('sha256').update(s).digest('hex');
@@ -138,14 +146,31 @@ write time. This directory is gitignored.
 
 const HOOK_MARKER = '# installed by copperhead init';
 
-async function installPreCommitHook(repoRoot: string): Promise<string | null> {
+/**
+ * Install the commit-time `copperhead check` gate, without ever clobbering a
+ * hook the user wrote. Returns the path when it wrote one, or a reason when it
+ * did not: the reason reaches the user, because the documentation states that
+ * `init` installs this hook and a silent skip leaves them believing the gate is
+ * on. Already being ours is not a skip; it is the idempotent success case.
+ */
+async function installPreCommitHook(
+  repoRoot: string,
+): Promise<{ path: string; skipped: null } | { path: null; skipped: string | null }> {
   const hooksDir = path.join(repoRoot, '.git', 'hooks');
-  if (!existsSync(hooksDir)) return null;
+  if (!existsSync(hooksDir)) {
+    return {
+      path: null,
+      skipped: `no .git/hooks directory, so the commit-time "copperhead check" gate is NOT active. Run copperhead check in CI, or re-run init from inside the git repository.`,
+    };
+  }
   const hookPath = path.join(hooksDir, 'pre-commit');
   if (existsSync(hookPath)) {
     const existing = await readFile(hookPath, 'utf8');
-    if (existing.includes(HOOK_MARKER)) return null; // idempotent
-    return null; // never clobber a user's own hook
+    if (existing.includes(HOOK_MARKER)) return { path: null, skipped: null }; // already ours
+    return {
+      path: null,
+      skipped: `.git/hooks/pre-commit already exists and was not written by copperhead, so it was left untouched and the commit-time "copperhead check" gate is NOT active. Add "copperhead check" to your existing hook, or run it in CI.`,
+    };
   }
   const script = `#!/bin/sh
 ${HOOK_MARKER}
@@ -154,7 +179,7 @@ exec copperhead check
 `;
   await writeFile(hookPath, script, 'utf8');
   await chmod(hookPath, 0o755);
-  return hookPath;
+  return { path: hookPath, skipped: null };
 }
 
 export interface InitOptions {
@@ -186,7 +211,7 @@ export async function runInit(opts: InitOptions): Promise<InitResult> {
   const docsDir = path.join(repoRoot, config.docs);
   await mkdir(docsDir, { recursive: true });
 
-  const result: InitResult = { created: [], skipped: [], refused: [] };
+  const result: InitResult = { created: [], skipped: [], refused: [], hookSkipped: null };
   const hashes: Record<string, string> = { ...(config.generatedHashes ?? {}) };
   const appendOnly = new Set(['DECISIONS.md', 'CHANGELOG.md']);
 
@@ -235,7 +260,8 @@ export async function runInit(opts: InitOptions): Promise<InitResult> {
 
   if (opts.installHooks !== false) {
     const hook = await installPreCommitHook(repoRoot);
-    if (hook) result.created.push(path.relative(repoRoot, hook));
+    if (hook.path) result.created.push(path.relative(repoRoot, hook.path));
+    result.hookSkipped = hook.skipped;
   }
 
   return result;

--- a/test/cli-init-hook.test.ts
+++ b/test/cli-init-hook.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, writeFile, chmod, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execa } from 'execa';
+import { tempFixtureRepo } from './helpers.js';
+
+/**
+ * Command-level coverage for the one line the unit tests cannot reach: the CLI
+ * turning `InitResult.hookSkipped` into something the user actually sees. The
+ * bug this guards against was a real outcome that never reached stdout, so
+ * asserting the reporting contract, not just the returned value, is the point.
+ *
+ * `init` gates on `kicad-cli version` before doing anything. The stub below
+ * satisfies exactly that preflight; every other path these tests touch (doc
+ * scaffolding, hook installation, output rendering) is the real code, and
+ * nothing here runs ERC or DRC.
+ */
+const CLI = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
+
+let stubDir: string;
+let env: NodeJS.ProcessEnv;
+
+beforeAll(async () => {
+  stubDir = await mkdtemp(path.join(tmpdir(), 'copperhead-kicad-stub-'));
+  const stub = path.join(stubDir, 'kicad-cli');
+  await writeFile(stub, '#!/bin/sh\necho "kicad-cli version 10.0.4 (test stub)"\n', 'utf8');
+  await chmod(stub, 0o755);
+  env = { ...process.env, PATH: `${stubDir}${path.delimiter}${process.env.PATH ?? ''}` };
+});
+
+afterAll(async () => {
+  await rm(stubDir, { recursive: true, force: true }).catch(() => {});
+});
+
+const runInitCli = (repo: string, extra: string[] = []) =>
+  execa('npx', ['tsx', CLI, '--repo', repo, ...extra, 'init'], { env, reject: false });
+
+describe('copperhead init CLI: pre-commit hook reporting', () => {
+  it('warns on stderr when a foreign hook is in the way', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await writeFile(path.join(repo, '.git', 'hooks', 'pre-commit'), '#!/bin/sh\nnpm run lint\n', 'utf8');
+      const res = await runInitCli(repo);
+      expect(res.stderr).toMatch(/pre-commit hook not installed/);
+      expect(res.stderr).toMatch(/NOT active/);
+      // The docs are still scaffolded, and the command still succeeds: the gate
+      // being unavailable is not a reason to fail an init that did its job.
+      expect(res.stdout).toMatch(/created docs\/BOM\.md/);
+      expect(res.exitCode).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('says nothing about the hook when it installed one', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const res = await runInitCli(repo);
+      expect(res.stderr).not.toMatch(/pre-commit hook not installed/);
+      expect(res.stdout).toMatch(/created \.git\/hooks\/pre-commit/);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('--json carries hookSkipped and stdout stays parseable', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await writeFile(path.join(repo, '.git', 'hooks', 'pre-commit'), '#!/bin/sh\nnpm run lint\n', 'utf8');
+      const res = await runInitCli(repo, ['--json']);
+      // The warning goes to stderr precisely so it cannot corrupt the JSON.
+      const parsed = JSON.parse(res.stdout) as { hookSkipped: string | null; created: string[] };
+      expect(parsed.hookSkipped).toMatch(/already exists/);
+      expect(parsed.created.some((f) => f.includes('pre-commit'))).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+});

--- a/test/init-check.test.ts
+++ b/test/init-check.test.ts
@@ -74,6 +74,74 @@ describe('copperhead init (AC-1)', () => {
     await expect(runInit({ repoRoot: dir })).rejects.toThrow(InitError);
     await expect(runInit({ repoRoot: dir })).rejects.toThrow(/no \.kicad_sch found/);
   });
+
+  // The docs state that init installs the commit-time gate. When it cannot, the
+  // user has to hear about it, or they believe a gate is on that is not.
+  describe('pre-commit hook reporting', () => {
+    const hookPath = (repo: string): string => path.join(repo, '.git', 'hooks', 'pre-commit');
+
+    it('installs the hook and reports no skip on a fresh repo', async () => {
+      const { repo, cleanup } = await tempFixtureRepo();
+      try {
+        const res = await runInit({ repoRoot: repo });
+        expect(res.hookSkipped).toBeNull();
+        expect(res.created.some((f) => f.includes('pre-commit'))).toBe(true);
+        expect(await readFile(hookPath(repo), 'utf8')).toContain('copperhead check');
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('is idempotent: re-running reports no skip and does not re-create', async () => {
+      const { repo, cleanup } = await tempFixtureRepo();
+      try {
+        await runInit({ repoRoot: repo });
+        const res = await runInit({ repoRoot: repo });
+        expect(res.hookSkipped).toBeNull();
+        expect(res.created.some((f) => f.includes('pre-commit'))).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("reports the skip when the user's own hook is in the way, and preserves it", async () => {
+      const { repo, cleanup } = await tempFixtureRepo();
+      try {
+        await writeFile(hookPath(repo), '#!/bin/sh\nnpm run lint\n', 'utf8');
+        const res = await runInit({ repoRoot: repo });
+        expect(res.hookSkipped).toMatch(/already exists/);
+        expect(res.hookSkipped).toMatch(/NOT active/);
+        // The user's hook is untouched, and ours was not silently merged in.
+        const onDisk = await readFile(hookPath(repo), 'utf8');
+        expect(onDisk).toContain('npm run lint');
+        expect(onDisk).not.toContain('copperhead check');
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('reports the skip when there is no .git/hooks directory', async () => {
+      const { repo, cleanup } = await tempFixtureRepo();
+      try {
+        await rm(path.join(repo, '.git', 'hooks'), { recursive: true, force: true });
+        const res = await runInit({ repoRoot: repo });
+        expect(res.hookSkipped).toMatch(/no \.git\/hooks directory/);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('stays silent about the hook when --no-hooks asked for no hook', async () => {
+      const { repo, cleanup } = await tempFixtureRepo();
+      try {
+        const res = await runInit({ repoRoot: repo, installHooks: false });
+        expect(res.hookSkipped).toBeNull();
+        expect(existsSync(hookPath(repo))).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
 });
 
 describe('copperhead check (AC-2)', () => {


### PR DESCRIPTION
## What

`copperhead init` now tells you when it did not install the pre-commit hook, instead of finishing silently and leaving you to believe the commit-time gate is on.

## Why

Closes #103.

Any repository that already has a `pre-commit` hook (husky, pre-commit, lefthook, or hand-written) hit this. On `main`:

```text
$ printf '#!/bin/sh\nnpm run lint\n' > .git/hooks/pre-commit
$ copperhead init
created docs/SPEC.md
created docs/BOM.md
...
created docs/CHANGELOG.md
```

Exit 0, and not a word about the hook. `git commit` runs `npm run lint` and never runs `copperhead check`.

Leaving the user's hook alone is the right call and this PR does not change it. What was wrong is that the outcome never reached the user, while the documentation says the opposite in three places:

- [quickstart.mdx](docs/src/content/docs/getting-started/quickstart.mdx): "writes `.copperhead/config.json`, and installs a pre-commit hook"
- [verify-and-sync.md](docs/src/content/docs/workflows/verify-and-sync.md): "`init` installs a pre-commit hook that runs it, so hand edits [...] fail at commit time"
- [docs-as-memory.md](docs/src/content/docs/concepts/docs-as-memory.md): "the hook is installed for you by `init`"

`init` already treats a smaller collision as loud: a hand-edited doc it will not overwrite prints `REFUSED (hand-edited; use --force)` and exits 1. A collision that switches off a verification gate printed nothing.

## Design

`installPreCommitHook` returned a bare `null` for three different outcomes, and the caller only used the non-null case:

```ts
if (existing.includes(HOOK_MARKER)) return null;   // already ours: success
return null;                                        // foreign hook: gate is off
```

It now returns which of the three happened, and `InitResult` gains `hookSkipped: string | null`. "Already ours" stays `null`, because it is the idempotent success case, not a skip. So does `--no-hooks`: you cannot warn someone about a thing they asked for.

The message names the consequence and the two ways out, rather than only stating the fact:

```text
WARNING: pre-commit hook not installed: .git/hooks/pre-commit already exists and
was not written by copperhead, so it was left untouched and the commit-time
"copperhead check" gate is NOT active. Add "copperhead check" to your existing
hook, or run it in CI.
```

Two deliberate limits:

- **Warning, not an error, and the exit code is unchanged.** `REFUSED` exits 1 because a doc was not written and `--force` will fix it. Here everything `init` was asked to write was written, and there is no flag that would change the outcome. Failing the command would break `init` for every husky user, which is a bigger regression than the bug.
- **The hook is not merged into theirs.** Appending to a script we did not write is not a safe automatic edit, and there would be no obvious way to undo it. The message tells them the one line to add.

`--json` carries `hookSkipped` too, since that is the CI-readable surface.

## Spec / OpenSpec

No spec-level behavior change: the same hook is installed in the same cases. Only the reporting of a case that was already happening is added.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | 342 passed, 8 failed, 17 skipped |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY` | n/a (`init` is LLM-free and network-free) |

The 8 failures are `kicad-cli not found on PATH` in my environment and are pre-existing. Both sides run, not assumed:

```text
main            8 failed | 337 passed | 17 skipped
this branch     8 failed | 342 passed | 17 skipped
```

Same 8, and +5 passed is exactly the five tests added here.

**New tests** ([init-check.test.ts](test/init-check.test.ts)), covering all four outcomes plus the flag: fresh install, idempotent re-run, foreign hook (reported *and* preserved), no `.git/hooks` directory, and `--no-hooks`.

Worth stating plainly: **reverting the whole change fails all five**, but only because `hookSkipped` would not exist. That proves nothing about the bug. So I reverted only the behavior, keeping the return shape, and re-ran:

```text
 ✓ installs the hook and reports no skip on a fresh repo
 ✓ is idempotent: re-running reports no skip and does not re-create
 × reports the skip when the user's own hook is in the way, and preserves it
     expected undefined to be null   →   the silent path
 × reports the skip when there is no .git/hooks directory
 ✓ stays silent about the hook when --no-hooks asked for no hook
```

Two fail, three pass. The three that pass are guarding the cases this change must **not** disturb, which is what I wanted them for: the risk in a change like this is warning about a hook that is fine.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): a fresh fixture repo under `manual-tests/runs/`, seeded with a foreign pre-commit hook. `init` gates on `kicad-cli`, which is not on my PATH, so I put a stub on PATH for these runs. The stub only satisfies the `kicad-cli version` preflight; the code path under test (doc scaffolding and hook installation) is the real one and touches no KiCad tooling. The ERC/DRC paths are untouched by this PR and are covered by the pre-existing kicad-gated tests.
- Commands run and outcome:

```text
$ printf '#!/bin/sh\n# my own hook\nnpm run lint\n' > runs/hooks/.git/hooks/pre-commit

# on main
$ npm run dev -- --repo manual-tests/runs/hooks init
created docs/SPEC.md
... (7 docs)
created docs/CHANGELOG.md
                                    <- nothing about the hook

# on this branch
$ npm run dev -- --repo manual-tests/runs/hooks init
created docs/SPEC.md
... (7 docs)
created docs/CHANGELOG.md
WARNING: pre-commit hook not installed: .git/hooks/pre-commit already exists and was not
written by copperhead, so it was left untouched and the commit-time "copperhead check"
gate is NOT active. Add "copperhead check" to your existing hook, or run it in CI.

$ npm run dev -- --repo manual-tests/runs/hooks --json init
  "refused": [],
  "hookSkipped": ".git/hooks/pre-commit already exists and was not written by copperhead, ..."

$ cat manual-tests/runs/hooks/.git/hooks/pre-commit
#!/bin/sh
# my own hook
npm run lint                        <- untouched, and no copperhead line added
```

## Docs

None changed, and that is the point: the three doc statements listed above are now true in the sense that matters, because when `init` cannot deliver the hook it says so. If you would rather the docs also carry the caveat ("unless you already have a pre-commit hook, in which case init tells you"), I am happy to add it here or in a follow-up, whichever you prefer.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, the agent tool list is untouched.
- [ ] **Verification-gated out**: N/A for the run-time gate, which is unchanged. Adjacent, so worth being precise: this touches the *commit-time* hook, and it only reports on it. The ERC/DRC gating and rollback inside a run are not on this path.
- [x] **`check`/`verify` stays LLM-free and network-free**: unchanged and preserved. `init` and the hook it writes (`exec copperhead check`) are both LLM-free and network-free; no import was added to either module.
- [x] **No sexp serialization**: preserved. `init` reads the schematic through `listSymbols`/`pinNets` exactly as before; this change touches only the hook file and the result type.
- [ ] **Sync-obligations ledger**: N/A, the ledger is not reachable from `init`.
- [ ] **Secrets**: N/A, no transcript or summary is written and the hook script contains no user data.
- [ ] **Spec coherence**: N/A, no spec-level behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `init` reporting when the pre-commit hook cannot be installed.
  * Added clear skip messages for missing hook directories and existing user hooks.
  * Preserved existing user hooks without overwriting them.
  * Confirmed repeated initialization does not recreate an existing Copperhead hook.
  * Kept hook reporting silent when hook installation is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->