### PR TITLE
fix(loop): a failed rollback no longer takes the run report with it

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -12,7 +12,16 @@ import { Transcript, type ExitPath, type RunStats } from './transcript.js';
 import { collectRunMeta, renderCliHeader, type RunMeta, type RunMetaInput } from './runmeta.js';
 import { plainRenderer, fmtDuration, fmtTokens, type ProgressRenderer } from './render.js';
 import { ObligationsLedger } from './ledger.js';
-import { gitPreflight, isDirty, snapshot, restore, commitAll, changedFiles, preserveFailedRun } from '../util/git.js';
+import {
+  gitPreflight,
+  isDirty,
+  snapshot,
+  restore,
+  commitAll,
+  changedFiles,
+  preserveFailedRun,
+  type GitSnapshot,
+} from '../util/git.js';
 import { withRetry, isRateLimit, sessionLimit } from '../util/retry.js';
 import { openspecArchive } from '../openspec/cli.js';
 import { existsSync } from 'node:fs';
@@ -121,6 +130,29 @@ function otherProvider(current: Provider): Provider | null {
   if (current.name === 'openai' && process.env.ANTHROPIC_API_KEY) return new AnthropicProvider();
   if (current.name === 'anthropic' && process.env.OPENAI_API_KEY) return new OpenAIProvider();
   return null;
+}
+
+/**
+ * Roll the working tree back, and never let that be the thing that ends the
+ * run. `restore` shells out to git, so it throws on anything git refuses:
+ * most reachably, `git stash apply` when the snapshot's stash object is gone.
+ * `git stash create` leaves that object unreferenced by design, so a `git gc`
+ * during a long run collects it and the rollback throws afterwards.
+ *
+ * An unhandled throw here skips `run-end` and `summary.md`, which are most
+ * valuable exactly when the tree has been left in an unknown state. Returns
+ * the error message so a caller that surfaces it can, and records the failure
+ * on the transcript either way.
+ */
+async function rollBack(repoRoot: string, snap: GitSnapshot, transcript: Transcript): Promise<string | null> {
+  try {
+    await restore(repoRoot, snap);
+    return null;
+  } catch (err) {
+    const message = (err as Error).message;
+    await transcript.event('restore-failed', { error: message });
+    return message;
+  }
 }
 
 async function appendChangelog(
@@ -340,16 +372,7 @@ async function runWithMemory(
     // it, so a budget-exhaustion (or any) failure is recoverable (issue #15).
     const preserved = await preserveFailedRun(repoRoot, ctx.runId);
     if (preserved) await transcript.event('work-preserved', { stash: preserved });
-    // The rollback itself can fail (git in a bad state). That must not become
-    // an unhandled throw that skips run-end and summary.md — the summary is
-    // most valuable exactly when the tree is left in an unknown state.
-    let restoreError: string | null = null;
-    try {
-      await restore(repoRoot, snap);
-    } catch (err) {
-      restoreError = (err as Error).message;
-      await transcript.event('restore-failed', { error: restoreError });
-    }
+    const restoreError = await rollBack(repoRoot, snap, transcript);
     const runStats = stats(exitPath);
     await transcript.event('run-end', runStats);
     const summaryPath = await transcript.writeSummary({
@@ -571,7 +594,10 @@ async function runWithMemory(
       const { outcome, summary } = ctx.finishRequest;
       const files = [...ctx.filesTouched];
       if (outcome === 'refuse') {
-        await restore(repoRoot, snap);
+        const restoreError = await rollBack(repoRoot, snap, transcript);
+        if (restoreError) {
+          log(`WARNING: rollback failed (${restoreError}); the working tree may be in a partial state`);
+        }
         await transcript.event('run-refused', { summary });
         const runStats = stats('refused');
         await transcript.event('run-end', runStats);
@@ -587,7 +613,9 @@ async function runWithMemory(
           tokensOut,
           outcome: 'aborted',
           openObligations: null,
-          detail: `REFUSED: ${summary}`,
+          detail: restoreError
+            ? `REFUSED: ${summary}\n\nROLLBACK FAILED: ${restoreError} — the working tree may be in a partial state; inspect it with git status/git diff before rerunning`
+            : `REFUSED: ${summary}`,
           env: meta,
           stats: runStats,
         });
@@ -631,7 +659,16 @@ async function runWithMemory(
         log('--- dry run: proposed diff ---');
         log(diff || '(no diff)');
         if (untracked) log(`new files:\n${untracked}`);
-        await restore(repoRoot, snap);
+        // A dry run's whole contract is that it leaves nothing behind, so a
+        // failed revert has to be said out loud rather than reported as
+        // "changes reverted".
+        const restoreError = await rollBack(repoRoot, snap, transcript);
+        if (restoreError) {
+          log(`WARNING: dry-run revert failed (${restoreError}); the proposed changes may still be in the working tree`);
+        }
+        const dryRunDetail = restoreError
+          ? `dry run: REVERT FAILED: ${restoreError} — the proposed changes may still be in the working tree; inspect it with git status/git diff`
+          : 'dry run: changes reverted';
         const runStats = stats('done');
         await transcript.event('run-end', runStats);
         await transcript.writeSummary({
@@ -646,11 +683,11 @@ async function runWithMemory(
           tokensOut,
           outcome: 'success',
           openObligations: null,
-          detail: 'dry run: changes reverted',
+          detail: dryRunDetail,
           env: meta,
           stats: runStats,
         });
-        r.finish(outcomeLine(runStats, 'dry run: changes reverted'));
+        r.finish(outcomeLine(runStats, dryRunDetail));
         return {
           outcome: 'success',
           exitPath: 'done',

--- a/test/rollback-failure.test.ts
+++ b/test/rollback-failure.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+import { execa } from 'execa';
+import { runAgentLoop } from '../src/agent/loop.js';
+import type { Msg, Provider, Turn } from '../src/agent/types.js';
+import { runInit } from '../src/memory/scaffold.js';
+import { tempFixtureRepo } from './helpers.js';
+
+/**
+ * A failed rollback must not take the run's own report down with it.
+ *
+ * `restore` shells out to git and throws on anything git refuses. The
+ * reachable case is `git stash apply`: `snapshot` records a `git stash create`
+ * object, which git leaves unreferenced by design, so a `git gc` during a long
+ * run collects it and the rollback throws afterwards. These tests reproduce
+ * that by running the gc themselves rather than by stubbing git.
+ *
+ * `fail()` already handled this. The refuse and dry-run paths did not, and an
+ * unhandled throw there skips `run-end` and `summary.md` entirely.
+ */
+function scriptedProvider(turns: Partial<Turn>[], beforeTurn?: () => Promise<void>): Provider {
+  let i = 0;
+  return {
+    name: 'scripted',
+    async chat(_messages: Msg[]): Promise<Turn> {
+      if (beforeTurn) await beforeTurn();
+      const t = turns[Math.min(i, turns.length - 1)]!;
+      i++;
+      return {
+        text: t.text ?? null,
+        toolCalls: (t.toolCalls ?? []).map((c, j) => ({ ...c, id: `call-${i}-${j}` })),
+        usage: { inputTokens: 10, outputTokens: 5 },
+      };
+    },
+  };
+}
+
+/**
+ * A repo where the run starts `--allow-dirty` over uncommitted work, so the
+ * snapshot carries a stash object, and that object is then collected.
+ */
+async function repoWithCollectedStash(): Promise<{ repo: string; cleanup: () => Promise<void> }> {
+  const t = await tempFixtureRepo();
+  await runInit({ repoRoot: t.repo, installHooks: false });
+  await execa('git', ['add', '-A'], { cwd: t.repo });
+  await execa('git', ['commit', '-q', '-m', 'docs'], { cwd: t.repo });
+  // Uncommitted user work: this is what makes `snapshot` create a stash object.
+  await writeFile(path.join(t.repo, 'docs', 'BOM.md'), '# hand edit in progress\n', 'utf8');
+  return t;
+}
+
+/** Collect the unreferenced stash object the in-flight snapshot is holding. */
+const collectStash = (repo: string): Promise<unknown> =>
+  execa('git', ['gc', '--prune=now', '--quiet'], { cwd: repo, reject: false });
+
+const summaryOf = async (dir: string): Promise<string> => readFile(path.join(dir, 'summary.md'), 'utf8');
+
+describe('a failed rollback does not swallow the run report', () => {
+  it('refuse path: still writes summary.md and names the rollback failure', async () => {
+    const { repo, cleanup } = await repoWithCollectedStash();
+    try {
+      // The gc runs between turns, i.e. after `snapshot` and before the
+      // rollback, which is exactly where a long run's gc would land.
+      const provider = scriptedProvider(
+        [{ toolCalls: [{ name: 'finish', args: { outcome: 'refuse', summary: 'budget says no' } }] }],
+        () => collectStash(repo).then(() => undefined),
+      );
+      const res = await runAgentLoop({
+        repoRoot: repo,
+        request: 'refuse me',
+        model: 'gpt-5',
+        provider,
+        allowDirty: true,
+        log: () => {},
+      });
+
+      // The run reported itself rather than dying inside the rollback.
+      expect(res.outcome).toBe('refused');
+      expect(res.exitPath).toBe('refused');
+      const summary = await summaryOf(res.transcriptDir);
+      expect(summary).toContain('REFUSED: budget says no');
+      expect(summary).toContain('ROLLBACK FAILED');
+      expect(summary).toContain('git status');
+    } finally {
+      await cleanup();
+    }
+  }, 30_000);
+
+  it('dry-run path: does not claim "changes reverted" when the revert failed', async () => {
+    const { repo, cleanup } = await repoWithCollectedStash();
+    try {
+      const provider = scriptedProvider(
+        [{ toolCalls: [{ name: 'finish', args: { outcome: 'done', summary: 'proposed' } }] }],
+        () => collectStash(repo).then(() => undefined),
+      );
+      const res = await runAgentLoop({
+        repoRoot: repo,
+        request: 'propose only',
+        model: 'gpt-5',
+        provider,
+        allowDirty: true,
+        dryRun: true,
+        log: () => {},
+      });
+
+      const summary = await summaryOf(res.transcriptDir);
+      expect(summary).toContain('REVERT FAILED');
+      expect(summary).not.toContain('dry run: changes reverted');
+    } finally {
+      await cleanup();
+    }
+  }, 30_000);
+
+  it('a rollback that succeeds still reports the plain outcome', async () => {
+    const { repo, cleanup } = await repoWithCollectedStash();
+    try {
+      const provider = scriptedProvider([
+        { toolCalls: [{ name: 'finish', args: { outcome: 'refuse', summary: 'budget says no' } }] },
+      ]);
+      const res = await runAgentLoop({
+        repoRoot: repo,
+        request: 'refuse me',
+        model: 'gpt-5',
+        provider,
+        allowDirty: true,
+        log: () => {},
+      });
+      const summary = await summaryOf(res.transcriptDir);
+      expect(summary).toContain('REFUSED: budget says no');
+      expect(summary).not.toContain('ROLLBACK FAILED');
+    } finally {
+      await cleanup();
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## What

A rollback that fails no longer destroys the run's own report. The refuse and dry-run paths now record the failure and keep going, the way `fail()` already does, and a dry run stops claiming "changes reverted" when the revert did not happen.

## Why

Closes #107.

`restore` shells out to git and throws on anything git refuses. Two of the three call sites in [loop.ts](src/agent/loop.ts) called it bare, so the exception escaped and skipped `run-end` and `summary.md`. The run left no report at exactly the moment one matters most: the tree is in a partial state and nothing on disk says so.

`fail()` already handled this, and its comment states the reasoning:

```ts
// The rollback itself can fail (git in a bad state). That must not become
// an unhandled throw that skips run-end and summary.md — the summary is
// most valuable exactly when the tree is left in an unknown state.
```

The other two paths did not get that treatment.

**No corruption is needed to reach it.** `snapshot` records a `git stash create` object when the tree is dirty, and git leaves that object unreferenced by design (`stash create` does not write it to the stash reflog). An ordinary `git gc --prune=now` collects it, and the later `git stash apply` fails. A `create` run is long enough that a gc landing in that window is unremarkable.

**Refuse is the worst place to lose the report.** The code just below the rollback says so itself:

```ts
// Refusals are the most valuable thing to remember: they encode a budget
// or constraint that this user's designs keep running into.
await remember({ ... });
```

A throw above it skips the `run-refused` event, `run-end`, `summary.md` **and** that `remember` call. The user gets a stack trace instead of the reason their request was refused.

**Dry run was additionally saying something untrue.** Its whole contract is that it leaves nothing behind, and its summary and finish line both read `dry run: changes reverted` regardless.

## Design

The `try`/`catch` in `fail()` is extracted as `rollBack(repoRoot, snap, transcript)`, which records `restore-failed` on the transcript and returns the message instead of throwing. All three call sites use it, so the handling cannot drift apart again.

The two newly-covered paths surface it the same way `fail()` does: a `WARNING:` log line and a `ROLLBACK FAILED: ... inspect it with git status/git diff before rerunning` line in the summary's Detail section. For the dry run the wording is `REVERT FAILED` and it replaces the "changes reverted" text in both the summary and the finish line, rather than being appended next to a claim that contradicts it.

Deliberately unchanged: the run's `outcome` and `exitPath`. A refusal is still a refusal, and a dry run still succeeded at proposing a diff. What failed is the cleanup, and the report is where that belongs. Changing the outcome would break callers (the create pipeline reads `res.outcome` to decide whether a stage advanced) for a condition that is about the tree, not the work.

`#34` (`--keep-on-fail`) touches the `fail()` rollback, the one path that already handled this. It does not touch the refuse or dry-run call sites, so the changed lines do not overlap.

## Spec / OpenSpec

No spec-level behavior change. AC-3.6's rollback is unchanged; this is about not losing the run report when it fails.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | 340 passed, 8 failed, 17 skipped |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY` | n/a (driven with a scripted provider; no live call) |

The 8 failures are `kicad-cli not found on PATH` in my environment and are pre-existing. Both sides run, not assumed:

```text
main            8 failed | 337 passed | 17 skipped
this branch     8 failed | 340 passed | 17 skipped
```

Same 8, and +3 is exactly the tests added here.

**New tests** ([rollback-failure.test.ts](test/rollback-failure.test.ts)) drive the real `runAgentLoop` with a scripted provider. They produce the failure the way production would rather than by stubbing git: the run starts `--allow-dirty` over uncommitted work so the snapshot carries a stash object, and a `git gc --prune=now` runs between turns, which is where a long run's gc would land.

Against `main`:

```text
× refuse path    ExecaError: Command failed with exit code 128: git stash apply 17dd3edf...
× dry-run path   ExecaError: Command failed with exit code 128: git stash apply 055fc9ec...
✓ a rollback that succeeds still reports the plain outcome
```

The two failures are the raw `ExecaError` escaping, which is the bug itself rather than a missing assertion. The third test passes on both sides on purpose: it pins that a successful rollback still produces a clean summary with no `ROLLBACK FAILED` in it, so the new reporting cannot start firing on healthy runs.

One correction I made while writing them: I first asserted `res.outcome === 'aborted'` for the refuse path. It is `'refused'` — `aborted` is the value in the summary document, not on `RunResult`. Fixed against the actual value rather than the one I expected.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a, and the reason is specific rather than convenience. Reaching this branch by hand needs a live provider that refuses, plus a `git gc` timed inside the run's window, plus `kicad-cli`. Staging all three by hand would be testing my staging. The automated tests above drive the real loop end to end against a real git repository, with real `snapshot`/`restore` calls and a real gc, which is the same code path a user would hit:

```text
$ npx vitest run test/rollback-failure.test.ts
 ✓ refuse path: still writes summary.md and names the rollback failure
 ✓ dry-run path: does not claim "changes reverted" when the revert failed
 ✓ a rollback that succeeds still reports the plain outcome
```

Nothing is mocked except the model turns.

## Docs

None needed: no flag, output format, or documented behavior changes. Two failure messages are added, both following the existing `fail()` wording so the three paths read alike.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, the agent tool list is untouched.
- [x] **Verification-gated out**: preserved. Every rollback still happens with the same arguments in the same place; only its failure is caught instead of thrown. The ERC/DRC gates and the `maxRepairCycles`-then-rollback flow are unchanged, and no path now skips a rollback it used to perform.
- [x] **`check`/`verify` stays LLM-free and network-free**: unchanged. `src/agent/loop.ts` is not reachable from `src/commands/check`, and no import was added beyond the existing `GitSnapshot` type.
- [x] **No sexp serialization**: preserved. Nothing here reads or writes a KiCad file.
- [x] **Sync-obligations ledger**: preserved, and this makes it more reliable rather than less. The ledger's open obligations are written into `summary.md`, which is one of the things the escaping throw was destroying.
- [x] **Secrets**: preserved. The new detail strings carry a git error message and are written through `transcript.writeSummary`, which runs `redactSecrets` on the whole document, and the `restore-failed` event goes through `transcript.event`, which redacts as well.
- [ ] **Spec coherence**: N/A, no spec-level behavior changed.
