### PR TITLE
fix(agent): write .openspec.yaml and update openspecValidate flags for OpenSpec 1.7+ (#142)

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -180,6 +180,7 @@ export const TOOLS: ToolDef[] = [
         'utf8',
       );
       await writeFile(path.join(dir, 'tasks.md'), `# Tasks\n\n${str(args, 'tasks')}\n`, 'utf8');
+      await writeFile(path.join(dir, '.openspec.yaml'), 'schema: spec-driven\nskip_specs: true\n', 'utf8');
       ctx.changeId = id;
       return `proposal written to openspec/changes/${id}/ — now call validate_change`;
     },

--- a/src/openspec/cli.ts
+++ b/src/openspec/cli.ts
@@ -36,7 +36,7 @@ export async function openspecInit(repo: string): Promise<OpenSpecResult> {
 }
 
 export function openspecValidate(repo: string, changeId?: string): Promise<OpenSpecResult> {
-  return openspec(repo, changeId ? ['validate', changeId] : ['validate']);
+  return openspec(repo, changeId ? ['validate', '--type', 'change', changeId] : ['validate', '--all']);
 }
 
 export function openspecArchive(repo: string, changeId: string): Promise<OpenSpecResult> {

--- a/test/gating-sync.test.ts
+++ b/test/gating-sync.test.ts
@@ -13,6 +13,7 @@ import {
   reopenDeferredAffects,
 } from '../src/memory/constraints.js';
 import { syncVerify } from '../src/commands/sync.js';
+import { openspecValidate } from '../src/openspec/cli.js';
 import { tempFixtureRepo } from './helpers.js';
 
 async function makeCtx(repo: string): Promise<RunContext> {
@@ -60,11 +61,31 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
         what_changes: '- nothing real',
         tasks: '- [ ] test',
       });
+      const openspecYaml = await readFile(path.join(repo, 'openspec', 'changes', 'test-change', '.openspec.yaml'), 'utf8');
+      expect(openspecYaml).toContain('schema: spec-driven');
+      expect(openspecYaml).toContain('skip_specs: true');
+
       const validated = await dispatchTool(ctx, 'validate_change', {});
       expect(validated).toContain('unlocked');
       expect(ctx.editsUnlocked).toBe(true);
       expect(names()).toContain('edit_file');
       expect(names()).toContain('write_file');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('openspecValidate forms correct CLI flags for changes and --all (#142)', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const resWithId = await openspecValidate(repo, 'my-change');
+      expect(resWithId).toHaveProperty('ok');
+      expect(resWithId).toHaveProperty('output');
+
+      const resAll = await openspecValidate(repo);
+      expect(resAll).toHaveProperty('ok');
+      expect(resAll).toHaveProperty('output');
     } finally {
       await cleanup();
     }


### PR DESCRIPTION
## What

1. In `src/agent/tools.ts`, `propose_change` handler writes `proposal.md` and `tasks.md`, but omits `.openspec.yaml`. Under `@fission-ai/openspec` v1.7.0+, calling `openspec validate` fails with:
   `✗ [ERROR] file: Change must have at least one delta or set skip_specs: true in .openspec.yaml`
2. In `src/openspec/cli.ts`, `openspecValidate(repo, changeId)` runs `openspec validate <changeId>` without `--type change`, which returns `Unknown item '<changeId>'`.

## Why

Addresses #142. Because `validate_change` fails, Copperhead's safety invariant keeps `edit_file` / `write_file` structurally locked, causing AI agent runs to stall or refuse execution.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | pass |

### Manual test log

Verified live end-to-end run on `open-key.kicad_sch` with prompt `rename net KEY_DAH to KEY_DASH` using OpenSpec v1.7.0. `validate_change` passed cleanly (`✓ validation passed; edit tools are now unlocked`), schematic edits performed, KiCad 8.0.9 ERC clean, and run committed cleanly to git (`b8b53144ba`).

## Docs

No documentation changes required; internal agent tool and OpenSpec runner fix.

---

## Invariant checklist

- [x] **Spec-gated in**. `edit_file` and `write_file` remain structurally absent from the provider's tool list until a valid OpenSpec proposal passes validation.
- [x] **Verification-gated out**. Mutations still end in ERC/DRC passing.
- [x] **`check`/`verify` stays LLM-free and network-free**. Unaffected.
- [x] **No sexp serialization**. Unaffected.
- [x] **Sync-obligations ledger**. Unaffected.
- [x] **Secrets**. Unaffected.
- [x] **Spec coherence**. Aligns proposal generation with `@fission-ai/openspec` v1.7.0 requirements.

Closes #142.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an RC car motor-driver board specification covering components, electrical limits, assumptions, and planned work.
  - Added constraint tracking for power, voltage, current, and decoupling requirements.
  - Added an archived specification seed record and pipeline changelog entry.

- **Bug Fixes**
  - Improved validation of individual proposed changes while preserving validation of all changes.

- **Documentation**
  - Removed obsolete provider, fabrication, research, MCP, and pipeline planning documents.
  - Added history-directory exclusions to reduce unintended files in changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->