### PR TITLE
feat(onboarding): prepare git in create, offer a way through the dirty gate, stop refusing over copperhead's own artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,14 @@ copperhead do "add reverse-polarity protection on VIN"
 copperhead check               # ERC + DRC + doc drift; no LLM, CI-safe
 ```
 
-Starting from nothing instead? Write a product brief and run `copperhead create --brief brief.md`. The [examples/](examples/) directory has ready-made briefs sorted by difficulty, plus a note on which one is designed to fail.
+Starting from nothing instead? In an empty directory, describe the board and copperhead does the rest:
+
+```bash
+mkdir keypad && cd keypad
+copperhead create "a 4-key USB-C macro keypad, RP2040, per-key RGB"
+```
+
+The text is saved as `brief.md`, and git is set up for you (init, baseline `.gitignore`, initial commit) so the run has something to snapshot and roll back to. Already have a brief written? `copperhead create --brief brief.md`. The [examples/](examples/) directory has ready-made briefs sorted by difficulty, plus a note on which one is designed to fail.
 
 ### Use your existing Codex login
 
@@ -118,7 +125,7 @@ copperhead do "<change request>"     # the core loop: propose, edit, verify, pro
 copperhead check                     # ERC + DRC + doc-drift + spec validation; no LLM calls (alias: verify)
 copperhead doctor                    # env preflight: kicad-cli, git, node, provider credential; no LLM/network
 copperhead sync [--dry-run]          # verify the whole design state, resolve drift
-copperhead create --brief brief.md   # brief → full output package
+copperhead create "<brief text>"     # brief → full output package (or --brief brief.md)
 copperhead export bom --supplier jlcpcb   # supplier-ready ordering file from docs/BOM.md
 ```
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -103,6 +103,19 @@ copperhead do "<change request>" [options]
 
 Exits 1 if the run ends in failure, 0 otherwise.
 
+### Uncommitted changes
+
+A rollback hard-resets to the pre-run snapshot, so a run will not start on a dirty tree unless it can protect what is there. On a terminal, `do`, `sync`, and the shell list the uncommitted files and offer four ways forward:
+
+| Choice | What happens |
+| --- | --- |
+| commit | The changes are committed (`chore: save work in progress before a copperhead run`), so a rollback returns to them instead of discarding them. |
+| stash | `git stash push -u` sets them aside; `git stash pop` brings them back. |
+| run anyway | Equivalent to `--allow-dirty`: the snapshot keeps them and a rollback restores them. |
+| cancel | Nothing changes, and the run stops with the usual refusal. |
+
+Without a terminal (CI, pipes, `--json`) there is nobody to ask, so the run refuses exactly as before. Pass `--allow-dirty` to skip the question entirely.
+
 ## `copperhead check`
 
 Alias: `copperhead verify`.
@@ -176,12 +189,14 @@ Exit code 2 is the important one. A requirement violation means the as-built des
 The full pipeline from a product brief to the output package.
 
 ```bash
+copperhead create "<brief text>" [--model <model>] [--interactive]
 copperhead create --brief brief.md [--model <model>] [--interactive]
 ```
 
 | Option | Description |
 | --- | --- |
-| `--brief <file>` | **Required.** The product brief, in markdown. |
+| `[brief]` | The brief as text, or the path to a brief markdown file. Text is written to `brief.md` in the repo (or the next free `brief-N.md`, never overwriting an existing one) so the run stays resumable. |
+| `--brief <file>` | The product brief, in markdown. Equivalent to passing the path positionally. |
 | `--model <model>` | `codex`, `cursor`, `gpt-5`, `claude`, or `claude-code` (saved-login; no model API key for those three). |
 | `--interactive` | Re-enable the human gates: spec approval, and a pause before export. |
 
@@ -203,6 +218,12 @@ Each stage is a full `do` loop with its own prompt and gate. Stage completion is
 | 8 | `devplan` | `docs/DEVPLAN.md` |
 
 Stages build on each other's uncommitted state, so `create` runs them as if `--allow-dirty` were set.
+
+### Git setup
+
+`create` is usually the first command run in a brand-new directory, so it sets git up itself rather than refusing: if there is no repository it runs `git init`, writes a baseline `.gitignore` (`.env`, `.copperhead/runs/`, `.history/`), and makes the initial commit that stage rollbacks snapshot against. When no git identity is configured it writes a repo-local one (`copperhead <copperhead@localhost>`); override it with `git config user.name` / `git config user.email`. In a repository that already has commits, nothing is initialized and only the brief is committed, so a stage rollback (`git reset --hard` + `git clean -fd`) cannot delete it.
+
+`do` and `sync` keep the strict preflight: those edit a repository you already own, where an implicit initial commit would be a surprise.
 
 ## Repo scripts
 

--- a/docs/src/content/docs/workflows/create-from-brief.md
+++ b/docs/src/content/docs/workflows/create-from-brief.md
@@ -7,6 +7,17 @@ sidebar:
 
 Flow A starts from nothing but a product brief and an empty git repo, and ends with a full design package. Underneath, it is [the same loop](/concepts/agent-loop/) as editing an existing board, run once per pipeline stage with a stage-specific prompt and gate.
 
+## 0. The one-liner version
+
+If you just want to see the pipeline run, hand it a sentence:
+
+```bash
+mkdir usb-c-breakout && cd usb-c-breakout
+copperhead create "a USB-C 5V power breakout, 3A, screw terminal and 0.1in header, power LED"
+```
+
+The text is saved as `brief.md` in the directory, and git is set up for you (init, baseline `.gitignore`, initial commit) so the run has a snapshot to roll back to. Everything below is the same flow with a brief you wrote yourself, which is what you want for anything you intend to build.
+
 ## 1. Write the brief
 
 The brief is a plain markdown file. This is the entire input to the pipeline, so it is worth ten minutes. Save it as `brief.md`:
@@ -63,11 +74,10 @@ Six ready-made briefs ship in [`examples/`](https://github.com/chouhanindustries
 
 ```bash
 mkdir usb-c-breakout && cd usb-c-breakout
-git init && git commit --allow-empty -m "baseline"
 copperhead create --brief ../brief.md
 ```
 
-The empty baseline commit matters: rollback snapshots need somewhere to roll back to.
+No git setup needed first: `create` initializes the repository, writes a baseline `.gitignore` (`.env`, `.copperhead/runs/`, `.history/`), and makes the initial commit, because rollback snapshots need somewhere to roll back to. In a repository that already has commits it changes none of that and only commits the brief, so a stage rollback cannot delete it.
 
 ## 3. What runs
 

--- a/openspec/changes/smooth-onboarding-gates/design.md
+++ b/openspec/changes/smooth-onboarding-gates/design.md
@@ -1,0 +1,42 @@
+# smooth-onboarding-gates: Design
+
+## Context
+
+The create pipeline's safety model rests on git: each stage snapshots HEAD, and a stage that fails its gate is rolled back with `git reset --hard` + `git clean -fd`. That made "a repo with at least one commit" a hard precondition, enforced by `gitPreflight` and surfaced to first-time users as a refusal. The brief, meanwhile, has to exist as a file because run metadata records its path and sha256 and the resume line prints `--brief <abs path>`.
+
+Both requirements are real. Neither has to be the *user's* job on the create path.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `mkdir board && cd board && copperhead create "<sentence>"` works, with no git or file setup first.
+- Text mode and file mode converge on one artifact, so resume, run metadata, and the brief hash have exactly one code path.
+- Nothing about the rollback guarantee weakens.
+
+**Non-Goals:**
+
+- Loosening the git gates for `do` / `repl` / `sync`.
+- Interpreting or reformatting the user's brief text (no LLM in the setup path; the text is written verbatim).
+- Auto-committing a user's unrelated working changes.
+
+## Decisions
+
+- **D1: `create` prepares git; `do` and `sync` refuse.** The split is about ownership. `create` authors a repository from nothing, so initializing it is part of the job. `do` edits a repo the user already owns, where an implicit `git add -A && git commit` could sweep up work the user never meant to commit. `ensureGitReady` is therefore a separate export from `gitPreflight` rather than a flag on it, and only `create` calls it. Alternative considered: an `--init` flag on `create`. Rejected: a flag you have to discover after a refusal fixes nothing for the person who just hit the refusal.
+- **D2: `ensureGitReady` never touches a repo that has commits.** Its only work on that path is the idempotent `.gitignore` top-up. Everything else (init, identity fallback, initial commit) is gated on the states that would otherwise refuse the run, so running `create` inside an existing project cannot rewrite or add to history unexpectedly.
+- **D3: The initial commit is `--allow-empty` with `git add -A`.** In an empty directory there is nothing to stage, and the point of the commit is to be a rollback anchor, not to carry content. In a directory with files, committing them is the honest thing to do: the pipeline is about to start rolling the tree back to this point, and an untracked file that a rollback would delete is worse than a tracked one.
+- **D4: A repo-local git identity fallback, not a failure.** `git commit` hard-fails without `user.name`/`user.email`, which is exactly the state of a fresh machine. Writing `copperhead <copperhead@localhost>` into the repo's own config keeps the run moving without touching the user's global config, and the run log says it happened so they can override it.
+- **D5: Text briefs are materialized, not held in memory.** A file is what makes the run resumable (`resumeCommand` prints `--brief <path>`) and auditable (per-stage brief sha256, AC-8.1). Materializing keeps one artifact and one code path for both input forms.
+- **D6: Never overwrite a brief; reuse an identical one.** Numbered fallbacks (`brief-2.md`, …) mean a second one-liner in the same directory cannot destroy the first. Reusing a byte-identical existing brief means the common case — rerunning the same command to resume after a stopped stage — does not litter the directory with copies. Alternative considered: refuse when `brief.md` exists. Rejected: it turns the resume path into an error.
+- **D7: The brief is committed before stage 1.** Otherwise the first failing stage's rollback (`git clean -fd`) deletes the untracked brief the printed resume command points at, which is precisely the moment the user needs it. `commitPaths` uses a pathspec commit so only the brief is committed, leaving any other dirty or staged path alone.
+- **D8: The dirty-tree gate asks instead of refusing, but only when someone is there.** The gate's reasoning (a rollback would destroy uncommitted work) is not weakened by asking; it is weakened by guessing. So the chooser is an injected callback: present on a TTY, absent under `--json`, in CI, and in pipes, where the run refuses exactly as it always did. A prompt that throws or is dismissed reads as cancel, never as consent.
+- **D9: The choices are the ones the refusal message already recommends.** Commit, stash, run anyway, cancel. Inventing a fourth recovery story would mean new behavior to explain and test; these three are already documented and are what a user does by hand after the refusal today.
+- **D10: The REPL resolves before the turn, not inside it.** The shell pauses its raw-mode key reader for the duration of an agent turn (so Ctrl+C is a real SIGINT), so a menu raised from inside `runAgentLoop` would never see a keypress. The shell therefore resolves the tree while its reader is live and passes the result as a per-turn `allowDirty` override; `do` and `sync`, which have no such reader, use the loop's `onDirtyTree` callback directly.
+- **D11: Commit is the recommended choice, and it is reversible.** Of the three, only "run anyway" leaves the work exposed to any later mistake, and only "commit" survives a rollback with zero further steps. A commit the user did not want is `git reset --soft HEAD~1` away, which is the cheapest failure mode of the four.
+
+## Risks / Trade-offs
+
+- **`git init` in an unexpected directory.** A user could run `create` in the wrong place and get a repository where they did not want one. Mitigated by it being non-destructive (no file content changes; `rm -rf .git` undoes it), by the run log naming what happened, and by the operation being skipped entirely inside any existing repo, including a subdirectory of one.
+- **The initial commit can include pre-existing files.** In a non-empty, non-git directory the anchor commit stages everything present. This is deliberate (D3): those files would otherwise be destroyed by the first rollback. The baseline `.gitignore` is written first, so `.env` is never in that commit (AC-4.3).
+- **A prompt in the middle of a session.** The dirty-tree menu is raised before an agent turn, inside the shell's alternate screen. It uses the same picker as `/model`, so the rendering path is proven, but a terminal that mishandles it would show a rough menu rather than a broken run: cancel and dismissal both land on the existing refusal.
+- **A brief that is gitignored cannot be committed.** `commitPaths` failure is caught and logged as a warning rather than failing the run; the pipeline continues, with the (documented) consequence that a rollback may remove that file.

--- a/openspec/changes/smooth-onboarding-gates/proposal.md
+++ b/openspec/changes/smooth-onboarding-gates/proposal.md
@@ -1,0 +1,33 @@
+# smooth-onboarding-gates: Proposal
+
+## Why
+
+Copperhead's git gates are correct and its error messages already explain the fix. They still stop a user cold at three of the most common first moments: an empty directory, no brief file, and a working tree with uncommitted work. Every one of those refusals ends with instructions the tool could carry out itself, after asking.
+
+`copperhead create` is the first command most new users run, and it is the one most likely to be run in a directory they just made. Two things stop them there:
+
+1. **The git gate.** The pipeline's snapshot/rollback needs a repository with at least one commit, so `create` refused with a preflight error telling the user to run `git init` and commit by hand. The advice is correct and the friction is pointless: `create` is going to write the repository's entire history anyway, so it can prepare the repo itself.
+2. **The brief file.** `--brief <file>` was required, so trying copperhead meant first opening an editor and writing a markdown file. The pipeline stage-1 prompt happily accepts a sentence; the file requirement was an artifact of how the brief is hashed and referenced in the resume command, not a real constraint on the input.
+
+## What Changes
+
+- **`create` accepts the brief as a positional argument**: `copperhead create "a 4-key USB-C macro keypad"`. Text is materialized into a real markdown file in the repo (`brief.md`, or the next free `brief-N.md`) before the pipeline starts, so run metadata, the brief sha256, and the printed resume command work exactly as they do in file mode. An existing brief is never overwritten; one with identical content is reused, so re-running the same one-liner resumes instead of littering. A positional argument that names an existing `.md`/`.markdown`/`.txt` file is treated as that file, so `create brief.md` also works.
+- **`--brief <file>` becomes optional** and keeps its current meaning. Invoking `create` with neither form exits non-zero with a usage line showing both.
+- **`create` prepares git instead of refusing over it**: `git init` when there is no repository, the baseline `.gitignore` (`.env`, `.copperhead/runs/`, `.history/`) before any commit (AC-4.3), a repo-local git identity when none is configured, and the initial commit that stage rollbacks snapshot against. In a repository that already has commits, nothing is initialized and the only commit made is the brief itself, so a stage rollback (`git reset --hard` + `git clean -fd`) cannot delete the file the resume command points at.
+- **`do`, `repl`, and `sync` keep the strict `gitPreflight`** for the repo and unborn-HEAD gates. Those edit a repository the user already owns, where an implicit initial commit would be a surprise rather than a convenience.
+- **The dirty-tree gate becomes a question on attended runs.** Instead of only describing the three fixes, `do`, `sync`, and the interactive shell list the uncommitted files and offer them: commit the work, stash it, run anyway (`--allow-dirty` semantics), or cancel. Cancelling, a prompt that throws, and every unattended run (no TTY, or `--json`) fall through to the existing refusal, so the protection AC-3.8 describes is unchanged wherever there is nobody to ask.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `cli-surface`: `create` takes the brief positionally as text or a path; `--brief` is optional.
+- `create-pipeline`: brief materialization and the git preparation step that runs before stage 1.
+- `safety-rails`: the dirty-tree gate gains an attended resolution path; the unattended refusal is unchanged.
+
+## Impact
+
+- **Code**: `src/util/git.ts` gains `ensureGitReady`, `commitPaths`, `dirtyFiles`, and `stashDirty`; new `src/util/dirty.ts` holds the choice set and applies it; `src/agent/loop.ts` gains an `onDirtyTree` chooser; `src/commands/create.ts` gains brief resolution and a `prepareGit` prologue; `src/commands/repl.ts` resolves the tree before a turn (its key reader is paused during one); `src/cli.ts` supplies the TTY menu and the positional brief argument.
+- **Tests**: `test/create-setup.test.ts` (git preparation, brief materialization, no-overwrite, reuse) and `test/dirty-tree.test.ts` (each choice's effect on the tree, prompt failure reads as cancel, unattended refusal unchanged, `--allow-dirty` never asks); the two obsolete refusal cases in `test/preflight.test.ts` are removed, and the `do`-path gates there are untouched.
+- **Docs**: README quick start, `docs/reference/cli.md`, `docs/workflows/create-from-brief.md`, SPEC §2.5 / §3 / §7 / AC-3.8 / AC-4.3.
+- **Unchanged contracts**: `check` stays LLM-free and network-free; unattended runs refuse on a dirty tree exactly as before, and the repo/unborn-HEAD gates still hold for `do`/`repl`/`sync`; the spec-gated-in and verification-gated-out invariants are untouched.

--- a/openspec/changes/smooth-onboarding-gates/specs/cli-surface/spec.md
+++ b/openspec/changes/smooth-onboarding-gates/specs/cli-surface/spec.md
@@ -1,0 +1,37 @@
+# cli-surface — Delta Spec
+
+## MODIFIED Requirements
+
+### Requirement: Command set
+The `copperhead` CLI SHALL provide the commands `create [brief] [--brief <file>]`, `init [--path <dir>]`, `do "<change request>"`, `check`, `sync`, and `export bom --supplier <jlcpcb|digikey|mouser> [--boards <n>] [--spares <percent>] [--include-unverified]`, plus the global flags `--repo <path>`, `--dry-run`, and `--json`.
+
+#### Scenario: Help lists all Phase 1 commands
+- **WHEN** `copperhead --help` is run
+- **THEN** the output lists `create`, `init`, `do`, `check`, `sync`, and `export` with one-line descriptions and the global flags
+
+#### Scenario: Unknown command
+- **WHEN** an unrecognized command is invoked
+- **THEN** the CLI exits non-zero with a usage message and no stack trace
+
+#### Scenario: export bom flag validation
+- **WHEN** `export bom` is invoked with an unknown `--supplier` value
+- **THEN** the CLI exits non-zero listing the supported suppliers
+
+### Requirement: create accepts the brief as text or as a file
+`copperhead create` SHALL accept the brief either as a positional argument or via `--brief <file>`, and SHALL NOT require `--brief`.
+
+#### Scenario: Brief given as text
+- **WHEN** `copperhead create "a 4-key USB-C macro keypad"` is run
+- **THEN** the text is written to a markdown file in the repo and the pipeline runs against it, with stage 1's prompt carrying that text
+
+#### Scenario: Positional argument naming an existing file
+- **WHEN** `copperhead create brief.md` is run and `brief.md` exists
+- **THEN** that file is used as the brief and no new brief file is written
+
+#### Scenario: Neither form given
+- **WHEN** `copperhead create` is run with no positional argument and no `--brief`
+- **THEN** the CLI exits non-zero with a usage line showing both forms
+
+#### Scenario: Named brief file is missing
+- **WHEN** `--brief <file>` names a path that does not exist
+- **THEN** the command exits non-zero with an error naming that path, before any repo state is changed

--- a/openspec/changes/smooth-onboarding-gates/specs/create-pipeline/spec.md
+++ b/openspec/changes/smooth-onboarding-gates/specs/create-pipeline/spec.md
@@ -1,0 +1,54 @@
+# create-pipeline — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: create prepares the git repository it needs
+Before stage 1 runs, `create` SHALL bring the target directory to the state the pipeline's snapshot and rollback require, rather than refusing over a missing one. `do`, `repl`, and `sync` SHALL keep the strict preflight (AC-3.8) unchanged.
+
+#### Scenario: Non-git directory
+- **WHEN** `create` is run in a directory that is not a git repository
+- **THEN** it runs `git init`, writes a `.gitignore` containing `.env`, `.copperhead/runs/`, and `.history/`, creates the initial commit, and proceeds to stage 1
+- **AND** the run log states that a repository was initialized and why
+
+#### Scenario: Repository with an unborn HEAD
+- **WHEN** `create` is run in a repository that has no commits
+- **THEN** it creates the initial commit and proceeds, without re-initializing the repository
+
+#### Scenario: Empty directory
+- **WHEN** `create` prepares a directory that contains no files
+- **THEN** an empty initial commit is created, so a stage rollback still has a snapshot to restore to
+
+#### Scenario: No git identity configured
+- **WHEN** the commit is needed and neither `user.name` nor `user.email` is configured
+- **THEN** a repo-local identity is written, the global git config is not modified, and the run log names the identity used
+
+#### Scenario: Repository that already has commits
+- **WHEN** `create` is run in a repository with existing history
+- **THEN** no repository is initialized, no identity is written, and no existing commit is altered
+
+#### Scenario: Secrets never enter the first commit
+- **WHEN** `create` initializes a repository and creates its initial commit
+- **THEN** the baseline `.gitignore` is written before that commit, so `.env` and `.copperhead/runs/` are ignored from the very first commit (AC-4.3)
+
+### Requirement: The brief exists as a committed file
+`create` SHALL run against a brief that exists as a file inside the repository whenever the brief was given as text, and SHALL commit that file before stage 1.
+
+#### Scenario: Text brief is materialized
+- **WHEN** the brief is given as text
+- **THEN** it is written verbatim to `brief.md` in the repo root, and the run's brief path and sha256 metadata refer to that file
+
+#### Scenario: An existing brief is never overwritten
+- **WHEN** the brief is given as text and `brief.md` exists with different content
+- **THEN** the text is written to the next free `brief-N.md` and the existing file is left untouched
+
+#### Scenario: Re-running the same text reuses the brief
+- **WHEN** the brief is given as text identical to an existing brief file's content
+- **THEN** that file is reused, no new file is written, and completed stages are skipped as on any other resume
+
+#### Scenario: Empty text
+- **WHEN** the brief text is empty or whitespace only
+- **THEN** the run is refused with a message naming both input forms, and no brief file is written
+
+#### Scenario: Brief survives a stage rollback
+- **WHEN** a stage fails and the tree is rolled back with `git reset --hard` and `git clean -fd`
+- **THEN** the brief file is still present, because it was committed before stage 1, and the printed resume command resolves

--- a/openspec/changes/smooth-onboarding-gates/specs/safety-rails/spec.md
+++ b/openspec/changes/smooth-onboarding-gates/specs/safety-rails/spec.md
@@ -1,0 +1,66 @@
+# safety-rails — Delta Spec
+
+## MODIFIED Requirements
+
+### Requirement: Git-state preconditions and rollback
+`do` and `repl` SHALL refuse to start on a dirty git tree unless `--allow-dirty` is passed or the user resolves the tree at the attended prompt below, whose snapshot pairs a `git stash create` object for tracked changes with a tree object for the untracked-but-not-ignored files that `git stash create` cannot capture; on unrecoverable failure the working tree SHALL be restored to the pre-run snapshot, tracked and untracked alike.
+
+#### Scenario: Dirty tree refusal (AC-3.8)
+- **WHEN** the repo has uncommitted changes and `do` or `repl` runs unattended (no TTY, or `--json`) without `--allow-dirty`
+- **THEN** it refuses to start and suggests `--allow-dirty`
+
+#### Scenario: Untracked work survives a rollback (AC-3.8)
+- **WHEN** a run started with `--allow-dirty` fails unrecoverably and the tree held untracked, non-ignored files before the run
+- **THEN** the rollback restores those files along with the tracked modifications, and gitignored paths are neither captured nor disturbed
+
+#### Scenario: Unsnapshottable untracked file refused
+- **WHEN** a run starts with `--allow-dirty` and an untracked, non-ignored file exists that copperhead cannot read
+- **THEN** it refuses to start, names the file, and explains that the rollback would delete it with nothing to restore it from
+
+#### Scenario: Snapshot restore
+- **WHEN** a run fails unrecoverably
+- **THEN** `git status` is clean and all files are byte-identical to the pre-run state
+
+## ADDED Requirements
+
+### Requirement: Attended runs are offered a way through the dirty-tree gate
+When an attended run (a TTY, without `--json`) meets the dirty-tree gate, copperhead SHALL name the uncommitted files and offer to commit them, stash them, run anyway, or cancel, and SHALL apply the choice before the run's snapshot is taken. Unattended runs SHALL keep refusing unchanged.
+
+#### Scenario: Commit
+- **WHEN** the user chooses to commit
+- **THEN** the uncommitted paths are committed, the tree is clean, the run proceeds, and a later rollback returns to that commit rather than discarding the work
+
+#### Scenario: Stash
+- **WHEN** the user chooses to stash
+- **THEN** the changes are stashed with untracked files included, the tree is clean, the run proceeds, and the run log states that `git stash pop` restores them
+
+#### Scenario: Run anyway
+- **WHEN** the user chooses to run anyway
+- **THEN** the run proceeds with `--allow-dirty` semantics: nothing is committed or stashed, and the snapshot preserves the changes across a rollback
+
+#### Scenario: Cancel
+- **WHEN** the user cancels, or the prompt fails or is dismissed
+- **THEN** the tree is left exactly as it was and the run refuses with the standard dirty-tree message and its fixes
+
+#### Scenario: Unattended run
+- **WHEN** the run has no TTY or was invoked with `--json`
+- **THEN** no prompt is raised and the run refuses exactly as it did before (AC-3.8)
+
+#### Scenario: Explicit opt-in skips the question
+- **WHEN** the run was invoked with `--allow-dirty`
+- **THEN** no prompt is raised and the run proceeds
+
+#### Scenario: The prompt is only for the dirty gate
+- **WHEN** the directory is not a git repository, or the repository has no commits
+- **THEN** no prompt is raised and the preflight reports that specific failure with its own fix
+
+### Requirement: Copperhead's own artifacts never count as the user's uncommitted work
+The dirty-tree gate SHALL consider only paths copperhead did not write itself. The run audit trail under `.copperhead/runs/` SHALL be excluded from the dirty check by path, whether or not the repository's `.gitignore` lists it, and every commit copperhead makes SHALL top that entry up so the trail is never swept into project history.
+
+#### Scenario: The session log does not block the session (AC-4.3)
+- **WHEN** `do`, `sync`, or the REPL runs in a repository the user initialized by hand, whose `.gitignore` does not list `.copperhead/runs/`, and copperhead has written its session log or transcript there
+- **THEN** the gate does not fire, no prompt is raised, and the run starts
+
+#### Scenario: Real uncommitted work still stops the run
+- **WHEN** the tree holds the user's own uncommitted changes alongside the run audit trail
+- **THEN** the gate fires, and the files it names are the user's, with the audit trail absent from the list and from the count

--- a/openspec/changes/smooth-onboarding-gates/tasks.md
+++ b/openspec/changes/smooth-onboarding-gates/tasks.md
@@ -33,7 +33,7 @@
 - [x] 5.3 `test/dirty-tree.test.ts`: each choice's effect on the tree and history, a thrown prompt reading as cancel, a clean tree never asking, the repo/unborn-HEAD gates never prompting, the file-list cap, plus in-loop coverage (no chooser refuses, cancel refuses, commit proceeds, `--allow-dirty` never asks)
 - [x] 5.4 Remove the two obsolete `create` refusal cases from `test/preflight.test.ts`; the `do`-path gates there stay untouched
 - [x] 5.5 `test/preflight.test.ts`: a hand-initialized repo with no copperhead ignores and a written session log passes the gate, while the user's own uncommitted file still refuses and is the only path named
-- [x] 5.6 `test/dirty-tree.test.ts`: `dirtyFiles` names paths in full for every porcelain status column (` M`, `??`, staged rename)
+- [x] 5.6 `test/dirty-tree.test.ts`: `dirtyFiles` names paths in full for every porcelain status column (an unstaged modification, whose column is a leading space, plus untracked and staged-rename)
 - [x] 5.7 `test/repl.test.ts`: the two session-log tests wait on the turn starting instead of a fixed 30ms sleep, which the new pre-turn git probe made too tight
 
 ## 6. Docs

--- a/openspec/changes/smooth-onboarding-gates/tasks.md
+++ b/openspec/changes/smooth-onboarding-gates/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: smooth-onboarding-gates
+
+## 1. Git preparation
+
+- [x] 1.1 Add `ensureGitReady` to `src/util/git.ts`: init when absent (`-b main`, falling back for git < 2.28), baseline `.gitignore` (`.env`, `.copperhead/runs/`, `.history/`), repo-local identity fallback, `--allow-empty` initial commit; no-op past the `.gitignore` top-up once the repo has commits
+- [x] 1.2 Add `commitPaths` (pathspec commit) so the brief can be committed without sweeping up the user's other dirty or staged paths
+- [x] 1.3 Call it from a `prepareGit` prologue in `runCreate`, logging what was done and why; leave `gitPreflight` as the gate for `do` / `repl` / `sync`
+
+## 2. Brief input
+
+- [x] 2.1 `resolveBriefPath`: `--brief` wins; a positional `.md`/`.markdown`/`.txt` argument naming an existing file is used as-is; anything else is brief text
+- [x] 2.2 `materializeBriefText`: write to `brief.md`, fall back to the next free `brief-N.md`, reuse a byte-identical existing brief, refuse empty text
+- [x] 2.3 Make `briefPath` optional on `CreateOptions`, add `briefText`, resolve once at the top of `runCreate` so metadata, the brief sha256, and the resume command all read the same path
+
+## 3. CLI
+
+- [x] 3.1 `create` takes `[brief]` positionally; `--brief` is no longer a required option
+- [x] 3.2 Neither form given: exit non-zero with a usage line showing both
+
+## 4. Dirty-tree gate
+
+- [x] 4.1 `src/util/git.ts`: `dirtyFiles` (porcelain parse, rename-aware) and `stashDirty` (`stash push -u`), reusing `commitAll` for the commit path
+- [x] 4.2 New `src/util/dirty.ts`: the four choices, the capped file list, and `resolveDirtyTree`, which applies the choice and reports whether the run continues under `--allow-dirty`; a thrown or dismissed prompt reads as cancel
+- [x] 4.3 `runAgentLoop` takes an `onDirtyTree` chooser and resolves before `gitPreflight`; absent chooser keeps the refusal (AC-3.8)
+- [x] 4.4 `src/cli.ts`: TTY-only `selectMenu` chooser wired into `do` and `sync`, suppressed under `--json`
+- [x] 4.5 REPL: resolve before the turn (its key reader is paused during one), passing a per-turn `allowDirty` override through the runner
+- [x] 4.6 Exclude copperhead's own `.copperhead/runs/` from the dirty check by path (`git status --porcelain -uall`, so a wholly-untracked `.copperhead/` is not collapsed into one unfilterable entry); make `isDirty` and `uncommittedCount` derive from `dirtyFiles` so the gate, its file list, and `/git` cannot disagree; add `.copperhead/runs/` to `GIT_ADD_EXCLUDES` so every copperhead commit tops the ignore entry up
+
+## 5. Tests
+
+- [x] 5.1 `test/create-setup.test.ts`: non-git directory, unborn HEAD, empty directory, existing-history repo (only the brief is committed, the user's unrelated file is not), `ensureGitReady` idempotence
+- [x] 5.2 Brief materialization: text written verbatim and carried into the stage prompt, identical text reused, different text never overwriting, positional path used as a file, empty text refused, missing `--brief` file named in the error
+- [x] 5.3 `test/dirty-tree.test.ts`: each choice's effect on the tree and history, a thrown prompt reading as cancel, a clean tree never asking, the repo/unborn-HEAD gates never prompting, the file-list cap, plus in-loop coverage (no chooser refuses, cancel refuses, commit proceeds, `--allow-dirty` never asks)
+- [x] 5.4 Remove the two obsolete `create` refusal cases from `test/preflight.test.ts`; the `do`-path gates there stay untouched
+- [x] 5.5 `test/preflight.test.ts`: a hand-initialized repo with no copperhead ignores and a written session log passes the gate, while the user's own uncommitted file still refuses and is the only path named
+- [x] 5.6 `test/dirty-tree.test.ts`: `dirtyFiles` names paths in full for every porcelain status column (` M`, `??`, staged rename)
+- [x] 5.7 `test/repl.test.ts`: the two session-log tests wait on the turn starting instead of a fixed 30ms sleep, which the new pre-turn git probe made too tight
+
+## 6. Docs
+
+- [x] 6.1 README quick start: the empty-directory one-liner
+- [x] 6.2 `docs/reference/cli.md`: both brief forms, a git-setup section covering what `create` does and why `do`/`sync` differ, and the uncommitted-changes table under `do`
+- [x] 6.3 `docs/workflows/create-from-brief.md`: one-liner section, and drop the manual `git init && git commit --allow-empty` step
+- [x] 6.4 SPEC.md: §2.5 inputs, §3 command list, §7 safety rails (both gates), AC-3.8 attended resolution, AC-4.3 note about the repo `create` initializes

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -124,8 +124,10 @@ their-board/
 ### Inputs (Mode A)
 
 ```
-copperhead create --brief brief.md
+copperhead create "<brief text>"     # or: copperhead create --brief brief.md
 ```
+
+The brief may be given as literal text or as a file. Text is materialized into a markdown file in the repo (`brief.md`, or the next free `brief-N.md`; an existing file is never overwritten, and one with identical content is reused) so both forms produce the same resumable, hashable artifact. `create` also prepares git rather than refusing over it: `git init`, the baseline `.gitignore`, and the initial commit when any is missing (§7).
 
 `brief.md` — the product brief, free-form markdown:
 
@@ -255,7 +257,8 @@ copperhead demo [--tour] [--model …] [--dir <path>]
     `demo-runs/usb-c-breakout/` and run the create pipeline against the
     packaged USB-C power breakout brief (same as `npm run demo:simple`).
 
-copperhead create --brief brief.md   # Mode A: full pipeline (§2.5)
+copperhead create "<brief text>"     # Mode A: full pipeline (§2.5)
+copperhead create --brief brief.md   # same, from a brief file
 copperhead init [--path hardware/]
     Detect .kicad_sch/.kicad_pcb, parse symbols/footprints/nets,
     generate docs/ skeleton pre-filled with the real BOM and pinout
@@ -402,10 +405,13 @@ Acceptance: type "add a second RGB LED on an RTC-capable pin" → watch schemati
 
 ## 7. Safety rails
 
+- `create` prepares git instead of refusing over it: with no repository it runs `git init`, writes the baseline `.gitignore` (`.env`, `.copperhead/runs/`, `.history/`), and makes the initial commit that stage rollbacks snapshot against; with no configured git identity it writes a repo-local fallback. It never touches a repository that already has commits beyond committing the brief (so a rollback's `git clean -fd` cannot delete it) and the idempotent `.gitignore` top-up. `do`, `repl`, and `sync` keep the strict preflight below: those edit a repo the user already owns, where an implicit initial commit would be a surprise
+- An attended run (TTY, no `--json`) that meets the dirty-tree gate is offered the fixes rather than only told about them: commit the changes, stash them, run anyway (`--allow-dirty` semantics), or cancel. Cancel, a failed prompt, and every unattended run fall through to the refusal below unchanged, so the protection is identical wherever there is nobody to ask
 - Refuse to run `do` or `repl` on a dirty git tree (offer `--allow-dirty`, whose snapshot pairs a `git stash create` object for tracked changes with a tree object for untracked files, so the rollback restores both rather than letting `git clean` delete what the stash never captured). An untracked file that exists but cannot be read refuses the run by name: it cannot be snapshotted, and the rollback would delete it regardless, so proceeding would break exactly the promise `--allow-dirty` makes. Untracked paths that vanish before the snapshot is taken are skipped rather than refused
+- The dirty-tree gate counts only what the user wrote. `.copperhead/runs/` is excluded by path, not by consulting `.gitignore`: the REPL opens its session log there before the first turn, so in a repository the user initialized by hand the gate would otherwise refuse a run over a file copperhead had just written. The exclusion costs nothing, because the audit trail is deliberately carried across a rollback rather than reset with the rest of the tree. Every copperhead commit tops the `.copperhead/runs/` ignore entry up (AC-4.3), so the trail never reaches project history
 - All file tools sandboxed to repo root; no network tools in Phase 1
 - `.env` in `.gitignore` from first commit; keys only via env vars — never written to any file, transcript, or commit
-- Transcripts in `.copperhead/runs/` redact anything matching `sk-[A-Za-z0-9_-]+`
+- Everything written under `.copperhead/runs/` redacts anything matching `sk-[A-Za-z0-9_-]+` at write time: the transcript and the summary
 - The Codex CLI's native read access and `~/.codex/sessions/` logs are outside Copperhead's enforcement/redaction boundary; the Codex path documents this host-local exposure explicitly
 - The agent never invents MPNs: any new part must come with a datasheet-verifiable justification in BOM.md, flagged `UNVERIFIED` for human review
 
@@ -447,7 +453,7 @@ Format: Given / When / Then. "Fixture" = the open-telegraph repo (or the tiny te
 - **AC-3.5 (repair loop)** Given an edit that first produces an ERC violation, the transcript shows: violation parsed → targeted fix → re-run → pass, within `maxRepairCycles`.
 - **AC-3.6 (rollback)** If violations persist after `maxRepairCycles`, working tree equals the pre-run state (`git status` clean, files byte-identical), exit non-zero, transcript path printed.
 - **AC-3.7 (surgical edits)** For every run above: the `.kicad_sch` diff touches only the s-expressions relevant to the change — file not regenerated (assert: < 5% of lines changed for AC-3.1).
-- **AC-3.8 (dirty tree)** With uncommitted changes and no `--allow-dirty`: refuses to start. Holds for `repl` as well as `do`, since `repl` is the default command. With `--allow-dirty`, a rollback restores both the tracked modifications and the untracked files that were present before the run.
+- **AC-3.8 (dirty tree)** With uncommitted changes and no `--allow-dirty`: refuses to start whenever the run is unattended (no TTY, or `--json`), or when the user declines the attended prompt described in §7; choosing commit or stash at that prompt leaves a clean tree and the run proceeds, and choosing "run anyway" proceeds under `--allow-dirty` semantics. Holds for `repl` as well as `do`, since `repl` is the default command. With `--allow-dirty`, a rollback restores both the tracked modifications and the untracked files that were present before the run. "Uncommitted changes" means the user's: a repository whose only uncommitted path is copperhead's own `.copperhead/runs/` counts as clean and starts without a prompt, even when `.gitignore` does not yet list it.
 - **AC-3.9 (dry run)** `--dry-run` prints the proposed diff and writes nothing.
 - **AC-3.10 (provider parity)** AC-3.1 passes with `--model codex`, `--model gpt-5`, `--model claude`, `--model claude-code`, `--model cursor`, and `--model compat:<id>` when each provider is configured.
 - **AC-3.11 (saved login)** With `--model claude-code`, a logged-in Claude Code (`CLAUDE_CODE_OAUTH_TOKEN` set) and **no** `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`, a `do` run completes through the normal verify/commit path; copperhead reads no credential store; and no key material appears in the transcript, summary, or tree (AC-4.1 holds). A missing optional dependency or an unauthenticated install fails through the rollback path with an actionable error, not a raw stack trace.
@@ -465,7 +471,7 @@ Format: Given / When / Then. "Fixture" = the open-telegraph repo (or the tiny te
 
 - **AC-4.1** No file in the repo, transcript, or any commit ever contains a string matching `sk-[A-Za-z0-9_-]{20,}` (grep the whole tree + `.copperhead/runs/` after all tests).
 - **AC-4.2** A tool call with a path outside the repo root (e.g. `../../etc/hosts`) is rejected.
-- **AC-4.3** `.gitignore` includes `.env` and `.copperhead/runs/` in the very first commit of the repo.
+- **AC-4.3** `.gitignore` includes `.env` and `.copperhead/runs/` in the very first commit of the repo. This holds for the repository `create` initializes itself: the baseline ignore file is written before that initial commit.
 
 ### AC-7 · `copperhead sync` — full-state consistency
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -22,6 +22,7 @@ import { plainRenderer, fmtDuration, fmtTokens, type ProgressRenderer } from './
 import { styleHeaderLines } from './theme.js';
 import { ObligationsLedger } from './ledger.js';
 import { gitPreflight, isDirty, snapshot, restore, commitAll, changedFiles, preserveFailedRun } from '../util/git.js';
+import { resolveDirtyTree, type DirtyChooser } from '../util/dirty.js';
 import { withRetry, isRateLimit, sessionLimit } from '../util/retry.js';
 import { openspecArchive } from '../openspec/cli.js';
 import { existsSync } from 'node:fs';
@@ -57,6 +58,12 @@ export interface RunOptions {
    * grant (0 fails the run as before). Absent means non-interactive: fail.
    */
   onBudgetExhausted?: (stats: BudgetExhaustedStats) => Promise<number>;
+  /**
+   * Called when the dirty-tree gate would refuse the run, to pick a way
+   * through it (commit, stash, run anyway, cancel). Absent means
+   * non-interactive: refuse as before.
+   */
+  onDirtyTree?: DirtyChooser;
   /** Extra prompt appended for pipeline stages (Mode A). */
   stagePrompt?: string;
   /** Test seam: bypass makeProvider. */
@@ -235,7 +242,14 @@ async function runWithMemory(
   const config = await loadConfig(repoRoot);
   const maxTurns = opts.maxTurns ?? config.maxTurns;
 
-  await gitPreflight(repoRoot, { allowDirty: opts.allowDirty ?? false });
+  // Dirty tree: an attended run is offered the fixes the refusal message would
+  // otherwise only describe (commit / stash / run anyway). No chooser means
+  // unattended, so the gate refuses exactly as before (AC-3.8).
+  let allowDirty = opts.allowDirty ?? false;
+  if (!allowDirty && opts.onDirtyTree) {
+    ({ allowDirty } = await resolveDirtyTree(repoRoot, opts.onDirtyTree, log));
+  }
+  await gitPreflight(repoRoot, { allowDirty });
   const snap = await snapshot(repoRoot);
 
   const transcript = new Transcript(repoRoot);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,9 @@ import { Command } from 'commander';
 import { createRequire } from 'node:module';
 import { createInterface } from 'node:readline/promises';
 import { loadConfig, resolveModel, type ModelSource } from './config.js';
-import { pickModel } from './util/select.js';
+import { pickModel, selectMenu } from './util/select.js';
+import { DIRTY_CHOICES, describeDirtyFiles, type DirtyChoice, type DirtyChooser } from './util/dirty.js';
+import { warn } from './agent/theme.js';
 import { runInit, InitError } from './memory/scaffold.js';
 import { runCheck } from './commands/check.js';
 import { runDoctor, formatDoctor } from './commands/doctor.js';
@@ -54,6 +56,23 @@ function budgetContinuePrompt(): ((stats: BudgetExhaustedStats) => Promise<numbe
   if (!process.stdin.isTTY || !process.stdout.isTTY) return undefined;
   return async (stats) =>
     (await confirmTty(budgetPromptText(stats))) ? budgetExtraTurns(stats) : 0;
+}
+
+/**
+ * Attended runs get to choose a way through the dirty-tree gate instead of
+ * being told to go do it by hand. Non-TTY keeps the refusal (AC-3.8): there is
+ * nobody to ask, and guessing on someone's uncommitted work is not an option.
+ */
+function dirtyTreePrompt(): DirtyChooser | undefined {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return undefined;
+  return async ({ files }) => {
+    console.log(
+      warn(`working tree has ${files.length} uncommitted file(s); a rollback would hard-reset over them:`),
+    );
+    for (const line of describeDirtyFiles(files)) console.log(line);
+    const choice = await selectMenu({ title: 'How should copperhead handle them?', items: DIRTY_CHOICES });
+    return (choice as DirtyChoice | null) ?? 'cancel';
+  };
 }
 
 program
@@ -218,6 +237,8 @@ program
         const config = await loadConfig(repo);
         const { model, source } = resolveModel(opts.model, config);
         const continuePrompt = budgetContinuePrompt();
+        // --json is a machine contract: never raise an interactive menu under it.
+        const dirtyPrompt = program.opts().json ? undefined : dirtyTreePrompt();
         const res = await runAgentLoop({
           repoRoot: repo,
           request,
@@ -228,6 +249,7 @@ program
           interactive: opts.interactive ?? false,
           confirm: confirmTty,
           ...(continuePrompt ? { onBudgetExhausted: continuePrompt } : {}),
+          ...(dirtyPrompt ? { onDirtyTree: dirtyPrompt } : {}),
           renderer: rendererOf(),
           meta: { command: 'do', modelSource: source, version, kicadCliVersion: kicadVer },
         });
@@ -265,8 +287,10 @@ program
       }
       const config = await loadConfig(repo);
       const { model, source } = resolveModel(opts.model, config);
+      const syncDirtyPrompt = json ? undefined : dirtyTreePrompt();
       const res = await syncResolve(repo, report, model, json ? () => {} : (s) => console.log(s), {
         renderer: rendererOf(),
+        ...(syncDirtyPrompt ? { onDirtyTree: syncDirtyPrompt } : {}),
         meta: { command: 'sync', modelSource: source, version, kicadCliVersion: kicadVer },
       });
       process.exit(res.ok ? 0 : 1);
@@ -326,11 +350,18 @@ program
 program
   .command('create')
   .description('Mode A: full pipeline from a product brief to the output package')
-  .requiredOption('--brief <file>', 'product brief (markdown)')
+  .argument('[brief]', 'the product brief as text, or the path to a brief markdown file')
+  .option('--brief <file>', 'product brief (markdown)')
   .option('--model <model>', 'codex | cursor | gpt-5 | claude | claude-code | compat:<id> (or a provider-specific model id)')
   .option('--interactive', 're-enable the human gates (spec approval, pre-export)')
-  .action(async (opts: { brief: string; model?: string; interactive?: boolean }) => {
+  .action(async (briefArg: string | undefined, opts: { brief?: string; model?: string; interactive?: boolean }) => {
     const repo = repoOf(program.opts());
+    if (!opts.brief && !briefArg) {
+      console.error(
+        'no brief given. Pass it as text: copperhead create "a USB-C powered ESP32 sensor board", or point at a file: copperhead create --brief brief.md',
+      );
+      process.exit(1);
+    }
     try {
       const kicadVer = await kicadCliVersion();
       const config = await loadConfig(repo);
@@ -338,7 +369,7 @@ program
       const continuePrompt = budgetContinuePrompt();
       const res = await runCreate({
         repoRoot: repo,
-        briefPath: opts.brief,
+        ...(opts.brief ? { briefPath: opts.brief } : { briefText: briefArg as string }),
         model,
         interactive: opts.interactive ?? false,
         ...(continuePrompt ? { onBudgetExhausted: continuePrompt } : {}),

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -6,7 +6,7 @@ import { loadConfig, resolveCompatSettings } from '../config.js';
 import { bootstrapKicadProject } from '../kicad/bootstrap.js';
 import { exportSvg, runErc } from '../kicad/cli.js';
 import { listSymbols } from '../kicad/sexp.js';
-import { isDirty, commitAll, changedFiles } from '../util/git.js';
+import { isDirty, commitAll, changedFiles, commitPaths, ensureGitReady } from '../util/git.js';
 import type { CompatSettings, CopperheadConfig } from '../config.js';
 import { checkDrift } from '../memory/drift.js';
 import { runAgentLoop, makeProvider, type BudgetExhaustedStats } from '../agent/loop.js';
@@ -236,7 +236,14 @@ export const STAGES: Stage[] = [
 
 export interface CreateOptions {
   repoRoot: string;
-  briefPath: string;
+  /** Path to the brief markdown. Optional when `briefText` is given. */
+  briefPath?: string;
+  /**
+   * The brief as literal text (`copperhead create "<text>"`). Materialized into
+   * a real file in the repo before the pipeline starts, so text and file mode
+   * share one resumable, hashable artifact. Ignored when `briefPath` is set.
+   */
+  briefText?: string;
   model: string;
   interactive?: boolean;
   /** Forwarded to each stage's run (attended continue-on-exhaustion prompt). */
@@ -245,6 +252,62 @@ export interface CreateOptions {
   renderer?: ProgressRenderer;
   /** Command-level metadata; stage and brief identity are filled in per stage. */
   meta?: Omit<RunMetaInput, 'stage' | 'brief'>;
+}
+
+/** CreateOptions after the brief has been resolved to a file on disk. */
+type ResolvedCreateOptions = CreateOptions & { briefPath: string };
+
+/** Brief filenames written by text mode: brief.md, then brief-2.md, brief-3.md… */
+function briefCandidates(repoRoot: string): string[] {
+  return ['brief.md', ...Array.from({ length: 98 }, (_, i) => `brief-${i + 2}.md`)].map((n) =>
+    path.join(repoRoot, n),
+  );
+}
+
+/**
+ * Turn `copperhead create "<text>"` into the same artifact `--brief <file>`
+ * gives the pipeline: a real markdown file in the repo. The file is what makes
+ * a run resumable (the printed resume command points at it) and hashable (the
+ * per-stage brief sha256), so text mode materializes one rather than carrying
+ * the string in memory.
+ *
+ * Never overwrites: an existing brief with identical content is reused (so
+ * re-running the same one-liner resumes instead of littering), otherwise the
+ * next free numbered name is used.
+ */
+async function materializeBriefText(repoRoot: string, text: string): Promise<string> {
+  const body = text.trim();
+  if (!body) throw new Error('the brief is empty; pass some text or use --brief <file>');
+  const content = `${body}\n`;
+  for (const candidate of briefCandidates(repoRoot)) {
+    if (!existsSync(candidate)) {
+      await mkdir(path.dirname(candidate), { recursive: true });
+      await writeFile(candidate, content, 'utf8');
+      return candidate;
+    }
+    if ((await readFile(candidate, 'utf8')) === content) return candidate;
+  }
+  throw new Error('too many brief files in this directory; pass --brief <file> to name one explicitly');
+}
+
+/**
+ * Resolve the run's brief to a path on disk. `--brief <file>` wins; a positional
+ * argument that names an existing file is treated as that file (so both
+ * `create brief.md` and `create --brief brief.md` work), and anything else is
+ * the brief text itself.
+ */
+export async function resolveBriefPath(opts: CreateOptions): Promise<string> {
+  if (opts.briefPath) {
+    const p = path.resolve(opts.repoRoot, opts.briefPath);
+    if (!existsSync(p)) throw new Error(`brief not found: ${opts.briefPath}`);
+    return p;
+  }
+  if (opts.briefText === undefined) {
+    throw new Error('no brief given; pass the brief as text (copperhead create "…") or --brief <file>');
+  }
+  const asPath = path.resolve(opts.repoRoot, opts.briefText.trim());
+  if (/\.(md|markdown|txt)$/i.test(opts.briefText.trim()) && existsSync(asPath)) return asPath;
+  return materializeBriefText(opts.repoRoot, opts.briefText);
 }
 
 /**
@@ -425,7 +488,7 @@ function shellQuote(s: string): string {
 
 /** The single command that resumes this pipeline, reconstructed from the run's
  *  own options so the operator never has to remember the flags (5.3). */
-function resumeCommand(opts: CreateOptions): string {
+function resumeCommand(opts: ResolvedCreateOptions): string {
   const parts = ['copperhead'];
   const repo = path.resolve(opts.repoRoot);
   if (repo !== process.cwd()) parts.push('--repo', shellQuote(repo));
@@ -442,7 +505,7 @@ function resumeCommand(opts: CreateOptions): string {
  * completion is inferred from repo state, so resuming is just re-running the
  * same command — the earlier completed stages are skipped automatically.
  */
-function logResumePoint(opts: CreateOptions, stage: Stage, index: number): void {
+function logResumePoint(opts: ResolvedCreateOptions, stage: Stage, index: number): void {
   opts.log('');
   opts.log(
     warn(`⏸  stopped at stage ${index + 1}/${STAGES.length} (${stage.name}). To resume from here, run:`),
@@ -639,19 +702,59 @@ async function writeRunReport(opts: CreateOptions, stageCosts: StageCost[]): Pro
   }
 }
 
-export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; completed: string[] }> {
-  const brief = await readFile(path.resolve(opts.briefPath), 'utf8');
-  // Hashed from the content already in hand: a brief edited mid-pipeline shows
-  // up as a different sha256 in the next stage's metadata (AC-8.1).
-  const briefMeta = { path: opts.briefPath, sha256: createHash('sha256').update(brief).digest('hex') };
-  const config = await loadConfig(opts.repoRoot);
+/**
+ * Put the repo into the state the pipeline needs instead of refusing over it.
+ * `create` is typically a new user's first command, run in a fresh directory:
+ * making them run git init + commit by hand after a rejected run is friction
+ * with no upside, since the pipeline's own commits give them the history
+ * anyway. `do` and `sync` keep the strict gitPreflight — those edit a repo the
+ * user already owns, where an implicit initial commit would be a surprise.
+ *
+ * The brief itself is committed too: a stage rollback is `git reset --hard` +
+ * `git clean -fd`, which would otherwise delete the untracked file the printed
+ * resume command points at.
+ */
+async function prepareGit(opts: ResolvedCreateOptions, briefPath: string): Promise<void> {
+  const setup = await ensureGitReady(opts.repoRoot);
+  if (setup.initialized) {
+    opts.log(stageLine('setup', 'initialized a git repository (each stage snapshots HEAD so a failure can roll back)', 'ok'));
+  }
+  if (setup.identityConfigured) {
+    opts.log(
+      stageLine('setup', 'set a repo-local git identity: copperhead <copperhead@localhost> (change it with git config user.name)', 'ok'),
+    );
+  }
+  if (setup.committed) {
+    opts.log(stageLine('setup', 'created the initial commit, the rollback anchor for stage 1', 'ok'));
+    return; // the initial commit already contains the brief
+  }
+  const rel = path.relative(opts.repoRoot, briefPath);
+  if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return; // brief lives outside the repo
+  try {
+    const sha = await commitPaths(opts.repoRoot, [rel], 'chore: add product brief');
+    if (sha) opts.log(stageLine('setup', `committed ${rel} so a stage rollback cannot delete it`, 'ok'));
+  } catch (err) {
+    // e.g. the brief is gitignored. Not worth failing a run over.
+    opts.log(stageLine('setup', `could not commit ${rel} (${(err as Error).message})`, 'warn'));
+  }
+}
+
+export async function runCreate(input: CreateOptions): Promise<{ ok: boolean; completed: string[] }> {
   // Fail fast on a nearly-full disk (4.1): a create run writes fab outputs and
   // KiCad local history and can otherwise fill the disk mid-stage, failing with
   // an opaque ENOSPC only after doing expensive work. Threshold overridable via
   // COPPERHEAD_MIN_FREE_MB; an unknown reading (unsupported platform) skips it.
   const minFreeMb = Number(process.env.COPPERHEAD_MIN_FREE_MB);
   const minFree = Number.isFinite(minFreeMb) && minFreeMb >= 0 ? minFreeMb * 1024 * 1024 : DEFAULT_MIN_FREE_BYTES;
-  await assertDiskSpace(opts.repoRoot, minFree);
+  await assertDiskSpace(input.repoRoot, minFree);
+  const briefPath = await resolveBriefPath(input);
+  const opts: ResolvedCreateOptions = { ...input, briefPath };
+  const brief = await readFile(briefPath, 'utf8');
+  // Hashed from the content already in hand: a brief edited mid-pipeline shows
+  // up as a different sha256 in the next stage's metadata (AC-8.1).
+  const briefMeta = { path: briefPath, sha256: createHash('sha256').update(brief).digest('hex') };
+  await prepareGit(opts, briefPath);
+  const config = await loadConfig(opts.repoRoot);
   // Reclaim scratch dirs leaked by earlier runs whose cleanup was skipped (a
   // watchdog SIGKILL or hard abort bypasses the per-call `finally`). Age-gated,
   // so a concurrent run's fresh dirs are never touched; best-effort, so it never

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -16,7 +16,13 @@ import { loadConfig } from '../config.js';
 import { branchName, headCommit, isDirty, isGitRepo, uncommittedCount } from '../util/git.js';
 import { shortPath } from '../util/paths.js';
 import { redactSecrets } from '../util/redact.js';
-import { pickModel, type SelectItem } from '../util/select.js';
+import { pickModel, selectMenu, type SelectItem } from '../util/select.js';
+import {
+  DIRTY_CHOICES,
+  describeDirtyFiles,
+  resolveDirtyTree,
+  type DirtyChoice,
+} from '../util/dirty.js';
 import { KeyReader, PASTE_OFF, PASTE_ON, promptWithSlashHints } from '../util/live-prompt.js';
 import { TerminalDock } from '../util/dock.js';
 import { DockRenderer } from '../agent/dock-renderer.js';
@@ -68,6 +74,7 @@ export interface ReplOptions {
     request: string,
     log?: (line: string) => void,
     renderer?: ProgressRenderer,
+    overrides?: { allowDirty?: boolean },
   ) => Promise<Pick<RunResult, 'outcome'>>;
   /** Injected /check (tests). */
   runCheckCmd?: (log?: (line: string) => void) => Promise<void>;
@@ -281,13 +288,18 @@ async function statusText(opts: ReplOptions): Promise<string> {
 }
 
 function defaultRunner(opts: ReplOptions, log: (l: string) => void) {
-  return (request: string) =>
+  return (
+    request: string,
+    _log?: (line: string) => void,
+    _renderer?: ProgressRenderer,
+    overrides?: { allowDirty?: boolean },
+  ) =>
     runAgentLoop({
       repoRoot: opts.repoRoot,
       request,
       model: opts.model,
       ...(opts.maxTurns !== undefined ? { maxTurns: opts.maxTurns } : {}),
-      allowDirty: opts.allowDirty ?? false,
+      allowDirty: overrides?.allowDirty ?? opts.allowDirty ?? false,
       interactive: opts.interactive ?? false,
       confirm: opts.confirm,
       ...(opts.onBudgetExhausted ? { onBudgetExhausted: opts.onBudgetExhausted } : {}),
@@ -398,9 +410,13 @@ export async function runRepl(opts: ReplOptions): Promise<{ ok: boolean; turns: 
   for (const line of banner(opts)) log(line);
 
   let turns = 0;
-  const handleRequest = async (request: string): Promise<void> => {
+  const handleRequest = async (request: string, overrides?: { allowDirty?: boolean }): Promise<void> => {
     try {
-      const res = await runOne(request, log, opts.renderer);
+      // Only widen the call when there is something to override: the runner
+      // contract (and the tests that pin it) is the three-argument form.
+      const res = overrides
+        ? await runOne(request, log, opts.renderer, overrides)
+        : await runOne(request, log, opts.renderer);
       turns++;
       if (res.outcome === 'failure') {
         log(dim('(session continues — fix the issue or try another request)'));
@@ -428,6 +444,32 @@ export async function runRepl(opts: ReplOptions): Promise<{ ok: boolean; turns: 
       yield k;
     }
   }
+
+  /**
+   * Offer the way through the dirty-tree gate before a turn starts, while the
+   * session key reader is still live (it is paused for the duration of a turn,
+   * so a menu raised from inside the run would never see a keypress). Returns
+   * the per-turn override for that run.
+   */
+  const resolveDirtyBeforeTurn = async (): Promise<{ allowDirty?: boolean } | undefined> => {
+    if (opts.allowDirty) return undefined;
+    const { allowDirty } = await resolveDirtyTree(
+      opts.repoRoot,
+      async ({ files }) => {
+        log(warn(`  working tree has ${files.length} uncommitted file(s); a rollback would hard-reset over them:`));
+        for (const line of describeDirtyFiles(files)) log(line);
+        const choice = await selectMenu({
+          title: 'How should copperhead handle them?',
+          items: DIRTY_CHOICES,
+          output: output as NodeJS.WriteStream,
+          keys: sessionKeys(),
+        });
+        return (choice as DirtyChoice | null) ?? 'cancel';
+      },
+      log,
+    );
+    return allowDirty ? { allowDirty } : undefined;
+  };
 
   const runSlash = async (cmd: string): Promise<'quit' | 'continue'> => {
     if (QUIT.has(cmd)) return 'quit';
@@ -655,11 +697,12 @@ export async function runRepl(opts: ReplOptions): Promise<{ ok: boolean; turns: 
         continue;
       }
 
+      const dirtyOverride = await resolveDirtyBeforeTurn();
       // Pause raw-mode so Ctrl+C is a real SIGINT during the agent turn.
       log('');
       keys.pause();
       try {
-        await handleRequest(line);
+        await handleRequest(line, dirtyOverride);
       } finally {
         keys.resume();
       }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -9,6 +9,7 @@ import { openspecValidate } from '../openspec/cli.js';
 import { runAgentLoop } from '../agent/loop.js';
 import type { RunMetaInput } from '../agent/runmeta.js';
 import type { ProgressRenderer } from '../agent/render.js';
+import type { DirtyChooser } from '../util/dirty.js';
 
 /**
  * `copperhead sync` (design D14): deterministic verify phase, then an optional
@@ -171,7 +172,7 @@ export async function syncResolve(
   report: SyncReport,
   model: string,
   log: (s: string) => void,
-  extras?: { renderer?: ProgressRenderer; meta?: RunMetaInput },
+  extras?: { renderer?: ProgressRenderer; meta?: RunMetaInput; onDirtyTree?: DirtyChooser },
 ): Promise<{ ok: boolean }> {
   const reportText = formatSyncReport(report);
   const res = await runAgentLoop({
@@ -181,6 +182,7 @@ export async function syncResolve(
     stagePrompt: `You are resolving drift found by the deterministic sync verifier. The inconsistency report is below. Truth precedence: the KiCad files are ground truth for as-built facts (fix the docs to match); openspec specs and SPEC.md budgets are ground truth for requirements. Do NOT touch anything listed as a requirement violation; those are for the human. Apply each proposed resolution, verify, and finish.\n\n${reportText}`,
     log,
     ...(extras?.renderer ? { renderer: extras.renderer } : {}),
+    ...(extras?.onDirtyTree ? { onDirtyTree: extras.onDirtyTree } : {}),
     ...(extras?.meta ? { meta: extras.meta } : {}),
   });
   return { ok: res.outcome === 'success' };

--- a/src/util/dirty.ts
+++ b/src/util/dirty.ts
@@ -1,0 +1,81 @@
+import { commitAll, dirtyFiles, hasCommits, isDirty, isGitRepo, stashDirty } from './git.js';
+import { dim, ok } from '../agent/theme.js';
+import type { SelectItem } from './select.js';
+
+/**
+ * The dirty-tree gate (AC-3.8) exists because a rollback hard-resets to the
+ * pre-run snapshot, which would destroy uncommitted work. That reasoning is
+ * sound; refusing outright is not the only way to honor it. Attended runs get
+ * offered the three fixes the refusal message already spells out, and the run
+ * continues with whichever one the user picks. Unattended runs (CI, pipes)
+ * have nobody to ask, so they keep refusing exactly as before.
+ */
+export type DirtyChoice = 'commit' | 'stash' | 'allow-dirty' | 'cancel';
+
+export interface DirtyTreeState {
+  /** Uncommitted paths: staged, unstaged, and untracked. */
+  files: string[];
+}
+
+/** Asked when the tree is dirty and the run has not opted into --allow-dirty. */
+export type DirtyChooser = (state: DirtyTreeState) => Promise<DirtyChoice>;
+
+/** The menu offered to an attended run, in recommended order. */
+export const DIRTY_CHOICES: SelectItem[] = [
+  { value: 'commit', label: 'commit', description: 'keep your changes as a commit (recommended)' },
+  { value: 'stash', label: 'stash', description: 'set them aside; git stash pop restores them' },
+  { value: 'allow-dirty', label: 'run anyway', description: 'kept through a rollback via git stash create' },
+  { value: 'cancel', label: 'cancel', description: 'change nothing and stop' },
+];
+
+/** How many dirty paths to name before summarizing the rest. */
+const LIST_CAP = 10;
+
+/** The uncommitted paths, for a prompt that tells the user what is at stake. */
+export function describeDirtyFiles(files: string[]): string[] {
+  const shown = files.slice(0, LIST_CAP).map((f) => dim(`  ${f}`));
+  if (files.length > LIST_CAP) shown.push(dim(`  …and ${files.length - LIST_CAP} more`));
+  return shown;
+}
+
+/**
+ * Offer the user a way through the dirty-tree gate and apply their choice.
+ * Returns whether the run should proceed with `allowDirty` set; a clean tree,
+ * a repo that fails an earlier gate, or a cancelled prompt all return false and
+ * leave the caller's normal preflight to do its usual job (which, for cancel,
+ * means the familiar refusal with its three fixes).
+ */
+export async function resolveDirtyTree(
+  repo: string,
+  choose: DirtyChooser,
+  log: (line: string) => void,
+): Promise<{ allowDirty: boolean }> {
+  // Earlier gates (not a repo, unborn HEAD) are not ours to answer here: let
+  // the preflight report those, so each failure keeps exactly one explanation.
+  if (!(await isGitRepo(repo)) || !(await hasCommits(repo))) return { allowDirty: false };
+  if (!(await isDirty(repo))) return { allowDirty: false };
+
+  const files = await dirtyFiles(repo);
+  const choice = await choose({ files }).catch(() => 'cancel' as DirtyChoice);
+  switch (choice) {
+    case 'commit': {
+      const sha = await commitAll(repo, 'chore: save work in progress before a copperhead run');
+      log(ok(`  committed ${files.length} file(s) as ${sha.slice(0, 7)}; a rollback now returns here`));
+      return { allowDirty: false };
+    }
+    case 'stash': {
+      const clean = await stashDirty(repo, 'copperhead: set aside before a run');
+      log(ok(`  stashed ${files.length} file(s); restore them with git stash pop`));
+      // A stash that left something behind (an ignored-but-tracked oddity, an
+      // unreadable path) falls through to the normal refusal rather than
+      // becoming a run that could roll over the leftovers.
+      if (!clean) log(dim('  some paths could not be stashed; the tree is still dirty'));
+      return { allowDirty: false };
+    }
+    case 'allow-dirty':
+      log(dim('  running on the dirty tree; the snapshot keeps your changes and a rollback restores them'));
+      return { allowDirty: true };
+    default:
+      return { allowDirty: false };
+  }
+}

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -6,17 +6,45 @@ import path from 'node:path';
 import { PreflightError } from './preflight.js';
 
 /**
- * Paths copperhead must keep out of `git add -A`. KiCad ≥9 writes a
- * git-backed local-history directory (`.history/`, complete with its own nested
- * `.git`) into the project the first time kicad-cli touches it. Left untracked,
- * that nested repo has an unborn HEAD, so a plain `git add -A` in the parent
- * aborts with `error: '.history/' does not have a commit checked out` (exit
- * 128) — which fails the commit at the end of every KiCad-touching stage
- * (schematic, layout, outputs). Ignoring it is both correct (local history is
- * never a project artifact) and the fix for that abort. Kept as a list so other
- * KiCad transients can join it if they surface.
+ * Paths copperhead must keep out of `git add -A`. Two kinds live here:
+ *
+ * KiCad ≥9 writes a git-backed local-history directory (`.history/`, complete
+ * with its own nested `.git`) into the project the first time kicad-cli touches
+ * it. Left untracked, that nested repo has an unborn HEAD, so a plain `git add
+ * -A` in the parent aborts with `error: '.history/' does not have a commit
+ * checked out` (exit 128) — which fails the commit at the end of every
+ * KiCad-touching stage (schematic, layout, outputs). Ignoring it is both
+ * correct (local history is never a project artifact) and the fix for that
+ * abort.
+ *
+ * `.copperhead/runs/` is the run audit trail, which AC-4.3 requires every
+ * copperhead repo to ignore. Topping it up here means a repo the user created
+ * by hand (`git init && git commit`, no copperhead .gitignore) gets the entry
+ * on the first commit copperhead makes, instead of having its transcripts
+ * swept into project history.
  */
-const GIT_ADD_EXCLUDES = ['.history/'];
+const GIT_ADD_EXCLUDES = ['.copperhead/runs/', '.history/'];
+
+/**
+ * Paths copperhead writes itself, which the dirty-tree gate must never count as
+ * the user's uncommitted work.
+ *
+ * The gate exists because a rollback hard-resets over uncommitted changes — but
+ * the run audit trail is not the user's work, and restore() deliberately copies
+ * it across a rollback rather than destroying it. Counting it made copperhead
+ * refuse to run over a file copperhead had just written: the REPL opens its
+ * session log under `.copperhead/runs/` before the first turn, so in a repo
+ * whose .gitignore does not yet list it (anyone who ran `git init` themselves)
+ * the very first request hit the dirty gate with `.copperhead/` as the only
+ * dirty path. Filtered by path rather than by .gitignore state, so the gate
+ * behaves the same before and after the ignore entry lands.
+ */
+const OWN_ARTIFACTS = ['.copperhead/runs/'];
+
+/** Whether a `git status` path is copperhead's own bookkeeping, not user work. */
+function isOwnArtifact(p: string): boolean {
+  return OWN_ARTIFACTS.some((prefix) => p === prefix || p.startsWith(prefix));
+}
 
 /**
  * Ensure the repo's root .gitignore lists each entry, appending only the
@@ -53,6 +81,12 @@ export interface GitSnapshot {
 async function git(repo: string, args: string[]): Promise<string> {
   const { stdout } = await execa('git', args, { cwd: repo });
   return stdout.trim();
+}
+
+/** Same as git(), without the trim: for output whose leading whitespace matters. */
+async function gitRaw(repo: string, args: string[]): Promise<string> {
+  const { stdout } = await execa('git', args, { cwd: repo });
+  return stdout;
 }
 
 /** Same as git(), with a scratch index so the repo's real index is untouched. */
@@ -190,8 +224,44 @@ export async function hasCommits(repo: string): Promise<boolean> {
 }
 
 export async function isDirty(repo: string): Promise<boolean> {
-  const status = await git(repo, ['status', '--porcelain']);
-  return status.length > 0;
+  return (await dirtyFiles(repo)).length > 0;
+}
+
+/**
+ * The user's uncommitted paths: staged, unstaged, and untracked, minus
+ * copperhead's own artifacts (see OWN_ARTIFACTS). The single source of truth
+ * for "is this tree dirty" — isDirty() is this list being non-empty, so the
+ * gate and the file list it prints can never disagree.
+ *
+ * `-uall` lists untracked files individually instead of collapsing them into
+ * the containing directory: `git status` reports a wholly-untracked
+ * `.copperhead/` as one entry, which no per-file filter can see inside.
+ */
+export async function dirtyFiles(repo: string): Promise<string[]> {
+  // Trailing-only trim, not git()'s .trim(): porcelain encodes the index and
+  // worktree states in two leading columns, and an unstaged modification is
+  // " M path" — a leading space. Trimming the whole payload ate that column on
+  // the first line, so the prompt offered to commit "EADME.md" and any path
+  // matched against it (the OWN_ARTIFACTS filter below) was off by a character.
+  const status = (await gitRaw(repo, ['status', '--porcelain', '-uall'])).replace(/\n+$/, '');
+  if (!status) return [];
+  return status
+    .split('\n')
+    .map((line) => line.slice(3).trim())
+    // Renames report "old -> new"; the new path is the one that exists.
+    .map((p) => (p.includes(' -> ') ? p.split(' -> ')[1]!.trim() : p))
+    .filter(Boolean)
+    .filter((p) => !isOwnArtifact(p));
+}
+
+/**
+ * Set the working tree aside as a stash entry, untracked files included, so
+ * the tree is clean enough to run on and the work is one `git stash pop` away.
+ */
+export async function stashDirty(repo: string, message: string): Promise<boolean> {
+  await ensureIgnored(repo, GIT_ADD_EXCLUDES);
+  await git(repo, ['stash', 'push', '-u', '-m', message]);
+  return !(await isDirty(repo));
 }
 
 /**
@@ -225,6 +295,88 @@ export async function gitPreflight(repo: string, opts: { allowDirty?: boolean } 
       ],
     );
   }
+}
+
+/**
+ * What every copperhead repo must ignore from its first commit: secrets
+ * (AC-4.3), the run audit trail, and KiCad's local-history directory.
+ */
+const BASELINE_IGNORES = [...new Set(['.env', ...GIT_ADD_EXCLUDES])];
+
+export interface GitBootstrap {
+  /** `git init` ran here. */
+  initialized: boolean;
+  /** A local user.name/user.email fallback was written (none was configured). */
+  identityConfigured: boolean;
+  /** An initial commit was created (the repo had an unborn HEAD). */
+  committed: boolean;
+}
+
+/** Read a git config value, or null when unset. */
+async function configValue(repo: string, key: string): Promise<string | null> {
+  const res = await execa('git', ['config', '--get', key], { cwd: repo, reject: false });
+  const value = res.exitCode === 0 ? res.stdout.trim() : '';
+  return value.length ? value : null;
+}
+
+/**
+ * Make a directory satisfy the git gates instead of refusing over them: init
+ * the repo if there is none, write the baseline .gitignore, and create the
+ * initial commit that snapshots/rollback need. Used by the pipeline commands,
+ * where "you must set up git first" is pure friction for a new user — `do` and
+ * `sync` keep the stricter gitPreflight, since those edit a repo the user
+ * already owns and an implicit commit there would be a surprise.
+ *
+ * Never touches a repo that already has commits: on that path the only work is
+ * the idempotent .gitignore top-up.
+ */
+export async function ensureGitReady(repo: string): Promise<GitBootstrap> {
+  const result: GitBootstrap = { initialized: false, identityConfigured: false, committed: false };
+
+  if (!(await isGitRepo(repo))) {
+    await mkdir(repo, { recursive: true });
+    // -b needs git >= 2.28; fall back so an older git still works.
+    const named = await execa('git', ['init', '-q', '-b', 'main'], { cwd: repo, reject: false });
+    if (named.exitCode !== 0) await git(repo, ['init', '-q']);
+    result.initialized = true;
+  }
+
+  await ensureIgnored(repo, BASELINE_IGNORES);
+
+  if (await hasCommits(repo)) return result;
+
+  // `git commit` hard-fails without an identity, which on a fresh machine is
+  // exactly the state a first-time user is in. A repo-local fallback keeps the
+  // run moving without touching their global config.
+  if (!(await configValue(repo, 'user.name'))) {
+    await git(repo, ['config', 'user.name', 'copperhead']);
+    result.identityConfigured = true;
+  }
+  if (!(await configValue(repo, 'user.email'))) {
+    await git(repo, ['config', 'user.email', 'copperhead@localhost']);
+    result.identityConfigured = true;
+  }
+
+  await git(repo, ['add', '-A']);
+  // --allow-empty: an empty directory has nothing to stage, and the point of
+  // the commit is the rollback anchor, not its contents.
+  await git(repo, ['commit', '-q', '--allow-empty', '-m', 'chore: initialize repository for copperhead']);
+  result.committed = true;
+  return result;
+}
+
+/**
+ * Commit exactly these paths, leaving anything else in the tree (and anything
+ * already staged) alone: `git commit -- <path>` commits from the working tree
+ * for those paths only. No-op when they hold nothing new.
+ */
+export async function commitPaths(repo: string, paths: string[], message: string): Promise<string | null> {
+  if (!paths.length) return null;
+  await git(repo, ['add', '--', ...paths]);
+  const staged = await execa('git', ['diff', '--cached', '--quiet', '--', ...paths], { cwd: repo, reject: false });
+  if (staged.exitCode === 0) return null; // nothing to commit for these paths
+  await git(repo, ['commit', '-q', '-m', message, '--', ...paths]);
+  return git(repo, ['rev-parse', 'HEAD']);
 }
 
 /**
@@ -345,10 +497,9 @@ export async function headCommit(repo: string): Promise<string> {
   return git(repo, ['rev-parse', 'HEAD']);
 }
 
-/** Count of uncommitted paths (staged, unstaged, and untracked). */
+/** Count of the user's uncommitted paths, matching what the dirty gate counts. */
 export async function uncommittedCount(repo: string): Promise<number> {
-  const status = await git(repo, ['status', '--porcelain']);
-  return status ? status.split('\n').length : 0;
+  return (await dirtyFiles(repo)).length;
 }
 
 export async function commitAll(repo: string, message: string): Promise<string> {

--- a/test/create-setup.test.ts
+++ b/test/create-setup.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { execa } from 'execa';
+import type { RunOptions, RunResult } from '../src/agent/loop.js';
+import { tempFixtureRepo } from './helpers.js';
+
+// Onboarding path: `copperhead create` in a directory a new user just made.
+// The pipeline itself is mocked out — what these cover is everything that has
+// to be true BEFORE stage 1 can run: a git repo with a commit to snapshot, and
+// a brief file on disk whether the user passed text or a path.
+const mockRunAgentLoop = vi.hoisted(() => vi.fn<(opts: RunOptions) => Promise<RunResult>>());
+
+vi.mock('../src/agent/loop.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  runAgentLoop: mockRunAgentLoop,
+}));
+vi.mock('../src/agent/recovery.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  diagnoseStageFailure: async () => ({ verdict: 'abort', reason: 'stop' }),
+  transcriptExcerpt: async () => '',
+}));
+vi.mock('../src/openspec/cli.js', () => ({ openspecInit: async () => ({ ok: true, output: '' }) }));
+vi.mock('../src/commands/check.js', () => ({ runCheck: async () => ({ ok: true }) }));
+
+import { runCreate } from '../src/commands/create.js';
+import { ensureGitReady } from '../src/util/git.js';
+
+/** Stage 1 runs but produces nothing, so the pipeline stops after it. Setup
+ *  work all happens before that, which is what these tests read. */
+function emptyRun(): RunResult {
+  return {
+    outcome: 'success',
+    exitPath: 'done',
+    summary: 'mock',
+    transcriptDir: '',
+    filesTouched: [],
+    commit: null,
+    stats: {
+      exitPath: 'done',
+      turnsUsed: 1,
+      maxTurns: 40,
+      repairCyclesUsed: 0,
+      maxRepairCycles: 5,
+      tokensIn: 10,
+      tokensOut: 5,
+      perTurn: [],
+      durationMs: 1,
+    },
+    cacheHits: 0,
+  };
+}
+
+let prevKey: string | undefined;
+beforeEach(() => {
+  mockRunAgentLoop.mockReset();
+  mockRunAgentLoop.mockImplementation(async () => emptyRun());
+  // diagnose() constructs a provider before the mocked diagnosis runs.
+  prevKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = 'sk-test-dummy';
+});
+afterEach(() => {
+  if (prevKey === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = prevKey;
+});
+
+async function bareDir(): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ch-setup-'));
+  return { dir, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+const git = async (repo: string, args: string[]): Promise<string> =>
+  (await execa('git', args, { cwd: repo })).stdout.trim();
+
+describe('create sets git up instead of refusing (onboarding)', () => {
+  it('a non-git directory is initialized, ignored, and committed before stage 1', async () => {
+    const { dir, cleanup } = await bareDir();
+    try {
+      await writeFile(path.join(dir, 'brief.md'), 'A tiny USB macro keypad\n', 'utf8');
+      const lines: string[] = [];
+      const res = await runCreate({
+        repoRoot: dir,
+        briefPath: path.join(dir, 'brief.md'),
+        model: 'gpt-5',
+        log: (s) => lines.push(s),
+      });
+
+      // The run stops on the unmet stage contract, not on a git preflight.
+      expect(res.ok).toBe(false);
+      expect(mockRunAgentLoop).toHaveBeenCalled();
+      expect(existsSync(path.join(dir, '.git'))).toBe(true);
+      expect(await git(dir, ['rev-parse', '--verify', 'HEAD'])).toMatch(/^[0-9a-f]{40}$/);
+      // The brief is committed, so a stage rollback (reset --hard + clean -fd)
+      // cannot delete the file the resume command points at.
+      expect(await git(dir, ['ls-files'])).toContain('brief.md');
+      const ignored = await readFile(path.join(dir, '.gitignore'), 'utf8');
+      expect(ignored).toContain('.env');
+      expect(ignored).toContain('.copperhead/runs/');
+      expect(lines.join('\n')).toMatch(/initialized a git repository/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('an existing repo with an unborn HEAD gets the initial commit, not a refusal', async () => {
+    const { dir, cleanup } = await bareDir();
+    try {
+      await execa('git', ['init', '-q'], { cwd: dir });
+      await writeFile(path.join(dir, 'brief.md'), 'A tiny USB macro keypad\n', 'utf8');
+      const res = await runCreate({ repoRoot: dir, briefPath: path.join(dir, 'brief.md'), model: 'gpt-5', log: () => {} });
+      expect(res.ok).toBe(false);
+      expect(await git(dir, ['ls-files'])).toContain('brief.md');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a repo that already has commits keeps its history: only the brief is committed', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const before = await git(repo, ['rev-parse', 'HEAD']);
+      await writeFile(path.join(repo, 'untouched.txt'), 'user WIP\n', 'utf8');
+      await runCreate({ repoRoot: repo, briefText: 'A tiny USB macro keypad', model: 'gpt-5', log: () => {} });
+      const after = await git(repo, ['rev-parse', 'HEAD']);
+      expect(after).not.toBe(before);
+      expect(await git(repo, ['ls-files'])).toContain('brief.md');
+      // The user's unrelated working file was not swept into the brief commit.
+      expect(await git(repo, ['ls-files'])).not.toContain('untouched.txt');
+      expect(existsSync(path.join(repo, 'untouched.txt'))).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('ensureGitReady is idempotent and never rewrites history on a healthy repo', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const head = await git(repo, ['rev-parse', 'HEAD']);
+      const first = await ensureGitReady(repo);
+      const second = await ensureGitReady(repo);
+      expect(first).toEqual({ initialized: false, identityConfigured: false, committed: false });
+      expect(second).toEqual(first);
+      expect(await git(repo, ['rev-parse', 'HEAD'])).toBe(head);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('an empty directory still gets a commit to snapshot against', async () => {
+    const { dir, cleanup } = await bareDir();
+    try {
+      const setup = await ensureGitReady(dir);
+      expect(setup.initialized).toBe(true);
+      expect(setup.committed).toBe(true);
+      expect(await git(dir, ['rev-parse', '--verify', 'HEAD'])).toMatch(/^[0-9a-f]{40}$/);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+describe('create accepts the brief as text', () => {
+  it('writes the text to brief.md and runs the pipeline against it', async () => {
+    const { dir, cleanup } = await bareDir();
+    try {
+      await runCreate({ repoRoot: dir, briefText: 'A tiny USB macro keypad, 4 keys, USB-C', model: 'gpt-5', log: () => {} });
+      const written = await readFile(path.join(dir, 'brief.md'), 'utf8');
+      expect(written).toBe('A tiny USB macro keypad, 4 keys, USB-C\n');
+      // The stage prompt carries the brief the user typed.
+      expect(mockRunAgentLoop.mock.calls[0]![0].stagePrompt).toContain('A tiny USB macro keypad, 4 keys, USB-C');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('re-running the same text reuses the brief instead of littering numbered copies', async () => {
+    const { dir, cleanup } = await bareDir();
+    try {
+      const opts = { repoRoot: dir, briefText: 'A tiny USB macro keypad', model: 'gpt-5', log: () => {} };
+      await runCreate(opts);
+      await runCreate(opts);
+      expect(existsSync(path.join(dir, 'brief.md'))).toBe(true);
+      expect(existsSync(path.join(dir, 'brief-2.md'))).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('never overwrites a different existing brief', async () => {
+    const { dir, cleanup } = await bareDir();
+    try {
+      await writeFile(path.join(dir, 'brief.md'), 'an older brief\n', 'utf8');
+      await runCreate({ repoRoot: dir, briefText: 'a different device', model: 'gpt-5', log: () => {} });
+      expect(await readFile(path.join(dir, 'brief.md'), 'utf8')).toBe('an older brief\n');
+      expect(await readFile(path.join(dir, 'brief-2.md'), 'utf8')).toBe('a different device\n');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a positional argument naming an existing file is used as that file', async () => {
+    const { dir, cleanup } = await bareDir();
+    try {
+      await writeFile(path.join(dir, 'keypad.md'), 'brief from a file\n', 'utf8');
+      await runCreate({ repoRoot: dir, briefText: 'keypad.md', model: 'gpt-5', log: () => {} });
+      expect(existsSync(path.join(dir, 'brief.md'))).toBe(false);
+      expect(mockRunAgentLoop.mock.calls[0]![0].stagePrompt).toContain('brief from a file');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('empty text is refused with a usage hint, not an empty brief file', async () => {
+    const { dir, cleanup } = await bareDir();
+    try {
+      await expect(runCreate({ repoRoot: dir, briefText: '   ', model: 'gpt-5', log: () => {} })).rejects.toThrow(
+        /brief is empty/,
+      );
+      expect(existsSync(path.join(dir, 'brief.md'))).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a missing --brief file is named in the error', async () => {
+    const { dir, cleanup } = await bareDir();
+    try {
+      await expect(
+        runCreate({ repoRoot: dir, briefPath: 'nope.md', model: 'gpt-5', log: () => {} }),
+      ).rejects.toThrow(/brief not found: nope\.md/);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/test/dirty-tree.test.ts
+++ b/test/dirty-tree.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi } from 'vitest';
+import path from 'node:path';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { execa } from 'execa';
+import { runAgentLoop } from '../src/agent/loop.js';
+import type { Msg, Provider, Turn } from '../src/agent/types.js';
+import { resolveDirtyTree, describeDirtyFiles, type DirtyChoice } from '../src/util/dirty.js';
+import { dirtyFiles, isDirty } from '../src/util/git.js';
+import { setColorEnabled } from '../src/agent/theme.js';
+import { tempFixtureRepo } from './helpers.js';
+
+/**
+ * The dirty-tree gate (AC-3.8) protects uncommitted work from a rollback's
+ * hard reset. Attended runs now get offered the fixes the refusal message
+ * describes instead of being sent away to run git by hand; unattended runs
+ * (no chooser) keep refusing exactly as before.
+ */
+
+setColorEnabled(false);
+
+const git = async (repo: string, args: string[]): Promise<string> =>
+  (await execa('git', args, { cwd: repo })).stdout.trim();
+
+/** A fixture repo with one uncommitted file. */
+async function dirtyRepo(): Promise<{ repo: string; cleanup: () => Promise<void> }> {
+  const { repo, cleanup } = await tempFixtureRepo();
+  await writeFile(path.join(repo, 'wip.txt'), 'work in progress\n', 'utf8');
+  return { repo, cleanup };
+}
+
+const chooser = (choice: DirtyChoice) => vi.fn(async () => choice);
+
+describe('resolveDirtyTree', () => {
+  it('commit: the work becomes a commit and the tree is clean to run on', async () => {
+    const { repo, cleanup } = await dirtyRepo();
+    try {
+      const before = await git(repo, ['rev-parse', 'HEAD']);
+      const res = await resolveDirtyTree(repo, chooser('commit'), () => {});
+      expect(res.allowDirty).toBe(false);
+      expect(await isDirty(repo)).toBe(false);
+      expect(await git(repo, ['rev-parse', 'HEAD'])).not.toBe(before);
+      expect(await git(repo, ['ls-files'])).toContain('wip.txt');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('stash: the tree is clean and the work is one git stash pop away', async () => {
+    const { repo, cleanup } = await dirtyRepo();
+    try {
+      const res = await resolveDirtyTree(repo, chooser('stash'), () => {});
+      expect(res.allowDirty).toBe(false);
+      expect(await isDirty(repo)).toBe(false);
+      expect(existsSync(path.join(repo, 'wip.txt'))).toBe(false);
+      expect(await git(repo, ['stash', 'list'])).toContain('copperhead');
+      await git(repo, ['stash', 'pop']);
+      expect(existsSync(path.join(repo, 'wip.txt'))).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('run anyway: nothing is committed or stashed; the run opts into --allow-dirty', async () => {
+    const { repo, cleanup } = await dirtyRepo();
+    try {
+      const head = await git(repo, ['rev-parse', 'HEAD']);
+      const res = await resolveDirtyTree(repo, chooser('allow-dirty'), () => {});
+      expect(res.allowDirty).toBe(true);
+      expect(await isDirty(repo)).toBe(true);
+      expect(await git(repo, ['rev-parse', 'HEAD'])).toBe(head);
+      expect(await git(repo, ['stash', 'list'])).toBe('');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('cancel: the tree is left exactly as it was, for the caller to refuse over', async () => {
+    const { repo, cleanup } = await dirtyRepo();
+    try {
+      const head = await git(repo, ['rev-parse', 'HEAD']);
+      const res = await resolveDirtyTree(repo, chooser('cancel'), () => {});
+      expect(res.allowDirty).toBe(false);
+      expect(await isDirty(repo)).toBe(true);
+      expect(await git(repo, ['rev-parse', 'HEAD'])).toBe(head);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a thrown or abandoned prompt reads as cancel, never as consent', async () => {
+    const { repo, cleanup } = await dirtyRepo();
+    try {
+      const res = await resolveDirtyTree(
+        repo,
+        async () => {
+          throw new Error('terminal closed');
+        },
+        () => {},
+      );
+      expect(res.allowDirty).toBe(false);
+      expect(await isDirty(repo)).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a clean tree never asks', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const ask = chooser('commit');
+      const res = await resolveDirtyTree(repo, ask, () => {});
+      expect(ask).not.toHaveBeenCalled();
+      expect(res.allowDirty).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('the earlier gates stay the preflight\'s to explain: no prompt without a repo or a commit', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'ch-dirty-'));
+    try {
+      const ask = chooser('commit');
+      expect((await resolveDirtyTree(dir, ask, () => {})).allowDirty).toBe(false);
+      expect(ask).not.toHaveBeenCalled();
+
+      await execa('git', ['init', '-q'], { cwd: dir });
+      await writeFile(path.join(dir, 'a.txt'), 'x\n', 'utf8');
+      expect((await resolveDirtyTree(dir, ask, () => {})).allowDirty).toBe(false);
+      expect(ask).not.toHaveBeenCalled();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('names paths in full, whatever their porcelain status column', async () => {
+    // Regression: git() trims the whole `git status --porcelain` payload, and
+    // an unstaged modification is " M path" — a leading space. Trimming ate
+    // that column on the first line only, so the very first file the prompt
+    // offered to commit was reported one character short ("EADME.md").
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await writeFile(path.join(repo, 'README.md'), 'seed\n', 'utf8');
+      await git(repo, ['add', '-A']);
+      await git(repo, ['commit', '-q', '-m', 'seed readme']);
+
+      await writeFile(path.join(repo, 'README.md'), 'seed\nmore\n', 'utf8'); // " M" — unstaged, sorts first
+      await writeFile(path.join(repo, 'wip.txt'), 'work\n', 'utf8'); // "??"
+      expect(await dirtyFiles(repo)).toEqual(['README.md', 'wip.txt']);
+
+      // A staged rename still resolves to the path that exists on disk.
+      await git(repo, ['add', '-A']);
+      await git(repo, ['commit', '-q', '-m', 'more']);
+      await git(repo, ['mv', 'README.md', 'DOCS.md']);
+      expect(await dirtyFiles(repo)).toEqual(['DOCS.md']);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('names the dirty files, summarizing past a cap', () => {
+    const many = Array.from({ length: 14 }, (_, i) => `docs/file-${i}.md`);
+    const lines = describeDirtyFiles(many);
+    expect(lines).toHaveLength(11);
+    expect(lines.at(-1)).toContain('4 more');
+    expect(describeDirtyFiles(['a.txt'])).toEqual(['  a.txt']);
+  });
+});
+
+describe('the gate inside a run', () => {
+  /** Never actually reached in these tests: the run stops at the gate. */
+  const idleProvider = (): Provider => ({
+    name: 'scripted',
+    async chat(_messages: Msg[]): Promise<Turn> {
+      return { text: 'done', toolCalls: [], usage: { inputTokens: 1, outputTokens: 1 } };
+    },
+  });
+
+  it('no chooser (CI, pipes): refuses with the message and its three fixes', async () => {
+    const { repo, cleanup } = await dirtyRepo();
+    try {
+      await expect(
+        runAgentLoop({ repoRoot: repo, request: 'noop', model: 'gpt-5', provider: idleProvider(), log: () => {} }),
+      ).rejects.toThrow(/working tree is dirty/);
+      expect(await isDirty(repo)).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('cancelling the prompt lands on that same refusal', async () => {
+    const { repo, cleanup } = await dirtyRepo();
+    try {
+      await expect(
+        runAgentLoop({
+          repoRoot: repo,
+          request: 'noop',
+          model: 'gpt-5',
+          provider: idleProvider(),
+          onDirtyTree: chooser('cancel'),
+          log: () => {},
+        }),
+      ).rejects.toThrow(/working tree is dirty/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('committing at the prompt lets the run start, with the work safe in history', async () => {
+    const { repo, cleanup } = await dirtyRepo();
+    try {
+      // The run itself goes nowhere (the provider never calls a tool, so it
+      // ends on the empty-completion path); what matters is that it got past
+      // the gate instead of throwing, and that the rollback it then performs
+      // restores to a HEAD that contains the user's work.
+      const res = await runAgentLoop({
+        repoRoot: repo,
+        request: 'noop',
+        model: 'gpt-5',
+        provider: idleProvider(),
+        onDirtyTree: chooser('commit'),
+        log: () => {},
+      });
+      expect(res.transcriptDir).toBeTruthy();
+      expect(await git(repo, ['ls-files'])).toContain('wip.txt');
+      expect(await git(repo, ['show', '--name-only', '--format=%s', 'HEAD'])).toContain('work in progress');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('an explicit --allow-dirty never raises the prompt', async () => {
+    const { repo, cleanup } = await dirtyRepo();
+    try {
+      const ask = chooser('commit');
+      await runAgentLoop({
+        repoRoot: repo,
+        request: 'noop',
+        model: 'gpt-5',
+        provider: idleProvider(),
+        allowDirty: true,
+        onDirtyTree: ask,
+        log: () => {},
+      });
+      expect(ask).not.toHaveBeenCalled();
+      expect(await isDirty(repo)).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { execa } from 'execa';
 import { runAgentLoop } from '../src/agent/loop.js';
-import { runCreate } from '../src/commands/create.js';
-import { gitPreflight } from '../src/util/git.js';
+import { dirtyFiles, gitPreflight, isDirty } from '../src/util/git.js';
 import { PreflightError, isNotFoundError } from '../src/util/preflight.js';
 import { KicadCliMissingError } from '../src/kicad/cli.js';
 import { tempFixtureRepo } from './helpers.js';
@@ -101,35 +100,10 @@ describe('git preflight (unborn HEAD, AC-3.8)', () => {
   });
 });
 
-describe('copperhead create without a git setup (bug-report path)', () => {
-  const createOpts = (repoRoot: string) => ({
-    repoRoot,
-    briefPath: path.join(repoRoot, 'brief.md'),
-    model: 'gpt-5',
-    log: () => {},
-  });
-
-  it('unborn HEAD: create fails with the no-commits message instead of crashing in spec-seed', async () => {
-    const { dir, cleanup } = await tempDir();
-    try {
-      await writeFile(path.join(dir, 'brief.md'), 'A tiny USB macro keypad', 'utf8');
-      await execa('git', ['init', '-q'], { cwd: dir });
-      await expect(runCreate(createOpts(dir))).rejects.toThrow(/repository has no commits/);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it('non-git directory: create fails with the not-a-repository message', async () => {
-    const { dir, cleanup } = await tempDir();
-    try {
-      await writeFile(path.join(dir, 'brief.md'), 'A tiny USB macro keypad', 'utf8');
-      await expect(runCreate(createOpts(dir))).rejects.toThrow(/not a git repository/);
-    } finally {
-      await cleanup();
-    }
-  });
-});
+// `create` no longer refuses over these two states — it sets git up itself, so
+// a new user's first command works in a directory they just made. The
+// behaviour that replaced the refusals is covered in create-setup.test.ts;
+// what stays asserted here is that the strict gates still apply to `do`.
 
 describe('preflight failures explain why and how to fix', () => {
   async function preflightError(dir: string, allowDirty = false): Promise<PreflightError> {
@@ -176,6 +150,37 @@ describe('preflight failures explain why and how to fix', () => {
       expect(err.message).toMatch(/--allow-dirty/);
       // the offered flag actually works
       await expect(gitPreflight(repo, { allowDirty: true })).resolves.toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('copperhead\'s own run artifacts never trip the gate, even unignored', async () => {
+    // Regression: in a repo the user set up by hand (git init && git commit, no
+    // copperhead .gitignore), the REPL opens its session log under
+    // .copperhead/runs/ before the first turn. git status then reports
+    // "?? .copperhead/" and the gate refused the run over a file copperhead had
+    // just written — telling the user to commit or stash work that was not
+    // theirs. The audit trail survives rollback by design, so it is not the
+    // user's uncommitted work and must not count as dirty.
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await rm(path.join(repo, '.gitignore'), { force: true });
+      await execa('git', ['add', '-A'], { cwd: repo });
+      await execa('git', ['commit', '-q', '--allow-empty', '-m', 'no copperhead ignores'], { cwd: repo });
+
+      await mkdir(path.join(repo, '.copperhead', 'runs'), { recursive: true });
+      await writeFile(path.join(repo, '.copperhead', 'runs', 'repl-2026-01-01.log'), 'session', 'utf8');
+      expect((await execa('git', ['status', '--porcelain'], { cwd: repo })).stdout).toContain('.copperhead/');
+
+      await expect(gitPreflight(repo)).resolves.toBeUndefined();
+      expect(await dirtyFiles(repo)).toEqual([]);
+      expect(await isDirty(repo)).toBe(false);
+
+      // The user's own uncommitted work still stops the run.
+      await writeFile(path.join(repo, 'junk.txt'), 'dirty', 'utf8');
+      expect(await dirtyFiles(repo)).toEqual(['junk.txt']);
+      await expect(gitPreflight(repo)).rejects.toThrow(/working tree is dirty/);
     } finally {
       await cleanup();
     }

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -468,11 +468,30 @@ describe('promptWithSlashHints', () => {
 });
 
 describe('session log file', () => {
+  /**
+   * Poll until `cond` holds, rather than sleeping a fixed span. A request turn
+   * now resolves the dirty-tree gate before it starts, which shells out to git,
+   * so the window between writing a request and writing `/quit` is no longer
+   * reliably shorter than a 30ms sleep: under load `/quit` could win the race
+   * and the turn never ran. Waiting on the effect keeps these deterministic.
+   */
+  const waitUntil = async (cond: () => boolean, timeoutMs = 5000): Promise<void> => {
+    const deadline = Date.now() + timeoutMs;
+    while (!cond()) {
+      if (Date.now() > deadline) throw new Error('timed out waiting for the turn to start');
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  };
+
   it('mirrors session lines to .copperhead/runs/repl-*.log with keys redacted', async () => {
     setColorEnabled(false);
     const repo = await mkdtemp(path.join(tmpdir(), 'copperhead-repl-log-'));
     try {
       const { input, output } = fakeTty();
+      const runRequest = vi.fn(async (_req: string, log?: (l: string) => void) => {
+        log?.('leaked sk-SECRET_KEY_123 in output');
+        return { outcome: 'success' as const };
+      });
       const done = runRepl({
         repoRoot: repo,
         model: 'gpt-5',
@@ -482,14 +501,11 @@ describe('session log file', () => {
         renderer: plainRenderer(() => {}),
         input,
         output,
-        runRequest: vi.fn(async (_req: string, log?: (l: string) => void) => {
-          log?.('leaked sk-SECRET_KEY_123 in output');
-          return { outcome: 'success' as const };
-        }),
+        runRequest,
       });
       await new Promise((r) => setTimeout(r, 30));
       input.write('do the thing\n');
-      await new Promise((r) => setTimeout(r, 30));
+      await waitUntil(() => runRequest.mock.calls.length > 0);
       input.write('/quit\n');
       await done;
 
@@ -523,6 +539,10 @@ describe('session log file', () => {
     ];
     try {
       const { input, output } = fakeTty();
+      const runRequest = vi.fn(async (_req: string, log?: (l: string) => void) => {
+        for (const s of secrets) log?.(`tool output: ${s} trailing`);
+        return { outcome: 'success' as const };
+      });
       const done = runRepl({
         repoRoot: repo,
         model: 'gpt-5',
@@ -532,14 +552,11 @@ describe('session log file', () => {
         renderer: plainRenderer(() => {}),
         input,
         output,
-        runRequest: vi.fn(async (_req: string, log?: (l: string) => void) => {
-          for (const s of secrets) log?.(`tool output: ${s} trailing`);
-          return { outcome: 'success' as const };
-        }),
+        runRequest,
       });
       await new Promise((r) => setTimeout(r, 30));
       input.write('publish it\n');
-      await new Promise((r) => setTimeout(r, 30));
+      await waitUntil(() => runRequest.mock.calls.length > 0);
       input.write('/quit\n');
       await done;
 


### PR DESCRIPTION
## What

Three onboarding gates met a new user with a refusal where copperhead could have acted.

1. `create` prepares git instead of refusing over it: `git init`, the baseline `.gitignore`, a repo-local identity fallback, and the initial commit that stage rollbacks snapshot against.
2. The brief can be given as literal text or as a file, positionally or via `--brief`: `copperhead create "a USB-C powered ESP32 sensor board"` now works in an empty directory.
3. An attended run that meets the dirty-tree gate is offered the fixes the refusal message already described (commit, stash, run anyway, cancel) instead of being sent away to run git by hand.

It also fixes #131: the dirty-tree gate counted copperhead's own audit trail as the user's uncommitted work, so the interactive shell refused to run over its own session log.

## Why

A first-time user's first command was a refusal. `create` in a fresh directory demanded `git init` plus a commit before it would do anything, even though the pipeline's own commits give them that history anyway. `--brief` was a required option, so there was no one-liner. And the dirty-tree gate could only describe the three ways out, never take one.

Issue #131 is the sharpest case. The shell opens its session log at `.copperhead/runs/repl-<ts>.log` before the first turn ([repl.ts](src/commands/repl.ts)). In a repository the user initialized by hand there is no `.gitignore` entry for it, so `git status` reports `?? .copperhead/` and the gate refuses. The repository was clean a second earlier, and all three suggested fixes miss: committing writes transcripts into project history, stashing is undone by the next launch, and `--allow-dirty` disables the protection for the user's real work too.

## Design

**Git preparation is scoped to `create` only.** [`ensureGitReady`](src/util/git.ts) never touches a repository that already has commits beyond committing the brief and an idempotent `.gitignore` top-up. `do`, `sync`, and the shell keep the strict `gitPreflight`: those edit a repo the user already owns, where an implicit initial commit would be a surprise. The brief is committed via a pathspec commit ([`commitPaths`](src/util/git.ts)) so the user's other dirty or staged paths are not swept in, and so a stage rollback's `git clean -fd` cannot delete the file the printed resume command points at.

**The dirty-tree menu never weakens the unattended path.** [`resolveDirtyTree`](src/util/dirty.ts) applies the user's choice and reports whether the run continues under `--allow-dirty`. A cancel, a thrown prompt, and a dismissed prompt all read as cancel, and every unattended run (no TTY, or `--json`) has no chooser at all, so it refuses exactly as before. The prompt is raised before the run's snapshot is taken, and in the shell it is raised before the turn starts, because the shell's key reader is paused for the duration of a turn.

**#131 is fixed by path, not by consulting `.gitignore`.** `.copperhead/runs/` is excluded from the dirty computation directly, so the gate behaves identically before and after the ignore entry lands. The exclusion costs nothing: `restore()` already copies the audit trail across a rollback rather than resetting it with the tree, so it was never work the gate was protecting. `.copperhead/runs/` also joins `GIT_ADD_EXCLUDES`, so every copperhead commit tops the ignore entry up and the transcripts never reach project history (AC-4.3).

`isDirty` and `uncommittedCount` now derive from `dirtyFiles`, so the gate, the file list it prints, and `/git` cannot disagree.

**Two defects found while testing that fix, both fixed here.**

`git()` trims the whole `git status --porcelain` payload, but porcelain encodes index and worktree state in two leading columns and an unstaged modification is `" M path"`. The trim ate that column on the first line only, so the prompt offered to commit `EADME.md`, and any path matched against the list (including the new exclusion) was off by a character. `dirtyFiles` now trims trailing newlines only. It also passes `-uall`, because `git status` collapses a wholly-untracked `.copperhead/` into a single entry that no per-file filter can see inside.

The two session-log tests in [repl.test.ts](test/repl.test.ts) sequenced input with a fixed 30ms sleep. A request turn now resolves the dirty gate first, which shells out to git, so `/quit` could win that race and the turn never ran: 2 of 5 full-suite runs failed on this branch before the fix. They now wait on the turn starting rather than on a clock.

## Spec / OpenSpec

OpenSpec change: `smooth-onboarding-gates` (`openspec validate smooth-onboarding-gates` passes).

Delta specs: `cli-surface`, `create-pipeline`, `safety-rails`.

Acceptance criteria touched:

- **AC-3.8 (dirty tree)** extended: attended resolution, and "uncommitted changes" now means the user's, so a repository whose only uncommitted path is `.copperhead/runs/` counts as clean.
- **AC-4.3** notes that the baseline ignore file is written before the initial commit of the repository `create` initializes, and that every copperhead commit tops the entry up.

SPEC.md moved with the change: section 2.5 (inputs), section 3 (command list), section 7 (both gates plus the new own-artifacts rule), AC-3.8 and AC-4.3.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | pass: 595 passed, 20 skipped, 43 files (3 consecutive clean full-suite runs) |
| Live-LLM (opt-in) | keyed on `COPPERHEAD_TEST_CODEX` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` | skip: none configured in this environment. Covered by the manual log below, run against a real model. |

New or changed tests:

- `test/create-setup.test.ts` (new): non-git directory, unborn HEAD, empty directory, existing-history repo (only the brief is committed, the user's unrelated file is not), `ensureGitReady` idempotence, and brief materialization.
- `test/dirty-tree.test.ts` (new): each choice's effect on tree and history, a thrown prompt reading as cancel, a clean tree never asking, the repo and unborn-HEAD gates never prompting, the file-list cap, in-loop coverage, and the porcelain-column regression (` M`, `??`, staged rename).
- `test/preflight.test.ts`: the two obsolete `create` refusal cases removed (`create` no longer refuses over them); a new case asserting a hand-initialized repo with a written session log passes the gate while the user's own file still refuses and is the only path named.
- `test/repl.test.ts`: the two session-log tests wait on the turn instead of a fixed sleep.

Known pre-existing failures unrelated to this PR: none. `main` is green (572 passed) and this branch is green (595 passed).

### Manual test log (required)

Sandbox variant used: **edit** (a copy of the `open-key` fixture, plus purpose-built repositories for the git-state gates). Driven through a real PTY so the interactive shell runs as a user meets it, with `--model claude-code`.

**Issue #131, the reported repro:**

```text
$ mkdir board && cd board && printf '# Brief\n' > brief.md
$ git init && git add -A && git commit -m "initial commit"
$ git status --porcelain
                                        # clean
$ copperhead --model claude-code
# shell opens, writes .copperhead/runs/repl-<ts>.log
$ git status --porcelain
?? .copperhead/
# at the prompt: "add a test resistor"
BEFORE: working tree is dirty; copperhead refuses to run on uncommitted changes by default
AFTER:  repl · model claude-code (claude-code, via flag) · turns <=40 · main@e0e2cbc clean
```

**Dirty-tree menu, every branch** (repository with `README.md` modified and `mywork.txt` untracked):

```text
commit      -> committed 2 file(s) as 841f4c5; a rollback now returns here
               git log: chore: save work in progress before a copperhead run; tree clean
stash       -> stashed 2 file(s); restore them with git stash pop; tree clean
run anyway  -> running on the dirty tree; run starts main@073fa98 dirty(2); nothing committed or stashed
cancel      -> the standard refusal with its three fixes, tree untouched, session continues
Esc         -> same as cancel
--allow-dirty -> no prompt at all; run starts main@df90d13 dirty(1)
--json do   -> refuses with no prompt (unattended)
```

The file list before and after the porcelain fix:

```text
BEFORE:   EADME.md
          mywork.txt
AFTER:    README.md
          mywork.txt
```

**Startup gates:**

```text
non-git directory -> not a git repository; copperhead requires git for snapshots and rollback (session continues)
unborn HEAD       -> repository has no commits; copperhead requires at least one commit (session continues)
```

**Full agent run, verification chain intact** (`open-key` fixture, `--model claude-code`):

```text
$ copperhead --model claude-code
> rename net KEY_DAH to KEY_DASH everywhere
  > propose_change   proposal written to openspec/changes/rename-key-dah-to-key-dash/
  v validate_change  validation passed; edit tools are now unlocked
  > edit_file        edited hardware/open-key.kicad_sch (2 occurrence(s) replaced)
  > edit_file        edited docs/PINOUT.md
  v run_erc          ERC: clean
  v check_drift      drift: clean
  > record_decision  decision recorded
  > finish           all gates satisfied; run will commit
committed a5639e77c6 (3 file(s))
done · ERC clean · committed a5639e77c6 · 1m09s · 18 in / 2.8k out

> /check
ERC ok  DRC ok  drift ok
check: all green
```

Edit tools stayed absent until `validate_change` returned, and the run committed only after ERC and drift passed.

**AC-4.3 top-up, in a repository with no `.gitignore` at all:**

```text
$ ls -a | grep gitignore        # none
$ git status --porcelain        # clean
$ copperhead --model claude-code
> rename net EN to ENABLE everywhere
committed c13307251e (3 file(s))

$ cat .gitignore
.copperhead/runs/
.history/
$ git ls-files | grep copperhead/runs
                                # nothing: transcripts stayed out of history
```

**Secret redaction (AC-4.1), live:** a request containing `sk-`, `Bearer`, and `ghp_` tokens landed in the session log as `[REDACTED]`, and a recursive grep of the whole repository directory found no live secret.

**Rest of the shell surface, exercised and correct:** `/help /version /config /git /status /parts /nets /bom /drift /constraints /runs /last /examples /sync /openspec /model /clear /check`, unknown `/nope`, empty Enter, the `/` filter menu, Tab completion, PgUp and PgDn, single ctrl+c clearing a half-typed line, ctrl+c twice quitting, ctrl+d quitting, and a bracketed multi-line paste arriving as one request. In a repository with no KiCad project every read-only command degrades with an actionable message.

## Docs

- `README.md`: the empty-directory one-liner in the quick start.
- `docs/reference/cli.md`: both brief forms, a git-setup section covering what `create` does and why `do` and `sync` differ, and the uncommitted-changes table under `do`.
- `docs/workflows/create-from-brief.md`: the one-liner section, and the manual `git init && git commit --allow-empty` step dropped.
- `openspec/specs/SPEC.md`: sections 2.5, 3, 7, AC-3.8, AC-4.3.

---

## Invariant checklist

- [x] **Spec-gated in**: `edit_file`/`write_file` stay structurally absent from the agent tool list until an OpenSpec proposal validates (gated by omission, not prompt text). Unchanged by this PR, and confirmed live in the manual log: the edit tools appeared only after `validate_change` returned.
- [x] **Verification-gated out**: mutations still end in ERC (and DRC when the board changed) passing, with repair up to `maxRepairCycles` then rollback to the git snapshot. Unchanged by this PR, and confirmed live: the run committed only after ERC and drift passed.
- [x] **`check`/`verify` stays LLM-free and network-free**: nothing reachable from `src/commands/check` touches a provider, an API key, or the network. Untouched by this PR.
- [x] **No sexp serialization**: the `src/kicad/` parser stays read-only; KiCad files are edited only via anchored exact-match text replace. Untouched by this PR.
- [x] **Sync-obligations ledger**: post-tool-call hooks keep feeding the ledger, and commit keeps refusing while obligations are open. Untouched by this PR.
- [x] **Secrets**: transcripts and summaries redact `sk-[A-Za-z0-9_-]+` at write time; keys live only in env vars; `.gitignore` keeps `.env` and `.copperhead/runs/`. Strengthened here: `.copperhead/runs/` now joins `GIT_ADD_EXCLUDES`, so a repository that lacked the entry gets it on the first copperhead commit instead of having transcripts committed. Verified live.
- [x] **Spec coherence**: SPEC.md and the change artifacts moved together, and `openspec validate smooth-onboarding-gates` passes.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `copperhead create` now accepts inline brief text (or an existing brief file) in addition to `--brief`.
  * New projects are automatically prepared with Git, baseline `.gitignore`, and an initial brief snapshot.
  * When running interactively, uncommitted work can be handled via a prompt: commit, stash, continue, or cancel.
* **Documentation**
  * Updated quick start, CLI reference, and workflow docs for brief onboarding and Git/dirty-tree safety behavior.
* **Bug Fixes**
  * Copperhead’s own run artifacts no longer cause dirty-working-tree warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->