### PR TITLE
add community automation workflows (greetings, stale, labeler, issue summary)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,61 @@
+# Path-based labels for actions/labeler@v5 (see workflows/labeler.yml).
+# Globs map onto the area:* labels defined in the repo's label set.
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '*.md'
+          - '.github/**/*.md'
+
+'area:ci':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/labeler.yml'
+
+'area:bom-export':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/kicad/bom-export.ts'
+          - 'src/memory/bom-table.ts'
+          - 'test/bom-*.test.ts'
+
+'area:fab-gate':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/kicad/fab.ts'
+          - 'test/fab-*.test.ts'
+
+'area:integrations':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/agent/providers/**'
+          - 'test/*provider*.test.ts'
+
+'area:pipeline':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/commands/**'
+          - 'src/agent/loop.ts'
+          - 'src/agent/tools.ts'
+          - 'src/agent/filetools.ts'
+          - 'src/kicad/**'
+
+'area:observability':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/agent/runmeta.ts'
+          - 'src/agent/transcript.ts'
+          - 'src/agent/render.ts'
+          - 'test/observability.test.ts'
+          - 'test/runmeta.test.ts'
+
+chore:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'package-lock.json'
+          - 'tsconfig*.json'
+          - '.gitignore'
+          - 'install.sh'

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,34 @@
+name: Greetings
+
+# Says hi to first-time contributors. Kept short and practical on purpose;
+# nobody wants a wall of boilerplate as their first interaction with the repo.
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: >
+            Hey, thanks for opening your first issue here. Someone will get
+            to it soon. If it is a bug, the output of `copperhead check` and
+            your KiCad version usually save a round trip of questions. And
+            if copperhead is useful to you, a star on the repo helps more
+            people find it.
+          pr-message: >
+            Thanks for the first PR. Two quick things: the CLA bot will ask
+            you to sign once (only takes a minute), and CI runs the full
+            test suite including real `kicad-cli` checks, so give it a few
+            minutes before worrying about red crosses. A maintainer will
+            review after that. If you like the project, consider leaving a
+            star too.

--- a/.github/workflows/issue-summary.yml
+++ b/.github/workflows/issue-summary.yml
@@ -1,0 +1,46 @@
+name: Issue summary
+
+# Posts a short tl;dr comment on new issues so maintainers can triage from
+# the notification list without opening every issue. Uses GitHub Models via
+# actions/ai-inference; the token only needs models: read for that.
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  models: read
+
+jobs:
+  summary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize the issue
+        id: inference
+        uses: actions/ai-inference@v1
+        with:
+          system-prompt: >
+            You write one-line triage notes for a maintainer of copperhead,
+            a CLI tool that edits KiCad circuit board projects. Write like a
+            person leaving a quick note, not like a report. Plain sentences
+            only: no headings, no bullet points, no bold text, no em dashes,
+            and never phrases like "the user reports" or "this issue
+            describes". Just say what is going on and what part of the tool
+            it touches, in two or three short sentences at most. If the
+            issue is too thin to summarize, say what is missing instead.
+          prompt: |
+            Issue title: ${{ github.event.issue.title }}
+
+            Issue body:
+            ${{ github.event.issue.body }}
+
+      - name: Post the summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          # Passed via env, never interpolated into the script, so model
+          # output cannot inject shell.
+          RESPONSE: ${{ steps.inference.outputs.response }}
+        run: |
+          gh issue comment "$ISSUE_URL" --body "tl;dr: $RESPONSE"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,22 @@
+name: Labeler
+
+# Applies area:* / documentation / chore labels from the paths a PR touches.
+# Config lives in .github/labeler.yml.
+#
+# pull_request_target so the token can write labels on fork PRs. Safe because
+# the job never checks out or runs PR code; the labeler action only reads the
+# changed-files list from the API.
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,46 @@
+name: Stale
+
+# Nudges issues and PRs that have gone quiet, then closes them if nobody
+# responds. Anything labeled bounty, good first issue, or help wanted is
+# left alone: those are meant to sit open until someone picks them up.
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          days-before-pr-stale: 45
+          days-before-pr-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: 'bounty,good first issue,help wanted'
+          exempt-pr-labels: 'bounty'
+          stale-issue-message: >
+            This one has been quiet for a couple of months. Is it still a
+            problem on the latest release? A quick comment keeps it open,
+            otherwise it will be closed in two weeks. Closed issues can
+            always be reopened.
+          close-issue-message: >
+            Closing this for now since there was no follow-up. If it is
+            still biting you, leave a comment or open a new issue with
+            fresh details and we will pick it back up.
+          stale-pr-message: >
+            Looks like this PR stalled. If you are still working on it,
+            a comment or a push will keep it open. Otherwise it will be
+            closed in two weeks. No hard feelings either way, it can be
+            reopened whenever you have time again.
+          close-pr-message: >
+            Closing this since it has been inactive for a while. Thanks
+            for the work that went into it. If you want to pick it back
+            up later, reopen it or start a fresh branch from main.


### PR DESCRIPTION
## What

Adds four GitHub Actions workflows for community and repo hygiene: a first-interaction greeter, a stale issue/PR sweeper, path-based PR auto-labeling, and an AI-generated triage summary on new issues.

## Why

The repo is getting outside contributors (first-time issues and PRs), and triage/labeling is currently all manual. These are stock, low-risk automations that keep the issue tracker tidy without changing anything about the tool itself.

## Design

- [greetings.yml](.github/workflows/greetings.yml): `actions/first-interaction@v1` welcomes first-time issue and PR authors. Messages are short and practical (asks for `copperhead check` output and KiCad version on bugs, warns PR authors about the CLA bot and the slow kicad-cli CI), and end with a small ask to star the repo.
- [stale.yml](.github/workflows/stale.yml): `actions/stale@v9` on a daily cron. Issues go stale after 60 days and close 14 days later; PRs after 45 and 14. Anything labeled `bounty`, `good first issue`, or `help wanted` is exempt, since those are meant to sit open.
- [labeler.yml](.github/workflows/labeler.yml) + [labeler.yml (config)](.github/labeler.yml): `actions/labeler@v5` applies `documentation`, `chore`, and `area:*` labels from the paths a PR touches, with `sync-labels: true`. Runs on `pull_request_target` so it can label fork PRs; safe because it never checks out or executes PR code, it only reads the changed-files list from the API. Note: the `area:*` labels must exist in the repo's label set for this to apply them.
- [issue-summary.yml](.github/workflows/issue-summary.yml): `actions/ai-inference@v1` (GitHub Models, `models: read` token permission only) posts a two-to-three sentence plain-prose triage note on each new issue so maintainers can triage from notifications.

All four declare minimal `permissions` blocks explicitly.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | n/a (CI-config-only, no TS touched) |
| Build | `npm run build` | n/a |
| Unit + offline | `npm test` | n/a |
| Live-LLM (opt-in) | keyed on `<ENV_VAR>` | n/a |
| YAML parse | `npx js-yaml <file>` on all 5 files | pass |

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a
- Commands run and outcome: n/a, CI-config-only change; workflows cannot run until merged to the default branch. All five YAML files validated with `js-yaml`.

## Docs

None touched. The workflow files carry their own explanatory header comments.

---

## Invariant checklist

This PR only adds files under `.github/`; it does not touch the agent loop, providers, commands, or the KiCad layer, so every invariant is N/A:

- [ ] **Spec-gated in**: N/A
- [ ] **Verification-gated out**: N/A
- [ ] **`check`/`verify` stays LLM-free and network-free**: N/A
- [ ] **No sexp serialization**: N/A
- [ ] **Sync-obligations ledger**: N/A
- [ ] **Secrets**: N/A (workflows use only the default `GITHUB_TOKEN` with minimal permissions)
- [ ] **Spec coherence**: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic labels based on the files changed in a pull request.
  * Added welcoming messages for first-time issue and pull request contributors.
  * Added concise automated summaries to newly opened issues.
  * Added scheduled and manual stale-item management with configurable notifications and exclusions.

* **Chores**
  * Added project categorization rules to improve issue and pull request organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->