### PR TITLE
fix(sync): match pins.h against assigned pins, not the whole document

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { loadConfig } from '../config.js';
 import { checkDrift } from '../memory/drift.js';
+import { pinoutIdentifiers } from '../memory/bom-table.js';
 import { loadConstraints, checkForbiddenPins } from '../memory/constraints.js';
 import { pinNets } from '../kicad/sexp.js';
 import { openspecValidate } from '../openspec/cli.js';
@@ -90,13 +91,21 @@ export async function syncVerify(repoRoot: string): Promise<SyncReport> {
   if (existsSync(pinsH) && existsSync(path.join(docsDir, 'PINOUT.md'))) {
     const header = await readFile(pinsH, 'utf8');
     const pinout = await readFile(path.join(docsDir, 'PINOUT.md'), 'utf8');
+    // Match against the identifiers the pin table actually assigns, not against
+    // the raw document text. `pinout.includes('LED')` is satisfied by the word
+    // LED anywhere at all: a different row's net (`LED_STATUS`), a Notes cell,
+    // or the prose above the table. Every `#define` then looks documented and
+    // the check reports nothing, which is the worst outcome for a check whose
+    // whole job is to catch a header that has drifted from the doc it was
+    // generated from.
+    const documented = pinoutIdentifiers(pinout);
     for (const m of header.matchAll(/#define\s+PIN_(\w+)\s+(\S+)/g)) {
-      if (!pinout.includes(m[1]!)) {
+      if (!documented.has(m[1]!)) {
         resolvable.push({
           kind: 'pins-h',
           doc: 'firmware/src/pins.h',
           claim: `defines PIN_${m[1]}`,
-          actual: 'PINOUT.md does not mention it',
+          actual: 'no pin in PINOUT.md carries that net or pin name',
           resolution: 'regenerate pins.h from PINOUT.md (PINOUT.md is the single source of truth)',
         });
       }

--- a/src/memory/bom-table.ts
+++ b/src/memory/bom-table.ts
@@ -122,6 +122,37 @@ export interface TableRow {
   }
 
   /**
+   * The identifiers PINOUT.md assigns to a pin: its net name and, when the
+   * table carries the optional Name column, the pin's own name. Both are
+   * legitimate sources for a firmware `#define PIN_<X>`, so a caller checking
+   * that a generated header agrees with the doc has to consider both.
+   *
+   * Distinct from `parsePinoutRows`, which answers "what net is on this pin"
+   * for the drift comparison. This answers "what names does the doc know",
+   * which is a set-membership question and needs no row structure.
+   */
+  export function pinoutIdentifiers(md: string): Set<string> {
+    const names = new Set<string>();
+    const strip = (s: string | undefined): string => (s ?? '').replace(/`/g, '').trim();
+    for (const { header, rows } of parseCanonicalTables(md)) {
+      const col = (re: RegExp): number => header.cells.findIndex((c) => re.test(c));
+      const pinI = col(/^pin$/i);
+      const netI = col(/^net$/i);
+      const nameI = col(/^name$/i);
+      if (pinI < 0) continue; // not the pin-assignment table
+      for (const row of rows) {
+        for (const i of [netI, nameI]) {
+          if (i < 0) continue;
+          const value = strip(row.cells[i]);
+          // KiCad writes `~` for an unnamed pin; it identifies nothing.
+          if (value && value !== '~') names.add(value);
+        }
+      }
+    }
+    return names;
+  }
+
+  /**
    * Fold the semantically-identical encodings that the model and KiCad render
    * differently, so a value that differs only in *encoding* is not flagged as
    * drift (#I11). A design that reached ERC-clean once churned for turns on

--- a/test/gating-sync.test.ts
+++ b/test/gating-sync.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import path from 'node:path';
-import { writeFile, readFile } from 'node:fs/promises';
+import { writeFile, readFile, mkdir } from 'node:fs/promises';
 import { runInit } from '../src/memory/scaffold.js';
 import { loadConfig } from '../src/config.js';
 import { availableTools, dispatchTool, type RunContext } from '../src/agent/tools.js';
@@ -365,6 +365,76 @@ describe('copperhead sync verify phase (AC-7)', () => {
     } finally {
       await cleanup();
     }
+  });
+
+  // The pins.h check compares a generated header against PINOUT.md. Matching on
+  // raw document text made any word appearing anywhere satisfy any #define, so
+  // the check reported nothing no matter how far the header had drifted.
+  describe('pins.h vs PINOUT.md', () => {
+    const writePinsH = async (repo: string, body: string): Promise<void> => {
+      const dir = path.join(repo, 'firmware', 'src');
+      await mkdir(dir, { recursive: true });
+      await writeFile(path.join(dir, 'pins.h'), body, 'utf8');
+    };
+
+    const PINOUT = [
+      '# Pinout',
+      '',
+      'The LED sits on its own rail; see LAYOUT.md before moving TX.',
+      '',
+      '| Refdes | Pin | Name | Net | Notes |',
+      '|---|---|---|---|---|',
+      '| U1 | 9 | GPIO9 | I2C_SCL | |',
+      '| U1 | 12 | GPIO12 | LED_STATUS | |',
+      '| R1 | 1 | ~ | GND | |',
+      '',
+    ].join('\n');
+
+    const syncWith = async (repo: string, pinsH: string): Promise<string[]> => {
+      await writeFile(path.join(repo, 'docs', 'PINOUT.md'), PINOUT, 'utf8');
+      await writePinsH(repo, pinsH);
+      const report = await syncVerify(repo);
+      return report.resolvable.filter((i) => i.kind === 'pins-h').map((i) => i.claim);
+    };
+
+    it('accepts a #define naming a net or a pin name in the table', async () => {
+      const { repo, cleanup } = await tempFixtureRepo();
+      try {
+        await runInit({ repoRoot: repo });
+        const flagged = await syncWith(repo, '#define PIN_I2C_SCL 9\n#define PIN_GPIO12 12\n');
+        expect(flagged).toEqual([]);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('flags a #define whose name only appears in prose or inside another name', async () => {
+      const { repo, cleanup } = await tempFixtureRepo();
+      try {
+        await runInit({ repoRoot: repo });
+        // LED and TX are both in the prose above the table; LED is also a
+        // prefix of the LED_STATUS net. None of them is an assigned pin.
+        const flagged = await syncWith(repo, '#define PIN_LED 5\n#define PIN_TX 21\n#define PIN_SCL 9\n');
+        expect(flagged).toEqual(['defines PIN_LED', 'defines PIN_TX', 'defines PIN_SCL']);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('does not let the unnamed-pin sentinel ~ document anything', async () => {
+      const { repo, cleanup } = await tempFixtureRepo();
+      try {
+        await runInit({ repoRoot: repo });
+        const flagged = await syncWith(repo, '#define PIN_~ 1\n');
+        // `~` is not a \w character, so it never forms a #define name; the point
+        // is that R1's `~` cell contributes no identifier at all.
+        expect(flagged).toEqual([]);
+        const still = await syncWith(repo, '#define PIN_GND 1\n');
+        expect(still).toEqual([]); // GND is a real net on that row
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   it('forbidden-pin use is a requirement violation: flagged, never resolvable (AC-7.3)', async () => {


### PR DESCRIPTION
## What

`copperhead sync` now actually checks `firmware/src/pins.h` against `PINOUT.md`. Before this, the check could not fail.

## Why

Closes #105.

The check substring-matched the raw document, so any word occurring anywhere in `PINOUT.md` satisfied any `#define`. On the `open-key` fixture, with the `PINOUT.md` that `init` itself generates:

```c
#define PIN_KEY  5
#define PIN_GPIO 21
#define PIN_3V   8
```

```text
$ copperhead sync          # on main
sync: no inconsistencies
```

None of those three pins is assigned by the table. `KEY` matched inside the net `KEY_DAH`, `GPIO` inside `GPIO14`, `3V` inside `3V3`. The prose counts as well: the generated line "Check strapping/RTC notes before reassigning pins" means `#define PIN_RTC` would pass on a document that never mentions an RTC pin.

Two things make this worse than a normal false negative:

- **Stage 7 of `create` generates `pins.h` *from* `PINOUT.md`**, and `sync` is the mechanism that says the two still agree. A check that cannot fail does not merely miss problems, it reports the invariant as holding.
- **It fails open**, so nothing ever drew attention to it. A false positive would have been noisy and fixed long ago.

## Design

`src/memory/bom-table.ts` already parses this table structurally (`parseCanonicalTables`), and the drift checker uses it. This one check did not. The fix is to ask the same parser what the table assigns.

`pinoutIdentifiers(md)` returns the set of names the pin table gives to pins: each row's `Net`, and its `Name` when the optional column is present. Both are legitimate sources for a `#define PIN_<X>` (the scaffold writes `Refdes | Pin | Name | Net | Notes`, and a firmware author may key off either), so accepting only one would produce false positives on correct headers.

It is deliberately a separate function from `parsePinoutRows` rather than an extra field on it. `parsePinoutRows` answers "what net is on this pin", which the drift comparison needs row by row. This is set membership, and it needs no row structure.

KiCad's `~` unnamed-pin sentinel is excluded: it identifies nothing, and letting it in would make `#define PIN_` shapes pass on any table containing an unnamed pin.

**The pin numbers stay unused, on purpose.** The regex already captures the value in `m[2]` and always discarded it, which looks like an oversight and is not one: `PINOUT.md`'s `Pin` column is the **symbol pin number** from KiCad, while a firmware header holds the **MCU GPIO number**. On the fixture, `GPIO14` sits at symbol pin 5, so comparing the two numbers would report drift on a header that is correct. Checking them properly needs an MCU pin map, which is a different change; this PR fixes the part that is checkable today.

## Spec / OpenSpec

No spec-level behavior change. AC-7's pins-h obligation is unchanged; this makes the existing check do what it says.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | 340 passed, 8 failed, 17 skipped |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY` | n/a (`sync`'s verify phase is deterministic, LLM-free and network-free) |

The 8 failures are `kicad-cli not found on PATH` in my environment and are pre-existing. Both sides run, not assumed:

```text
main            8 failed | 337 passed | 17 skipped
this branch     8 failed | 340 passed | 17 skipped
```

Same 8, and +3 is exactly the tests added here.

**New tests** ([gating-sync.test.ts](test/gating-sync.test.ts)): a `#define` naming a net or a pin name is accepted; one whose name only appears in prose or inside another name is flagged; and the `~` sentinel documents nothing while a real net on the same row still does.

Reverting only the comparison (`documented.has` back to `pinout.includes`) and keeping everything else:

```text
✓ accepts a #define naming a net or a pin name in the table
× flags a #define whose name only appears in prose or inside another name
✓ does not let the unnamed-pin sentinel ~ document anything
```

One fails, and it is the one aimed at the bug. The other two pass on both sides by design: they guard the false-positive direction, which is the risk when a check that never fired starts firing.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): a fixture repo under `manual-tests/runs/`, `init`ed, then given a `firmware/src/pins.h`. `init` and `sync` gate on `kicad-cli version`, which is not on my PATH, so a stub on PATH answers that one call. The verify phase itself is deterministic and reads only the doc and the header; no ERC or DRC runs, and the resolve phase (which needs a model) is not reached.
- Commands run and outcome:

```text
$ printf '#define PIN_KEY 5\n#define PIN_GPIO 21\n#define PIN_3V 8\n' > runs/sync/firmware/src/pins.h

# on main
$ npm run dev -- --repo manual-tests/runs/sync sync
sync: no inconsistencies

# on this branch
$ npm run dev -- --repo manual-tests/runs/sync sync
3 resolvable inconsistency(ies):
- [pins-h] firmware/src/pins.h: claims "defines PIN_KEY" but actual is "no pin in PINOUT.md carries that net or pin name"
- [pins-h] firmware/src/pins.h: claims "defines PIN_GPIO" but actual is "no pin in PINOUT.md carries that net or pin name"
- [pins-h] firmware/src/pins.h: claims "defines PIN_3V" but actual is "no pin in PINOUT.md carries that net or pin name"
    resolution: regenerate pins.h from PINOUT.md (PINOUT.md is the single source of truth)
```

I also checked the accepting direction by hand, so the new strictness is not just "flags more": `#define PIN_KEY_DAH` and `#define PIN_GPIO14` (a real net and a real pin name from the same table) both pass.

## Docs

None needed: no flag or output format changes. The `actual` string is more precise ("no pin in PINOUT.md carries that net or pin name" rather than "PINOUT.md does not mention it"), which matches what is now being tested and tells the reader why a `#define` was flagged despite the word appearing in the file.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, the agent tool list is untouched.
- [ ] **Verification-gated out**: N/A. This is `sync`'s deterministic verify phase, not the ERC/DRC mutation gate; no mutation happens on this path.
- [x] **`check`/`verify` stays LLM-free and network-free**: preserved, and directly relevant since this *is* the verify phase. The only import added is `pinoutIdentifiers` from `src/memory/bom-table.ts`, a pure string module with no I/O and no dependencies. `syncVerify` still touches no provider, key, or network.
- [x] **No sexp serialization**: preserved. Nothing here reads or writes a KiCad file; `sync`'s existing `pinNets` call is unchanged and read-only.
- [ ] **Sync-obligations ledger**: N/A. This is the `sync` command's report, not the run-time ledger; `src/agent/ledger.ts` is untouched.
- [ ] **Secrets**: N/A, no transcript or summary is written.
- [ ] **Spec coherence**: N/A, no spec-level behavior changed.
