### PR TITLE
Fix/compat gemini groq docs redaction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,14 +65,47 @@ SYNAP_API_KEY=
 SYNAP_USER_ID=
 SYNAP_CUSTOMER_ID=
 
-# --- OpenAI-compatible endpoint (issue #110) -------------------------------
-# Point the OpenAI provider at Groq, OpenRouter, Gemini's compat
-# endpoint, or a local Ollama. Read ONLY by the `compat:<model-id>` model route,
-# so leaving these set never redirects a plain `gpt-5` run.
+# --- OpenAI-compatible endpoint -------------------------------
+# Point the OpenAI provider at Gemini, Groq, OpenRouter, or a local Ollama.
+# Read ONLY by the `compat:<model-id>` model route, so leaving these set never
+# redirects a plain `gpt-5` run. Three pieces, always set together: the
+# endpoint, the name of the env var holding that endpoint's key, and the key
+# itself. A loopback endpoint (Ollama) needs no key — leave COPPERHEAD_API_KEY_ENV
+# and the key both blank.
+#
+# Gemini:
+#   COPPERHEAD_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/
+#   COPPERHEAD_API_KEY_ENV=GEMINI_API_KEY
+#   GEMINI_API_KEY=...
+#   COPPERHEAD_MODEL=compat:<model-id>   (or --model compat:<model-id> per command)
+#
+# Groq:
+#   COPPERHEAD_BASE_URL=https://api.groq.com/openai/v1
+#   COPPERHEAD_API_KEY_ENV=GROQ_API_KEY
+#   GROQ_API_KEY=...
+#   COPPERHEAD_MODEL=compat:<model-id>   (or --model compat:<model-id> per command)
+#
+# OpenRouter:
+#   COPPERHEAD_BASE_URL=https://openrouter.ai/api/v1
+#   COPPERHEAD_API_KEY_ENV=OPENROUTER_API_KEY
+#   OPENROUTER_API_KEY=...
+#   COPPERHEAD_MODEL=compat:<model-id>   (or --model compat:<model-id> per command)
+#
+# Ollama (local, no key):
+#   COPPERHEAD_BASE_URL=http://localhost:11434/v1
+#   COPPERHEAD_MODEL=compat:<model-id>   (or --model compat:<model-id> per command)
+#
+# Model ids are whatever the provider calls them - check their model list.
+# baseURL must be the OpenAI-compatible base path specifically, not the provider's general API root.
 COPPERHEAD_BASE_URL=
-# Name of the variable holding that endpoint's key (not the key itself).
-# Defaults to OPENAI_API_KEY. A loopback endpoint (Ollama) needs no key.
 COPPERHEAD_API_KEY_ENV=
-# A compatible endpoint has no default model (Groq/OpenRouter each serve
-# dozens), so set COPPERHEAD_MODEL=compat:<model-id> above, or pass
-# --model compat:<model-id> on every command.
+# A compatible endpoint has no default model (each of the above serves many),
+# so COPPERHEAD_MODEL (or --model) must always be set to compat:<model-id> as
+# unlike gpt-5/claude, there is no bare "compat" fallback.
+
+# Fill in only the key for the provider you're using, leave the rest blank.
+# COPPERHEAD_API_KEY_ENV above must name that same variable, e.g. if you fill
+# in GEMINI_API_KEY, set COPPERHEAD_API_KEY_ENV=GEMINI_API_KEY too.
+GEMINI_API_KEY=
+GROQ_API_KEY=
+OPENROUTER_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -70,8 +70,11 @@ SYNAP_CUSTOMER_ID=
 # Read ONLY by the `compat:<model-id>` model route, so leaving these set never
 # redirects a plain `gpt-5` run. Three pieces, always set together: the
 # endpoint, the name of the env var holding that endpoint's key, and the key
-# itself. A loopback endpoint (Ollama) needs no key — leave COPPERHEAD_API_KEY_ENV
-# and the key both blank.
+# itself. A loopback endpoint (Ollama) needs no key of its own - but
+# COPPERHEAD_API_KEY_ENV defaults to OPENAI_API_KEY when left unset, and
+# whatever that holds (e.g. your OPENAI_API_KEY above) is sent to the endpoint
+# regardless. Point COPPERHEAD_API_KEY_ENV at an unset variable name if you
+# don't want that.
 #
 # Gemini:
 #   COPPERHEAD_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ copperhead export bom --supplier jlcpcb   # supplier-ready ordering file from do
 
 Global flags: `--repo <path>` (default: cwd) and `--json` for machine-readable output. `--model` is available on `do`, `sync`, `create`, and `doctor`; `--interactive` only on `do` and `create`; `do` also takes `--dry-run`, `--max-turns`, and `--allow-dirty`.
 
-`--model` accepts `gpt-5` (OpenAI), `claude` / `claude-<id>` (Anthropic API), `claude-code` / `claude-code:<id>` (Claude Code, saved login), `cursor` / `cursor:<id>` (Cursor Agent CLI, saved login), and `codex` / `codex:<id>` (Codex CLI, saved login). Routing is by prefix; `claude-code` is matched before the `claude` prefix. `compat:<id>` targets any OpenAI-compatible endpoint (Groq, OpenRouter, Gemini, or a local Ollama) via `COPPERHEAD_BASE_URL` and `COPPERHEAD_API_KEY_ENV`.
+`--model` accepts `gpt-5` (OpenAI), `claude` / `claude-<id>` (Anthropic API), `claude-code` / `claude-code:<id>` (Claude Code, saved login), `cursor` / `cursor:<id>` (Cursor Agent CLI, saved login), and `codex` / `codex:<id>` (Codex CLI, saved login). Routing is by prefix; `claude-code` is matched before the `claude` prefix. `compat:<id>` targets any OpenAI-compatible endpoint (Groq, OpenRouter, Gemini, or a local Ollama) via `COPPERHEAD_BASE_URL` and `COPPERHEAD_API_KEY_ENV` - worked examples for each in [`.env.example`](.env.example) and the [configuration reference](https://docs.copperhead.sh/reference/configuration/#model-selection).
 
 ### Saved login (Cursor Agent)
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -95,29 +95,65 @@ If `codex` is not on `PATH`, point `COPPERHEAD_CODEX_PATH` at an executable expl
 
 If none of these produce a model, the command exits with an error telling you the available ways to set one. `check` never needs a model, since it makes no LLM calls at all.
 
-Accepted model values (routing is by prefix; `makeProvider` checks `codex`, then `claude-code`, then `cursor`, then `claude`, then OpenAI):
+Accepted model values (routing is by prefix; `makeProvider` checks `compat`, then `codex`, then `claude-code`, then `cursor`, then `claude`, then OpenAI):
+
+Two rows below both mention "OpenAI," but mean different things - worth pulling apart before the table:
+
+- **`gpt-5`** talks to OpenAI's own service, running OpenAI's own models. Needs `OPENAI_API_KEY`.
+- **`compat:<id>`** talks to somebody else's service - Google's Gemini servers, Groq's servers, OpenRouter's servers, or your own machine running Ollama. None of them are OpenAI. They're called "OpenAI-**compatible**" only because those companies chose to format their requests the same way OpenAI does, so copperhead can talk to them with the same code it already has for `gpt-5` - just pointed at a different address (`baseURL`) with a different key.
+
+So every other row below is a dedicated integration for one specific vendor's login or API. `compat:<id>` is the odd one out: a generic bridge that works for any of them, precisely because it assumes nothing about which one you're using.
 
 | Value | Provider | Key |
 | --- | --- | --- |
+| `compat:<id>` | Any OpenAI-compatible endpoint (Groq, OpenRouter, Gemini, Ollama) | the variable named by `apiKeyEnv`; none for a local endpoint |
 | `codex` / `codex:<id>` | Codex CLI, saved login | none (local Codex login) |
 | `claude-code` / `claude-code:<id>` | Claude Code, saved login | none (uses `CLAUDE_CODE_OAUTH_TOKEN` / your logged-in CLI) |
 | `cursor` / `cursor:<id>` | Cursor Agent CLI, saved login | none (`agent login`) |
-| `compat:<id>` | Any OpenAI-compatible endpoint (Groq, OpenRouter, Gemini, Ollama) | the variable named by `apiKeyEnv`; none for a local endpoint |
 | `claude` / `claude-<id>` | Anthropic API | `ANTHROPIC_API_KEY` |
 | `gpt-5` / anything else | OpenAI API | `OPENAI_API_KEY` |
 
 `claude-code` is matched before the `claude` prefix, so it is never captured by the Anthropic API route. Cursor runs report 0 token usage (CLI JSON has no usage fields).
 
-For `compat:<id>`, set `baseURL` and `apiKeyEnv` together — either as `COPPERHEAD_BASE_URL`/`COPPERHEAD_API_KEY_ENV`, or as `baseURL`/`apiKeyEnv` in `.copperhead/config.json`:
+For `compat:<id>`, set `baseURL` (env `COPPERHEAD_BASE_URL` or `.copperhead/config.json`) and, if the endpoint needs a key, `apiKeyEnv` (env `COPPERHEAD_API_KEY_ENV` or config). Each resolves independently - env wins over config for whichever one it sets - so you can mix sources, e.g. `baseURL` in config with `COPPERHEAD_API_KEY_ENV` as an env var. Only `baseURL` is required; `apiKeyEnv` defaults to `OPENAI_API_KEY` if left unset. The three pieces below are always: the endpoint, the name of the env var holding the key, and that env var itself.
+
+**Gemini:**
+
+```bash
+export COPPERHEAD_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/
+export COPPERHEAD_API_KEY_ENV=GEMINI_API_KEY
+export GEMINI_API_KEY=...
+copperhead do "..." --model compat:<model-id>
+```
+
+**Groq:**
+
+```bash
+export COPPERHEAD_BASE_URL=https://api.groq.com/openai/v1
+export COPPERHEAD_API_KEY_ENV=GROQ_API_KEY
+export GROQ_API_KEY=...
+copperhead do "..." --model compat:<model-id>
+```
+
+**OpenRouter:**
 
 ```bash
 export COPPERHEAD_BASE_URL=https://openrouter.ai/api/v1
 export COPPERHEAD_API_KEY_ENV=OPENROUTER_API_KEY
-export OPENROUTER_API_KEY=sk-or-v1-...
+export OPENROUTER_API_KEY=...
 copperhead do "..." --model compat:<model-id>
 ```
 
-A local endpoint (Ollama) needs no key: `COPPERHEAD_BASE_URL=http://localhost:11434/v1` and no `apiKeyEnv` at all. Only the `compat` route reads `baseURL`, so leaving these set does not affect `gpt-5` or any other model.
+**Ollama (local, no key):**
+
+```bash
+export COPPERHEAD_BASE_URL=http://localhost:11434/v1
+copperhead do "..." --model compat:<model-id>
+```
+
+Leave `COPPERHEAD_API_KEY_ENV` unset for a local endpoint - no key is sent. Only the `compat` route reads `baseURL`, so leaving any of these set does not affect `gpt-5` or any other model.
+
+The model id after `compat:` is whatever that provider calls it (check their model list - ids and availability change over the ones shown above). `baseURL` must be the OpenAI-compatible base path specifically (the `/v1`, or `/v1beta/openai/` for Gemini), not the provider's general API root.
 
 ### Saved login (Claude Code)
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -155,7 +155,7 @@ export COPPERHEAD_MODEL=compat:<model-id>   # or pass --model compat:<model-id> 
 copperhead do "..."
 ```
 
-Leave `COPPERHEAD_API_KEY_ENV` unset for a local endpoint - no key is sent. Only the `compat` route reads `baseURL`, so leaving any of these set does not affect `gpt-5` or any other model.
+A local endpoint needs no key of its own, but `COPPERHEAD_API_KEY_ENV` still defaults to `OPENAI_API_KEY` when left unset, and whatever that variable holds is sent to the endpoint as a bearer token - including over the LAN if `baseURL` points at another machine (e.g. a `.local` hostname), not just loopback. If you have `OPENAI_API_KEY` exported for normal `gpt-5` use, as in the example `.env` above, that key will be sent to Ollama too unless you point `COPPERHEAD_API_KEY_ENV` at an unset variable to suppress it. Only the `compat` route reads `baseURL`, so leaving any of these set does not affect `gpt-5` or any other model.
 
 The model id after `compat:` is whatever that provider calls it (check their model list - ids and availability change over the ones shown above). `baseURL` must be the OpenAI-compatible base path specifically (the `/v1`, or `/v1beta/openai/` for Gemini), not the provider's general API root.
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -115,7 +115,7 @@ So every other row below is a dedicated integration for one specific vendor's lo
 
 `claude-code` is matched before the `claude` prefix, so it is never captured by the Anthropic API route. Cursor runs report 0 token usage (CLI JSON has no usage fields).
 
-For `compat:<id>`, set `baseURL` (env `COPPERHEAD_BASE_URL` or `.copperhead/config.json`) and, if the endpoint needs a key, `apiKeyEnv` (env `COPPERHEAD_API_KEY_ENV` or config). Each resolves independently - env wins over config for whichever one it sets - so you can mix sources, e.g. `baseURL` in config with `COPPERHEAD_API_KEY_ENV` as an env var. Only `baseURL` is required; `apiKeyEnv` defaults to `OPENAI_API_KEY` if left unset. The three pieces below are always: the endpoint, the name of the env var holding the key, and that env var itself.
+For `compat:<id>`, set `baseURL` (env `COPPERHEAD_BASE_URL` or `.copperhead/config.json`) and, if the endpoint needs a key, `apiKeyEnv` (env `COPPERHEAD_API_KEY_ENV` or config). Each resolves independently - env wins over config for whichever one it sets - so you can mix sources, e.g. `baseURL` in config with `COPPERHEAD_API_KEY_ENV` as an env var. `baseURL` is required for every compat endpoint. Non-local endpoints (Gemini, Groq, OpenRouter) also need the actual key, held in the variable `apiKeyEnv` names (defaults to `OPENAI_API_KEY` if left unset) - a local endpoint (Ollama) can skip the key entirely. The three pieces below are always: the endpoint, the name of the env var holding the key, and that env var itself.
 
 **Gemini:**
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -123,7 +123,8 @@ For `compat:<id>`, set `baseURL` (env `COPPERHEAD_BASE_URL` or `.copperhead/conf
 export COPPERHEAD_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/
 export COPPERHEAD_API_KEY_ENV=GEMINI_API_KEY
 export GEMINI_API_KEY=...
-copperhead do "..." --model compat:<model-id>
+export COPPERHEAD_MODEL=compat:<model-id>   # or pass --model compat:<model-id> instead, per command
+copperhead do "..."
 ```
 
 **Groq:**
@@ -132,7 +133,8 @@ copperhead do "..." --model compat:<model-id>
 export COPPERHEAD_BASE_URL=https://api.groq.com/openai/v1
 export COPPERHEAD_API_KEY_ENV=GROQ_API_KEY
 export GROQ_API_KEY=...
-copperhead do "..." --model compat:<model-id>
+export COPPERHEAD_MODEL=compat:<model-id>   # or pass --model compat:<model-id> instead, per command
+copperhead do "..."
 ```
 
 **OpenRouter:**
@@ -141,14 +143,16 @@ copperhead do "..." --model compat:<model-id>
 export COPPERHEAD_BASE_URL=https://openrouter.ai/api/v1
 export COPPERHEAD_API_KEY_ENV=OPENROUTER_API_KEY
 export OPENROUTER_API_KEY=...
-copperhead do "..." --model compat:<model-id>
+export COPPERHEAD_MODEL=compat:<model-id>   # or pass --model compat:<model-id> instead, per command
+copperhead do "..."
 ```
 
 **Ollama (local, no key):**
 
 ```bash
 export COPPERHEAD_BASE_URL=http://localhost:11434/v1
-copperhead do "..." --model compat:<model-id>
+export COPPERHEAD_MODEL=compat:<model-id>   # or pass --model compat:<model-id> instead, per command
+copperhead do "..."
 ```
 
 Leave `COPPERHEAD_API_KEY_ENV` unset for a local endpoint - no key is sent. Only the `compat` route reads `baseURL`, so leaving any of these set does not affect `gpt-5` or any other model.

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -131,9 +131,9 @@ export function checkCredential(
     const settings = compat ?? { apiKeyEnv: DEFAULT_API_KEY_ENV };
     // Display only: some endpoints embed a credential in the URL itself (a
     // query param, userinfo) — Gemini's compat endpoint does this with
-    // ?key=..., in a format redactSecrets' key-shape patterns don't cover.
-    // Drop the query and userinfo entirely rather than pattern-matching, so
-    // this holds regardless of what a given provider's key looks like.
+    // ?key=.... redactSecrets covers known key shapes, but a key embedded in
+    // a URL query isn't reliably one of them, so drop the query and userinfo
+    // entirely rather than pattern-matching, regardless of shape.
     // isLocalEndpoint() below still runs against the raw settings.baseURL,
     // never this.
     const where = (() => {

--- a/src/util/redact.ts
+++ b/src/util/redact.ts
@@ -15,6 +15,9 @@ const PATTERNS: RegExp[] = [
   /npm_[A-Za-z0-9-]{36,}/g,
   /gh[pousr]_[A-Za-z0-9]{36,}/g,
   /github_pat_[A-Za-z0-9_]{22,}/g,
+  // Gemini and Groq keys: same idea as sk- above, just a different prefix.
+  /AIzaSy[A-Za-z0-9_-]+/g,
+  /gsk_[A-Za-z0-9]+/g,
 ];
 
 export function redactSecrets(text: string): string {

--- a/src/util/redact.ts
+++ b/src/util/redact.ts
@@ -16,8 +16,11 @@ const PATTERNS: RegExp[] = [
   /gh[pousr]_[A-Za-z0-9]{36,}/g,
   /github_pat_[A-Za-z0-9_]{22,}/g,
   // Gemini and Groq keys: same idea as sk- above, just a different prefix.
-  /AIzaSy[A-Za-z0-9_-]+/g,
-  /gsk_[A-Za-z0-9]+/g,
+  // Real keys are AIza + 35 chars, but AIzaSy (the common fifth/sixth pair)
+  // isn't the only prefix Google issues - match on AIza alone so other
+  // Google keys aren't left unredacted.
+  /AIza[A-Za-z0-9_-]{20,}/g,
+  /gsk_[A-Za-z0-9]{20,}/g,
 ];
 
 export function redactSecrets(text: string): string {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -318,11 +318,12 @@ describe('doctor — OpenAI-compatible endpoints (issue #110)', () => {
   });
 
   it('strips a Gemini-shaped key (AIza..., not sk-...) from the endpoint URL — regression', () => {
-    // redactSecrets' key-shape patterns (sk-, Bearer, npm_, gh*_) don't match
-    // Gemini's AIza... format or Groq's gsk_... format, and Gemini's own
-    // compat endpoint puts the key in the URL as ?key=.... Dropping the whole
-    // query/userinfo (not pattern-matching the key) is what makes this hold
-    // for every provider's key shape, not just the ones tested here.
+    // redactSecrets covers known key shapes (sk-, Bearer, npm_, gh*_, AIza,
+    // gsk_...), but a key embedded in a URL query isn't reliably one of them,
+    // and Gemini's own compat endpoint puts the key in the URL as ?key=....
+    // Dropping the whole query/userinfo (not pattern-matching the key) is
+    // what makes this hold for every provider's key shape, not just the ones
+    // tested here.
     const gemini = {
       baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai?key=AIzaSyABCDEF1234567890shouldnotleak',
       apiKeyEnv: 'GEMINI_API_KEY',

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -76,6 +76,18 @@ describe('secret redaction (AC-4.1)', () => {
     expect(out).toBe('[REDACTED]');
   });
 
+  it('redacts Gemini and Groq keys', () => {
+    // Synthetic, correctly-shaped, never valid.
+    const input = [
+      'AIzaSyD-9tSrke72PouQMnMX-a7eZSW0jkFMBc',
+      'gsk_0123456789abcdefghijklmnopqrstuvwxyzABCDEFGH',
+    ].join(' ');
+    const out = redactSecrets(input);
+    expect(out).not.toMatch(/AIzaSy[A-Za-z0-9_-]{10,}/);
+    expect(out).not.toMatch(/gsk_[A-Za-z0-9]{10,}/);
+    expect(out).toBe('[REDACTED] [REDACTED]');
+  });
+
   it('leaves ordinary prose alone', () => {
     // The patterns are deliberately broad, but not so broad that a run summary
     // loses readable text.

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -88,6 +88,13 @@ describe('secret redaction (AC-4.1)', () => {
     expect(out).toBe('[REDACTED] [REDACTED]');
   });
 
+  it('redacts a Google key with a prefix other than AIzaSy — regression', () => {
+    // AIzaSy is the common fifth/sixth pair but not the only one Google
+    // issues; the pattern must match on AIza alone.
+    const out = redactSecrets('AIzaBcD1234567890abcdefghijklmnopqrstu');
+    expect(out).toBe('[REDACTED]');
+  });
+
   it('leaves ordinary prose alone', () => {
     // The patterns are deliberately broad, but not so broad that a run summary
     // loses readable text.
@@ -96,6 +103,8 @@ describe('secret redaction (AC-4.1)', () => {
       'Bearer token missing',
       'a npm_ package name',
       'see the github_pat docs',
+      'a gsk_ prefixed identifier',
+      'an AIza-prefixed placeholder',
     ]) {
       expect(redactSecrets(text), text).toBe(text);
     }


### PR DESCRIPTION
## What

Adds worked Gemini/Groq examples for `compat:<id>` (previously only OpenRouter/Ollama had them), and closes a redaction gap: `redactSecrets()` didn't recognize Gemini (`AIzaSy...`) or Groq (`gsk_...`) key shapes.

## Why

Closes #129.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` (`test/safety.test.ts`) | pass (28/28) |

New test: `redacts Gemini and Groq keys` in `test/safety.test.ts`.

## Docs

`README.md`, `docs/src/content/docs/reference/configuration.md`, `.env.example`.

---

## Invariant checklist

- [ ] N/A: **Spec-gated in**. Unaffected; this PR doesn't touch tool gating.
- [ ] N/A: **Verification-gated out**. Unaffected; no mutation/ERC/DRC path touched.
- [ ] N/A: **`check`/`verify` stays LLM-free and network-free**. Unaffected.
- [ ] N/A: **No sexp serialization**. This PR doesn't touch `src/kicad/`.
- [ ] N/A: **Sync-obligations ledger**. Unaffected.
- [x] **Secrets**: adds `AIzaSy...` (Gemini) and `gsk_...` (Groq) patterns to `PATTERNS` in `src/util/redact.ts`, closing a gap where those key shapes reached transcripts/summaries unredacted. Regression test added.
- [ ] N/A: **Spec coherence**. No spec-level behavior added; this closes a gap in the existing AC-4.1 secrets guarantee rather than introducing a new capability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration guidance for Gemini, Groq, OpenRouter, and local Ollama compatible models.
  * Clarified endpoint, API key, and model-routing settings, including local Ollama key handling.

* **Bug Fixes**
  * Improved secret protection by redacting Gemini and Groq API key formats.

* **Documentation**
  * Expanded CLI and configuration references with provider-specific examples and routing details.

* **Tests**
  * Added coverage confirming Gemini and Groq credentials are removed from reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->