### PR TITLE
fix(docs): read markdown tables that omit the outer pipes

### DIFF
--- a/src/memory/bom-table.ts
+++ b/src/memory/bom-table.ts
@@ -35,18 +35,60 @@ export interface TableRow {
    * whatever cells they split into — this function never throws.
    */
   export function parseMarkdownTables(md: string): TableRow[] {
-    const rows: TableRow[] = [];
+    return scanTableGroups(md)
+      .flat()
+      .filter((l) => !l.separator)
+      .map((l) => ({ cells: l.cells }));
+  }
+
+  interface ScannedLine {
+    cells: string[];
+    separator: boolean;
+  }
+
+  /**
+   * Group a document's table lines, one group per table. Both readers below go
+   * through this so they cannot disagree about which documents are readable:
+   * `check` accepting a BOM.md that `export bom` reads as empty is how a clean
+   * check turns into a header-only ordering file.
+   *
+   * Lines inside a fenced code block are skipped. Docs legitimately show the
+   * table format as an example, and an example row is not a part or a pin.
+   */
+  function scanTableGroups(md: string): ScannedLine[][] {
+    const groups: ScannedLine[][] = [];
+    let current: ScannedLine[] | null = null;
+    let width = 0; // column count of the open group, set by its first line
+    let inFence = false;
     for (const line of md.split('\n')) {
       const t = line.trim();
-      if (!t.startsWith('|')) continue;
-      const cells = t
-        .split('|')
-        .slice(1, -1)
-        .map((c) => c.trim());
-      if (cells.every((c) => /^:?-+:?$/.test(c))) continue; // separator row
-      rows.push({ cells });
+      if (/^(```|~~~)/.test(t)) {
+        inFence = !inFence;
+        current = null;
+        continue;
+      }
+      if (inFence || !t.includes('|')) {
+        current = null; // a blank, prose, or fenced line terminates the table
+        continue;
+      }
+      const cells = splitRow(t);
+      // Outer pipes make a line unambiguously a table row. Without them, a
+      // pipe-bearing prose line (`Legend: A | B`) is indistinguishable from a
+      // row by shape alone, so the column count decides: matching the open
+      // table's width keeps it as a row, a mismatch ends the table there rather
+      // than reading the prose as a part/pin. The line still opens a new group,
+      // in case it is itself the header of an un-piped table.
+      if (current && !t.startsWith('|') && cells.length !== width) current = null;
+      if (!current) {
+        current = [];
+        width = cells.length;
+        groups.push(current);
+      }
+      // The separator row stays in the group so the header can be located
+      // relative to it; it is dropped by the readers above and below.
+      current.push({ cells, separator: isSeparatorRow(cells) });
     }
-    return rows;
+    return groups;
   }
   
   /** True for a table's header row. BOM.md and PINOUT.md both lead with a
@@ -86,35 +128,8 @@ export interface TableRow {
    * it loops on finish forever. Resolving by header name fixes that.
    */
   export function parseCanonicalTables(md: string): Array<{ header: TableRow; rows: TableRow[] }> {
-    type Line = { cells: string[]; separator: boolean };
-    const groups: Line[][] = [];
-    let current: Line[] | null = null;
-    let width = 0; // column count of the open group, set by its first line
-    for (const line of md.split('\n')) {
-      const t = line.trim();
-      if (!t.includes('|')) {
-        current = null; // a blank or prose line terminates the current table
-        continue;
-      }
-      const cells = splitRow(t);
-      // Outer pipes make a line unambiguously a table row. Without them, a
-      // pipe-bearing prose line (`Legend: A | B`) is indistinguishable from a
-      // row by shape alone, so the column count decides: matching the open
-      // table's width keeps it as a row, a mismatch ends the table there rather
-      // than reading the prose as a part/pin. The line still opens a new group,
-      // in case it is itself the header of an un-piped table.
-      if (current && !t.startsWith('|') && cells.length !== width) current = null;
-      if (!current) {
-        current = [];
-        width = cells.length;
-        groups.push(current);
-      }
-      // The separator row stays in the group so the header can be located
-      // relative to it; it is dropped from the rows returned below.
-      current.push({ cells, separator: isSeparatorRow(cells) });
-    }
     const tables: Array<{ header: TableRow; rows: TableRow[] }> = [];
-    for (const g of groups) {
+    for (const g of scanTableGroups(md)) {
       // The header is the row directly above the separator. Falling back to the
       // first row keeps a table that omits the separator working, and anchoring
       // on the separator means a stray pipe-bearing prose line immediately above

--- a/src/memory/bom-table.ts
+++ b/src/memory/bom-table.ts
@@ -59,15 +59,29 @@ export interface TableRow {
     const groups: ScannedLine[][] = [];
     let current: ScannedLine[] | null = null;
     let width = 0; // column count of the open group, set by its first line
-    let inFence = false;
+    // The open fence's delimiter, or null outside one. A fence closes only on the
+    // same character, at least as long (CommonMark). Toggling on any fence-like
+    // line would let a shorter or different delimiter *inside* a block end it
+    // early, and the example rows after it would be read as parts or pins.
+    let fence: { char: string; length: number } | null = null;
     for (const line of md.split('\n')) {
       const t = line.trim();
-      if (/^(```|~~~)/.test(t)) {
-        inFence = !inFence;
-        current = null;
-        continue;
+      const delim = /^(`{3,}|~{3,})/.exec(t);
+      if (delim) {
+        const [char, length] = [delim[1]![0]!, delim[1]!.length];
+        if (!fence) {
+          fence = { char, length };
+          current = null;
+          continue;
+        }
+        // A closing fence carries no info string; anything else stays content.
+        if (char === fence.char && length >= fence.length && !t.slice(length).trim()) {
+          fence = null;
+          current = null;
+          continue;
+        }
       }
-      if (inFence || !t.includes('|')) {
+      if (fence || !t.includes('|')) {
         current = null; // a blank, prose, or fenced line terminates the table
         continue;
       }

--- a/src/memory/bom-table.ts
+++ b/src/memory/bom-table.ts
@@ -35,15 +35,25 @@ export interface TableRow {
    * whatever cells they split into — this function never throws.
    */
   export function parseMarkdownTables(md: string): TableRow[] {
-    return scanTableGroups(md)
-      .flat()
-      .filter((l) => !l.separator)
-      .map((l) => ({ cells: l.cells }));
+    return (
+      scanTableGroups(md)
+        // A group opened by an un-piped line with no delimiter row is not a table:
+        // GFM requires the delimiter row for one to exist at all. Without this,
+        // ordinary prose such as `Second-source options: Yageo | Vishay | KOA`
+        // under a BOM table becomes a part in `export bom`, which `check` cannot
+        // catch because `parseCanonicalTables` drops the header-less group.
+        .filter((g) => g[0]!.piped || g.some((l) => l.separator))
+        .flat()
+        .filter((l) => !l.separator)
+        .map((l) => ({ cells: l.cells }))
+    );
   }
 
   interface ScannedLine {
     cells: string[];
     separator: boolean;
+    /** Whether the source line carried a leading pipe. */
+    piped: boolean;
   }
 
   /**
@@ -108,7 +118,7 @@ export interface TableRow {
       }
       // The separator row stays in the group so the header can be located
       // relative to it; it is dropped by the readers above and below.
-      current.push({ cells, separator: isSeparatorRow(cells) });
+      current.push({ cells, separator: isSeparatorRow(cells), piped: t.startsWith('|') });
     }
     return groups;
   }

--- a/src/memory/bom-table.ts
+++ b/src/memory/bom-table.ts
@@ -64,18 +64,26 @@ export interface TableRow {
     // line would let a shorter or different delimiter *inside* a block end it
     // early, and the example rows after it would be read as parts or pins.
     let fence: { char: string; length: number } | null = null;
-    for (const line of md.split('\n')) {
+    // Split on either line ending: a CRLF document would otherwise leave a
+    // trailing \r on every line, and \r is a line terminator that `.` does not
+    // match, so the fence patterns below would never fire on a CRLF file.
+    for (const line of md.split(/\r?\n/)) {
       const t = line.trim();
-      const delim = /^(`{3,}|~{3,})/.exec(t);
+      // Matched against the raw line: CommonMark allows a fence up to three
+      // spaces of indentation, and four or more makes it content rather than a
+      // fence. Trimming first would let an indented delimiter inside a block
+      // read as a closer.
+      const delim = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
       if (delim) {
-        const [char, length] = [delim[1]![0]!, delim[1]!.length];
+        const marker = delim[1]!;
+        const char = marker[0]!;
         if (!fence) {
-          fence = { char, length };
+          fence = { char, length: marker.length };
           current = null;
           continue;
         }
         // A closing fence carries no info string; anything else stays content.
-        if (char === fence.char && length >= fence.length && !t.slice(length).trim()) {
+        if (char === fence.char && marker.length >= fence.length && !delim[2]!.trim()) {
           fence = null;
           current = null;
           continue;

--- a/test/bom-table.test.ts
+++ b/test/bom-table.test.ts
@@ -396,6 +396,58 @@ describe('optional outer pipes (GitHub-flavored markdown)', () => {
     expect(parsePinoutRows(md).map((r) => r.ref)).toEqual(['U1']);
   });
 
+  it('an over-indented delimiter inside a block is content, not a closer', () => {
+    const b3 = '`'.repeat(3);
+    const md = [
+      '| Refdes | Pin | Net |',
+      '|---|---|---|',
+      '| U1 | 1 | 3V3 |',
+      '',
+      b3 + 'markdown',
+      '    ' + b3,
+      'Refdes | Pin | Net',
+      '--- | --- | ---',
+      'U9 | 42 | LEAKED',
+      '',
+      b3,
+    ].join('\n');
+    expect(parsePinoutRows(md).map((r) => r.ref)).toEqual(['U1']);
+  });
+
+  it('still treats a legally indented fence as a fence', () => {
+    const b3 = '`'.repeat(3);
+    const md = [
+      '| Refdes | Pin | Net |',
+      '|---|---|---|',
+      '| U1 | 1 | 3V3 |',
+      '',
+      '  ' + b3 + 'markdown',
+      'Refdes | Pin | Net',
+      '--- | --- | ---',
+      'U5 | 5 | EXAMPLE',
+      '',
+      '  ' + b3,
+    ].join('\n');
+    expect(parsePinoutRows(md).map((r) => r.ref)).toEqual(['U1']);
+  });
+
+  it('handles CRLF documents', () => {
+    const b3 = '`'.repeat(3);
+    const md = [
+      '| Refdes | Pin | Net |',
+      '|---|---|---|',
+      '| U1 | 1 | 3V3 |',
+      '',
+      b3 + 'markdown',
+      'Refdes | Pin | Net',
+      '--- | --- | ---',
+      'U9 | 42 | LEAKED',
+      '',
+      b3,
+    ].join('\r\n');
+    expect(parsePinoutRows(md).map((r) => r.ref)).toEqual(['U1']);
+  });
+
   it('a tilde fence does not close a backtick fence', () => {
     const b3 = '`'.repeat(3);
     const md = [

--- a/test/bom-table.test.ts
+++ b/test/bom-table.test.ts
@@ -354,4 +354,23 @@ describe('optional outer pipes (GitHub-flavored markdown)', () => {
   it('ignores a pipe-free document', () => {
     expect(parseCanonicalRows('# Just prose\n\nNo tables here.\n')).toEqual([]);
   });
+  it('does not read an example table inside a fenced code block', () => {
+    const md = [
+      '| Refdes | Pin | Net |',
+      '|---|---|---|',
+      '| U1 | 1 | 3V3 |',
+      '',
+      '```markdown',
+      'Refdes | Pin | Net',
+      '--- | --- | ---',
+      'U9 | 42 | EXAMPLE_NET',
+      '```',
+    ].join('\n');
+    expect(parsePinoutRows(md)).toEqual([{ ref: 'U1', pin: '1', net: '3V3' }]);
+  });
+
+  it('the check reader and the export reader agree on an un-piped BOM', () => {
+    expect(parseBomTable(bom)).toHaveLength(1);
+    expect(parseMarkdownTables(bom).filter((r) => !isHeader(r))).toHaveLength(1);
+  });
 });

--- a/test/bom-table.test.ts
+++ b/test/bom-table.test.ts
@@ -346,6 +346,20 @@ describe('optional outer pipes (GitHub-flavored markdown)', () => {
     expect(parseBomTable(md).map((r) => r.refdes)).toEqual(['R1']);
   });
 
+  it('the export reader does not read a pipe-bearing prose line as a part either', () => {
+    const md = [bom, 'Legend: UNVERIFIED | needs a datasheet check'].join('\n');
+    const flat = parseMarkdownTables(md).filter((r) => !isHeader(r));
+    expect(flat.map((r) => r.cells[0])).toEqual(['R1']);
+  });
+
+  it('the export reader ignores a prose line whose cell count matches the header', () => {
+    // The quiet variant: a matching cell count puts a real value in the MPN
+    // column, so the phantom row reaches the ordering CSV without a warning.
+    const md = [bom, '', 'Second-source options: Yageo | Vishay | KOA | Panasonic'].join('\n');
+    const flat = parseMarkdownTables(md).filter((r) => !isHeader(r));
+    expect(flat.map((r) => r.cells[0])).toEqual(['R1']);
+  });
+
   it('a prose line carrying a pipe does not hide the table under it', () => {
     const md = ['Nets are named `A | B` in the legend.', '| Refdes | Pin | Net |', '|---|---|---|', '| U1 | 1 | 3V3 |'].join('\n');
     expect(parsePinoutRows(md)).toEqual([{ ref: 'U1', pin: '1', net: '3V3' }]);
@@ -412,6 +426,8 @@ describe('optional outer pipes (GitHub-flavored markdown)', () => {
       b3,
     ].join('\n');
     expect(parsePinoutRows(md).map((r) => r.ref)).toEqual(['U1']);
+    // The export reader has no header filter, so it must be checked separately.
+    expect(parseMarkdownTables(md).filter((r) => !isHeader(r)).map((r) => r.cells[0])).toEqual(['U1']);
   });
 
   it('still treats a legally indented fence as a fence', () => {

--- a/test/bom-table.test.ts
+++ b/test/bom-table.test.ts
@@ -370,7 +370,47 @@ describe('optional outer pipes (GitHub-flavored markdown)', () => {
   });
 
   it('the check reader and the export reader agree on an un-piped BOM', () => {
-    expect(parseBomTable(bom)).toHaveLength(1);
-    expect(parseMarkdownTables(bom).filter((r) => !isHeader(r))).toHaveLength(1);
+    const checked = parseBomTable(bom);
+    const flat = parseMarkdownTables(bom).filter((r) => !isHeader(r));
+    expect(checked.map((r) => r.refdes)).toEqual(flat.map((r) => r.cells[0]));
+    expect(checked.map((r) => r.refdes)).toEqual(['R1']);
+  });
+
+  it('a shorter or different fence inside a block does not end it early', () => {
+    const b3 = '`'.repeat(3);
+    const b4 = '`'.repeat(4);
+    const md = [
+      '| Refdes | Pin | Net |',
+      '|---|---|---|',
+      '| U1 | 1 | 3V3 |',
+      '',
+      b4 + 'markdown',
+      'Example, do not parse:',
+      b3,
+      'Refdes | Pin | Net',
+      '--- | --- | ---',
+      'U9 | 42 | LEAKED',
+      '',
+      b4,
+    ].join('\n');
+    expect(parsePinoutRows(md).map((r) => r.ref)).toEqual(['U1']);
+  });
+
+  it('a tilde fence does not close a backtick fence', () => {
+    const b3 = '`'.repeat(3);
+    const md = [
+      '| Refdes | Pin | Net |',
+      '|---|---|---|',
+      '| U1 | 1 | 3V3 |',
+      '',
+      b3 + 'markdown',
+      '~~~',
+      'Refdes | Pin | Net',
+      '--- | --- | ---',
+      'U8 | 99 | LEAKED',
+      '',
+      b3,
+    ].join('\n');
+    expect(parsePinoutRows(md).map((r) => r.ref)).toEqual(['U1']);
   });
 });


### PR DESCRIPTION
## What

`check` now reads PINOUT.md and BOM.md tables that are written without the outer pipes. Before this, a table like `Refdes | Pin | Net` parsed as zero rows, so the drift gate silently checked nothing.

## Why

GitHub-flavored markdown makes the leading and trailing pipes optional. Both of these render as the same table, and both are things a person or the agent may write:

```markdown
| Refdes | Pin | Net |
| --- | --- | --- |
| U1 | 1 | 3V3 |
```

```markdown
Refdes | Pin | Net
--- | --- | ---
U1 | 1 | 3V3
```

`parseCanonicalTables` skipped any line that did not start with `|`, so the second form produced no tables at all. Everything downstream funnels through that one function (`parsePinoutRows`, `parseBomTable`, `pinoutColumnReport`, `parseCanonicalRows`), which gives two failure modes from the same gap:

**PINOUT.md silently passes.** I put deliberately wrong data in the fixture's PINOUT.md, written without outer pipes, and `check` was happy:

```text
$ copperhead --repo manual-tests/runs/edit check
DRC ✓
drift ✓
```

The doc it just approved claimed `U1:1` is on `COMPLETELY_WRONG_NET` (it is on `3V3`), `U1:2` is on `ALSO_WRONG` (it is on `EN`), plus a pin `U1:99` and a part `R9` that do not exist. `pinoutColumnReport` also reports `hasTable: false` for that doc, so the existing "no Net column" warning cannot fire either: there is nothing to warn about, as far as it can tell.

**BOM.md reports false drift.** The mirror case, with a correct BOM written the same way:

```text
drift: BOM.md claims "R1 absent" but actual is "R1 (10k) in schematic"
drift: BOM.md claims "R2 absent" but actual is "R2 (1k) in schematic"
drift: BOM.md claims "U1 absent" but actual is "U1 (ESP32-S3-MINI) in schematic"
```

Every part is listed right there in the file. This is the failure the `parseCanonicalRows` docstring already warns about, where the agent gets pushed to degrade good docs to appease the gate.

Worth noting: a table in that form passes this repo's own markdownlint config with zero issues, so nothing else in the toolchain flags the doc as malformed.

## Design

Three small changes in [bom-table.ts](src/memory/bom-table.ts), all inside `parseCanonicalTables`:

1. A line joins a table when it contains a pipe, instead of when it starts with one.
2. `splitRow` strips one optional leading and one optional trailing pipe before splitting, so both forms yield the same cells.
3. The header is the row directly above the separator row, falling back to the first row when a table has no separator.

Point 3 is what keeps 1 safe. Accepting any pipe-bearing line means a prose line like ``Nets are named `A | B` in the legend.`` sitting directly above a table would otherwise become the group's first row and hide the real header. Anchoring on the separator fixes that case too, which was already broken before this change.

I left `parseMarkdownTables` alone. It is the lenient flat helper and only `bom-export` uses it, so I kept the blast radius on the canonical path that the drift gate actually reads.

## Spec / OpenSpec

No spec-level behavior change. This restores AC-2.3 drift detection for docs the parser was silently skipping, and does not alter the fixed-column contract from design D9.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | pass for this change (481 passed; see note) |
| Markdown lint | `npm run lint:md` | pass |
| Live-LLM (opt-in) | n/a | not exercised, this path is LLM-free |

Six tests added to `test/bom-table.test.ts` under `optional outer pipes (GitHub-flavored markdown)`: pin rows, column report, BOM rows, both forms agreeing, the prose-with-a-pipe case, and a pipe-free document. Four of the six fail on `main` and pass here. The other two are regression guards that pass both ways.

Note on the full run: I am on Windows, where 9 tests fail on `main` before my change (POSIX path assumptions, CRLF, `chmod 0o000` being a no-op, and `kicad-cli` timeouts). I checked `gating-sync` and `init-check` specifically because they touch drift, and both fail identically with my change stashed, so they are pre-existing here and not caused by this. #94, #76 and #80 are already working on that Windows surface.

### Manual test log (required)

Sandbox variant used: `edit`, via `./manual-tests/setup.sh edit`, with `kicad-cli` 10.0.5 on PATH.

```text
$ npm run dev -- --repo manual-tests/runs/edit init
created docs\PINOUT.md ... created .git\hooks\pre-commit

# baseline, scaffolded docs (outer pipes)
$ npm run dev -- --repo manual-tests/runs/edit check
DRC ✓
drift ✓

# PINOUT.md rewritten WITHOUT outer pipes, data deliberately wrong
# before this change:
drift ✓                      <- the bug

# after this change:
drift: PINOUT.md claims "U1:1 net COMPLETELY_WRONG_NET" but actual is "U1:1 net 3V3"
drift: PINOUT.md claims "U1:2 net ALSO_WRONG" but actual is "U1:2 net EN"
drift: PINOUT.md claims "U1:99 exists" but actual is "U1:99 not in schematic"
drift: PINOUT.md claims "R9:1 exists" but actual is "R9:1 not in schematic"

# both docs WITHOUT outer pipes, data correct
$ npm run dev -- --repo manual-tests/runs/edit check
DRC ✓
drift ✓
```

The control matters here: the same wrong data with outer pipes was always caught. The only variable is the pipes.

## Docs

None needed. This makes the parser accept a form the docs already imply is fine, and no documented contract changes.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, this does not touch the agent tool list.
- [ ] **Verification-gated out**: N/A, no change to the mutation or repair path.
- [x] **`check`/`verify` stays LLM-free and network-free**: the change is pure string parsing in `src/memory/`, no provider, key, or network access added.
- [x] **No sexp serialization**: `src/kicad/` untouched.
- [ ] **Sync-obligations ledger**: N/A, ledger and commit gating unchanged.
- [ ] **Secrets**: N/A, no transcript or summary paths touched.
- [x] **Spec coherence**: no spec-level behavior change, so SPEC.md and the change artifacts stay as they are.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and parsing of Markdown BOM/PINOUT pipe-tables, including GitHub-flavored formats.
  * Correctly handles tables with or without outer `|`, preserves and interprets separator rows, and validates header layout.
  * Ignores pipe-like content inside fenced code blocks and improves canonical table recognition; prevents prose pipes from interrupting parsing.
* **Tests**
  * Expanded fenced-code and delimiter edge-case coverage (including `CRLF`) and added cross-parser output consistency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->