### PR TITLE
Fix #146: Support Grok Build CLI as a provider

### DIFF
--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -64,6 +64,8 @@ kicad-cli version
 
    The Claude Agent SDK ships as an optional dependency, so a normal install includes it. See [Saved login (Claude Code)](/reference/configuration/#saved-login-claude-code).
 
+   Alternatively, if you use Grok Build CLI, you can simply run `grok login` and then use `export COPPERHEAD_MODEL=grok`. See [Saved login (Grok Build CLI)](/reference/configuration/#saved-login-grok-build-cli).
+
    Or set a direct model API key. Keys are read from the environment only, never written to a config file, and redacted from transcripts.
 
    ```bash

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -41,6 +41,7 @@ Interactive agent shell (default when no command is given). On a TTY it takes ov
 copperhead
 copperhead "add reverse-polarity protection on VIN"   # seed request, then stay in the shell
 copperhead repl --model claude-code
+# or grok, codex, cursor, gpt-5, claude
 ```
 
 | Option | Description |
@@ -95,7 +96,7 @@ copperhead do "<change request>" [options]
 
 | Option | Description |
 | --- | --- |
-| `--model <model>` | `codex`, `cursor`, `gpt-5`, `claude`, `claude-code`, or a provider-specific model id. Saved-login providers: `codex` (Codex CLI), `cursor` (Cursor Agent CLI), `claude-code` (Claude Code). |
+| `--model <model>` | `grok`, `codex`, `cursor`, `gpt-5`, `claude`, `claude-code`, or a provider-specific model id. Saved-login providers: `grok` (Grok Build CLI), `codex` (Codex CLI), `cursor` (Cursor Agent CLI), `claude-code` (Claude Code). |
 | `--max-turns <n>` | Turn budget for this run. Overrides `maxTurns` from config. |
 | `--allow-dirty` | Permit a dirty working tree. The snapshot keeps tracked changes as a `git stash create` object and untracked files as a tree object, so a rollback restores both. |
 | `--dry-run` | Propose the diff and write nothing. |
@@ -135,7 +136,7 @@ Checks, in order:
 - **node** — at least the version copperhead requires.
 - **kicad-cli** — present on PATH (a missing binary is reported, not thrown).
 - **git** — present on PATH (copperhead snapshots and commits its work).
-- **provider** — resolves the model the same way a run does (`--model` > `COPPERHEAD_MODEL` > config > available key) and checks its credential. Saved-login providers (`codex`, `cursor`, `claude-code`) need no key and report `info`. For `compat:<id>` it checks the variable named by `apiKeyEnv`; a local endpoint needs no key.
+- **provider** — resolves the model the same way a run does (`--model` > `COPPERHEAD_MODEL` > config > available key) and checks its credential. Saved-login providers (`grok`, `codex`, `cursor`, `claude-code`) need no key and report `info`. For `compat:<id>` it checks the variable named by `apiKeyEnv`; a local endpoint needs no key.
 - **privacy** — `compat` only. `[warn]` when the endpoint's host is documented as training on submitted prompts; `[info]` naming the host when a remote endpoint has no known policy on record. Neither ever fails the check. A true loopback endpoint (`localhost`/`127.0.0.1`/`::1`) skips this line entirely; a `.local`/LAN host does not, since that traffic still leaves the machine.
 - **project** — informational: whether `.copperhead/config.json` exists and what it wires. Never blocks.
 
@@ -182,7 +183,7 @@ copperhead create --brief brief.md [--model <model>] [--interactive]
 | Option | Description |
 | --- | --- |
 | `--brief <file>` | **Required.** The product brief, in markdown. |
-| `--model <model>` | `codex`, `cursor`, `gpt-5`, `claude`, or `claude-code` (saved-login; no model API key for those three). |
+| `--model <model>` | `grok`, `codex`, `cursor`, `gpt-5`, `claude`, or `claude-code` (saved-login; no model API key for those four). |
 | `--interactive` | Re-enable the human gates: spec approval, and a pause before export. |
 
 Exits 1 if any stage fails to complete, 0 when the pipeline finishes.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -41,7 +41,6 @@ Interactive agent shell (default when no command is given). On a TTY it takes ov
 copperhead
 copperhead "add reverse-polarity protection on VIN"   # seed request, then stay in the shell
 copperhead repl --model claude-code
-# or grok, codex, cursor, gpt-5, claude
 ```
 
 | Option | Description |
@@ -96,7 +95,7 @@ copperhead do "<change request>" [options]
 
 | Option | Description |
 | --- | --- |
-| `--model <model>` | `grok`, `codex`, `cursor`, `gpt-5`, `claude`, `claude-code`, or a provider-specific model id. Saved-login providers: `grok` (Grok Build CLI), `codex` (Codex CLI), `cursor` (Cursor Agent CLI), `claude-code` (Claude Code). |
+| `--model <model>` | `codex`, `cursor`, `gpt-5`, `claude`, `claude-code`, or a provider-specific model id. Saved-login providers: `codex` (Codex CLI), `cursor` (Cursor Agent CLI), `claude-code` (Claude Code). |
 | `--max-turns <n>` | Turn budget for this run. Overrides `maxTurns` from config. |
 | `--allow-dirty` | Permit a dirty working tree. The snapshot keeps tracked changes as a `git stash create` object and untracked files as a tree object, so a rollback restores both. |
 | `--dry-run` | Propose the diff and write nothing. |
@@ -136,7 +135,7 @@ Checks, in order:
 - **node** — at least the version copperhead requires.
 - **kicad-cli** — present on PATH (a missing binary is reported, not thrown).
 - **git** — present on PATH (copperhead snapshots and commits its work).
-- **provider** — resolves the model the same way a run does (`--model` > `COPPERHEAD_MODEL` > config > available key) and checks its credential. Saved-login providers (`grok`, `codex`, `cursor`, `claude-code`) need no key and report `info`. For `compat:<id>` it checks the variable named by `apiKeyEnv`; a local endpoint needs no key.
+- **provider** — resolves the model the same way a run does (`--model` > `COPPERHEAD_MODEL` > config > available key) and checks its credential. Saved-login providers (`codex`, `cursor`, `claude-code`) need no key and report `info`. For `compat:<id>` it checks the variable named by `apiKeyEnv`; a local endpoint needs no key.
 - **privacy** — `compat` only. `[warn]` when the endpoint's host is documented as training on submitted prompts; `[info]` naming the host when a remote endpoint has no known policy on record. Neither ever fails the check. A true loopback endpoint (`localhost`/`127.0.0.1`/`::1`) skips this line entirely; a `.local`/LAN host does not, since that traffic still leaves the machine.
 - **project** — informational: whether `.copperhead/config.json` exists and what it wires. Never blocks.
 
@@ -183,7 +182,7 @@ copperhead create --brief brief.md [--model <model>] [--interactive]
 | Option | Description |
 | --- | --- |
 | `--brief <file>` | **Required.** The product brief, in markdown. |
-| `--model <model>` | `grok`, `codex`, `cursor`, `gpt-5`, `claude`, or `claude-code` (saved-login; no model API key for those four). |
+| `--model <model>` | `codex`, `grok`, `cursor`, `claude-code`, `gpt-5`, or `claude` (saved login applies only to `grok`, `codex`, `cursor`, and `claude-code`, while `gpt-5` and `claude` require API keys). |
 | `--interactive` | Re-enable the human gates: spec approval, and a pause before export. |
 
 Exits 1 if any stage fails to complete, 0 when the pipeline finishes.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -95,18 +95,19 @@ If `codex` is not on `PATH`, point `COPPERHEAD_CODEX_PATH` at an executable expl
 
 If none of these produce a model, the command exits with an error telling you the available ways to set one. `check` never needs a model, since it makes no LLM calls at all.
 
-Accepted model values (routing is by prefix; `makeProvider` checks `codex`, then `claude-code`, then `cursor`, then `claude`, then OpenAI):
+Accepted model values (routing is by prefix; `makeProvider` checks `grok`, then `codex`, then `claude-code`, then `cursor`, then `claude`, then OpenAI):
 
 | Value | Provider | Key |
 | --- | --- | --- |
-| `codex` / `codex:<id>` | Codex CLI, saved login | none (local Codex login) |
+| `codex` / `codex:<id>` | Codex CLI, saved login | none (uses your logged-in CLI) |
+| `grok` / `grok:<id>` | Grok Build CLI, saved login | none (uses your logged-in CLI) |
 | `claude-code` / `claude-code:<id>` | Claude Code, saved login | none (uses `CLAUDE_CODE_OAUTH_TOKEN` / your logged-in CLI) |
 | `cursor` / `cursor:<id>` | Cursor Agent CLI, saved login | none (`agent login`) |
 | `compat:<id>` | Any OpenAI-compatible endpoint (Groq, OpenRouter, Gemini, Ollama) | the variable named by `apiKeyEnv`; none for a local endpoint |
 | `claude` / `claude-<id>` | Anthropic API | `ANTHROPIC_API_KEY` |
 | `gpt-5` / anything else | OpenAI API | `OPENAI_API_KEY` |
 
-`claude-code` is matched before the `claude` prefix, so it is never captured by the Anthropic API route. Cursor runs report 0 token usage (CLI JSON has no usage fields).
+`claude-code` is matched before the `claude` prefix, so it is never captured by the Anthropic API route. Cursor and Grok runs report 0 token usage (CLI JSON has no usage fields).
 
 For `compat:<id>`, set `baseURL` and `apiKeyEnv` together — either as `COPPERHEAD_BASE_URL`/`COPPERHEAD_API_KEY_ENV`, or as `baseURL`/`apiKeyEnv` in `.copperhead/config.json`:
 
@@ -130,7 +131,7 @@ One-time setup:
 
 Authentication stays entirely with the CLI: copperhead never reads, copies, or logs the credential. A missing dependency or an unauthenticated install fails with an actionable message and leaves your tree untouched, and a rate-limited `claude-code` run never silently falls back to a billed API provider.
 
-### Saved login (Cursor Agent)
+### Saved login (Cursor Agent CLI)
 
 `--model cursor` drives the Cursor Agent CLI with your saved login from `agent login`, so you can run copperhead with **no model API keys**. Cursor runs in plan mode with sandbox enabled; copperhead maps tool calls through the same JSON prompt protocol as `claude-code` and keeps every mutation inside its own gated loop.
 
@@ -138,6 +139,10 @@ Authentication stays entirely with the CLI: copperhead never reads, copies, or l
 2. Run copperhead with `--model cursor` (use `--model cursor:<id>` for an explicit model).
 
 If `agent` is not on `PATH`, set `COPPERHEAD_CURSOR_PATH`. A rate-limited `cursor` run never silently falls back to a billed API provider.
+
+### Saved login (Grok Build CLI)
+
+`--model grok` drives the Grok Build CLI with your saved login from `grok login`, so you can run copperhead with **no model API keys**. Grok runs in plan mode; copperhead maps tool calls through the same JSON prompt protocol as `cursor` and keeps every mutation inside its own gated loop.
 
 ## Files copperhead writes
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -95,19 +95,19 @@ If `codex` is not on `PATH`, point `COPPERHEAD_CODEX_PATH` at an executable expl
 
 If none of these produce a model, the command exits with an error telling you the available ways to set one. `check` never needs a model, since it makes no LLM calls at all.
 
-Accepted model values (routing is by prefix; `makeProvider` checks `grok`, then `codex`, then `claude-code`, then `cursor`, then `claude`, then OpenAI):
+Accepted model values (routing is by prefix; makeProvider checks compat first, followed by codex, grok, claude-code, cursor, and claude, then OpenAI):
 
 | Value | Provider | Key |
 | --- | --- | --- |
-| `codex` / `codex:<id>` | Codex CLI, saved login | none (uses your logged-in CLI) |
-| `grok` / `grok:<id>` | Grok Build CLI, saved login | none (uses your logged-in CLI) |
+| `codex` / `codex:<id>` | Codex CLI, saved login | none (local Codex login) |
+| `grok` / `grok:<id>` | Grok CLI, saved login | none (`grok login`) |
 | `claude-code` / `claude-code:<id>` | Claude Code, saved login | none (uses `CLAUDE_CODE_OAUTH_TOKEN` / your logged-in CLI) |
 | `cursor` / `cursor:<id>` | Cursor Agent CLI, saved login | none (`agent login`) |
 | `compat:<id>` | Any OpenAI-compatible endpoint (Groq, OpenRouter, Gemini, Ollama) | the variable named by `apiKeyEnv`; none for a local endpoint |
 | `claude` / `claude-<id>` | Anthropic API | `ANTHROPIC_API_KEY` |
 | `gpt-5` / anything else | OpenAI API | `OPENAI_API_KEY` |
 
-`claude-code` is matched before the `claude` prefix, so it is never captured by the Anthropic API route. Cursor and Grok runs report 0 token usage (CLI JSON has no usage fields).
+`claude-code` is matched before the `claude` prefix, so it is never captured by the Anthropic API route. Cursor runs report 0 token usage (CLI JSON has no usage fields).
 
 For `compat:<id>`, set `baseURL` and `apiKeyEnv` together — either as `COPPERHEAD_BASE_URL`/`COPPERHEAD_API_KEY_ENV`, or as `baseURL`/`apiKeyEnv` in `.copperhead/config.json`:
 
@@ -131,7 +131,7 @@ One-time setup:
 
 Authentication stays entirely with the CLI: copperhead never reads, copies, or logs the credential. A missing dependency or an unauthenticated install fails with an actionable message and leaves your tree untouched, and a rate-limited `claude-code` run never silently falls back to a billed API provider.
 
-### Saved login (Cursor Agent CLI)
+### Saved login (Cursor Agent)
 
 `--model cursor` drives the Cursor Agent CLI with your saved login from `agent login`, so you can run copperhead with **no model API keys**. Cursor runs in plan mode with sandbox enabled; copperhead maps tool calls through the same JSON prompt protocol as `claude-code` and keeps every mutation inside its own gated loop.
 
@@ -139,10 +139,6 @@ Authentication stays entirely with the CLI: copperhead never reads, copies, or l
 2. Run copperhead with `--model cursor` (use `--model cursor:<id>` for an explicit model).
 
 If `agent` is not on `PATH`, set `COPPERHEAD_CURSOR_PATH`. A rate-limited `cursor` run never silently falls back to a billed API provider.
-
-### Saved login (Grok Build CLI)
-
-`--model grok` drives the Grok Build CLI with your saved login from `grok login`, so you can run copperhead with **no model API keys**. Grok runs in plan mode; copperhead maps tool calls through the same JSON prompt protocol as `cursor` and keeps every mutation inside its own gated loop.
 
 ## Files copperhead writes
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -29,6 +29,7 @@ import { OpenAIProvider } from './providers/openai.js';
 import { AnthropicProvider } from './providers/anthropic.js';
 import { CodexProvider } from './providers/codex.js';
 import { ClaudeCodeProvider } from './providers/claude-code.js';
+import { GrokProvider } from './providers/grok.js';
 import { CursorProvider } from './providers/cursor.js';
 import { openSynapMemory, type RunRecord, type SynapMemory } from '../memory/synap.js';
 
@@ -135,6 +136,11 @@ export async function makeProvider(
         codexPathOverride: process.env.COPPERHEAD_CODEX_PATH || 'codex',
       }),
     });
+  }
+  if (model === 'grok' || model.startsWith('grok:')) {
+    const grokModel = model.startsWith('grok:') ? model.slice('grok:'.length) : undefined;
+    if (grokModel === '') throw new Error('grok model override cannot be empty; use "grok" or "grok:<model-id>"');
+    return new GrokProvider(grokModel, undefined, sessionResume);
   }
   // Match claude-code before the `claude*` prefix: both `claude-code` and
   // `claude-code:<id>` start with `claude` and would otherwise route to the

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -28,8 +28,8 @@ import { existsSync } from 'node:fs';
 import { OpenAIProvider } from './providers/openai.js';
 import { AnthropicProvider } from './providers/anthropic.js';
 import { CodexProvider } from './providers/codex.js';
-import { ClaudeCodeProvider } from './providers/claude-code.js';
 import { GrokProvider } from './providers/grok.js';
+import { ClaudeCodeProvider } from './providers/claude-code.js';
 import { CursorProvider } from './providers/cursor.js';
 import { openSynapMemory, type RunRecord, type SynapMemory } from '../memory/synap.js';
 
@@ -139,7 +139,9 @@ export async function makeProvider(
   }
   if (model === 'grok' || model.startsWith('grok:')) {
     const grokModel = model.startsWith('grok:') ? model.slice('grok:'.length) : undefined;
-    if (grokModel === '') throw new Error('grok model override cannot be empty; use "grok" or "grok:<model-id>"');
+    if (grokModel === '') {
+      throw new Error('grok model override cannot be empty; use "grok" or "grok:<model-id>"');
+    }
     return new GrokProvider(grokModel, undefined, sessionResume);
   }
   // Match claude-code before the `claude*` prefix: both `claude-code` and
@@ -387,7 +389,7 @@ async function runWithMemory(
   });
 
   const flushMetrics = async (exitPath?: ExitPath): Promise<void> => {
-    const currentStats = stats(exitPath ?? 'stalled');
+    const currentStats = stats(exitPath ?? 'running');
     const p = path.join(transcript.dir, 'metrics.json');
     const tmp = `${p}.tmp`;
     try {
@@ -455,12 +457,16 @@ async function runWithMemory(
         `failed work preserved: git stash entry "copperhead failed run ${ctx.runId}" (${preserved.slice(0, 10)}); recover with \`git stash apply\`, discard with \`git stash drop\``,
       );
     }
-    try {
-      await execa('git', ['add', '-f', transcript.dir], { cwd: repoRoot });
-      await commitAll(repoRoot, `copperhead: partial run data ${ctx.runId}`);
-      log(`committed partial run data for failed run`);
-    } catch (err) {
-      log(`warning: could not commit partial run data (${(err as Error).message})`);
+    if (!restoreError) {
+      try {
+        await execa('git', ['add', '-f', transcript.dir], { cwd: repoRoot });
+        await execa('git', ['commit', '-m', `copperhead: partial run data ${ctx.runId}`, '--', transcript.dir], { cwd: repoRoot });
+        log(`committed partial run data for failed run`);
+      } catch (err) {
+        log(`warning: could not commit partial run data (${(err as Error).message})`);
+      }
+    } else {
+      log(`skipping partial run data commit because rollback failed and repository state is unverified`);
     }
     log(`transcript: ${transcript.jsonlPath}`);
     log(`summary: ${summaryPath}`);
@@ -640,12 +646,12 @@ async function runWithMemory(
       tokensOut: res.usage.outputTokens,
       cacheRead: 0,
       cacheWrite: 0,
-      cacheHit: (res as any).cacheHit ?? false,
+      cacheHit: res.cacheHit ?? false,
       latencyMs: Date.now() - turnStartMs,
       startedAt: turnStartAtIso,
       finishedAt: callFinishedAt,
-      stopReason: (res as any).stopReason ?? 'unknown',
-      toolCalls: res.toolCalls.map((c: any) => c.name),
+      stopReason: res.stopReason ?? 'unknown',
+      toolCalls: res.toolCalls.map((c) => c.name),
       error: null
     });
     await flushMetrics();

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, rename } from 'node:fs/promises';
 import { execa } from 'execa';
 import type { Msg, Provider, Turn } from './types.js';
 import { availableTools, dispatchTool, type RunContext } from './tools.js';
@@ -380,6 +380,18 @@ async function runWithMemory(
     durationMs: Date.now() - startMs,
   });
 
+  const flushMetrics = async (exitPath?: ExitPath): Promise<void> => {
+    const currentStats = stats(exitPath ?? 'stalled');
+    const p = path.join(transcript.dir, 'metrics.json');
+    const tmp = `${p}.tmp`;
+    try {
+      await writeFile(tmp, JSON.stringify(currentStats, null, 2), 'utf8');
+      await rename(tmp, p);
+    } catch {
+      // best-effort
+    }
+  };
+
   /** One outcome line, printed last at every terminal branch (AC-8.5). */
   const outcomeLine = (s: RunStats, extra?: string | null): string =>
     [
@@ -409,6 +421,7 @@ async function runWithMemory(
     }
     const runStats = stats(exitPath);
     await transcript.event('run-end', runStats);
+    await flushMetrics(exitPath);
     const summaryPath = await transcript.writeSummary({
       request: opts.request,
       changeId: ctx.changeId,
@@ -435,6 +448,13 @@ async function runWithMemory(
       log(
         `failed work preserved: git stash entry "copperhead failed run ${ctx.runId}" (${preserved.slice(0, 10)}); recover with \`git stash apply\`, discard with \`git stash drop\``,
       );
+    }
+    try {
+      await execa('git', ['add', '-f', transcript.dir], { cwd: repoRoot });
+      await commitAll(repoRoot, `copperhead: partial run data ${ctx.runId}`);
+      log(`committed partial run data for failed run`);
+    } catch (err) {
+      log(`warning: could not commit partial run data (${(err as Error).message})`);
     }
     log(`transcript: ${transcript.jsonlPath}`);
     log(`summary: ${summaryPath}`);
@@ -514,6 +534,7 @@ async function runWithMemory(
           )
         : null;
     heartbeat?.unref?.();
+    const turnStartAtIso = new Date(turnStartMs).toISOString();
     try {
       res = await withRetry(
         () =>
@@ -525,6 +546,27 @@ async function runWithMemory(
         { onRetry: (attempt) => log(`rate limited; retry ${attempt}`) },
       );
     } catch (err) {
+      const callFinishedAt = new Date().toISOString();
+      await transcript.event('llm-call', {
+        turn: turn + 1,
+        stage: meta.stage?.name,
+        callId: `call-${turn + 1}-${turnTimeouts}`,
+        model: provider.name,
+        provider: provider.name,
+        tokensIn: 0,
+        tokensOut: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cacheHit: false,
+        latencyMs: Date.now() - turnStartMs,
+        startedAt: turnStartAtIso,
+        finishedAt: callFinishedAt,
+        stopReason: 'error',
+        toolCalls: [],
+        error: (err as Error).message
+      });
+      await flushMetrics();
+
       if (err instanceof TurnTimeoutError) {
         // A hung provider turn: the watchdog aborted the in-flight call and tore
         // down its subprocess. Retry the same turn a bounded number of times
@@ -580,6 +622,28 @@ async function runWithMemory(
     tokensIn += res.usage.inputTokens;
     tokensOut += res.usage.outputTokens;
     perTurn.push({ turn: turn + 1, in: res.usage.inputTokens, out: res.usage.outputTokens });
+    
+    const callFinishedAt = new Date().toISOString();
+    await transcript.event('llm-call', {
+      turn: turn + 1,
+      stage: meta.stage?.name,
+      callId: `call-${turn + 1}`,
+      model: provider.name,
+      provider: provider.name,
+      tokensIn: res.usage.inputTokens,
+      tokensOut: res.usage.outputTokens,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cacheHit: (res as any).cacheHit ?? false,
+      latencyMs: Date.now() - turnStartMs,
+      startedAt: turnStartAtIso,
+      finishedAt: callFinishedAt,
+      stopReason: (res as any).stopReason ?? 'unknown',
+      toolCalls: res.toolCalls.map((c: any) => c.name),
+      error: null
+    });
+    await flushMetrics();
+
     await transcript.event('assistant', { text: res.text, toolCalls: res.toolCalls });
 
     if (res.text) {

--- a/src/agent/providers/grok.ts
+++ b/src/agent/providers/grok.ts
@@ -1,0 +1,371 @@
+import { mkdtemp, rm, utimes } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { execa } from 'execa';
+import type { ChatOpts, Msg, Provider, ToolSchema, Turn } from '../types.js';
+import { parseToolCalls, renderConversation, renderDelta, renderToolProtocol } from './tool-protocol.js';
+
+/**
+ * Saved-login provider: drives the Grok Agent CLI (`agent` / `grok-agent`) with
+ * `agent login` authentication. Reasoning-only: plan mode, sandbox, isolated
+ * workspace, JSON tool protocol (see `add-grok-cli-provider`).
+ *
+ * Session resume is opt-in and mutually exclusive with the response cache (same
+ * rule as claude-code): the cache can replay turns a resumed CLI session never
+ * saw, which desyncs history. `makeProvider` enables resume only when the cache
+ * is off.
+ */
+
+export interface GrokRunArgs {
+  prompt: string;
+  systemPrompt: string;
+  workspace: string;
+  model?: string;
+  resume?: string;
+  signal?: AbortSignal;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface GrokRunResult {
+  text: string;
+  sessionId?: string;
+  usage: { inputTokens: number; outputTokens: number };
+}
+
+export type GrokRunLike = (args: GrokRunArgs) => Promise<GrokRunResult>;
+
+const NATIVE_MUTATION_TYPES = new Set([
+  'tool_call',
+  'tool_use',
+  'tool-call',
+  'shell',
+  'write',
+  'edit',
+  'apply_patch',
+  'file_change',
+  'mcp_tool',
+]);
+
+/** Subtype tokens that indicate native execution (whole-token match). */
+const NATIVE_SUBTYPE_RE = /(^|_)(tool|shell|write|edit|patch|mutation)(_|$)/;
+
+export class GrokProvider implements Provider {
+  readonly name = 'grok';
+  private callSeq = 0;
+  private cwdPromise?: Promise<string>;
+  private sessionId?: string;
+  private sentCount = 0;
+  private readonly inFlight = new Set<AbortController>();
+
+  constructor(
+    private readonly model?: string,
+    private readonly runFn: GrokRunLike = defaultGrokRun,
+    /**
+     * Opt-in: resume one CLI session across turns and send only new messages.
+     * OFF by default and mutually exclusive with the response cache — mixing
+     * them desyncs the resumed session. `makeProvider` enables it only when
+     * the cache is off.
+     */
+    private readonly sessionResume = false,
+  ) {}
+
+  async chat(messages: Msg[], tools: ToolSchema[], opts: ChatOpts = {}): Promise<Turn> {
+    const system = messages
+      .filter((m) => m.role === 'system')
+      .map((m) => m.content)
+      .join('\n\n');
+    const systemPrompt = [system, renderToolProtocol(tools)].filter(Boolean).join('\n\n');
+    const resume = this.sessionResume ? this.sessionId : undefined;
+    const prompt = resume ? renderDelta(messages, this.sentCount) : renderConversation(messages);
+    const catalog = new Set(tools.map((t) => t.name));
+    const workspace = await this.ensureWorkspace();
+
+    const aborter = new AbortController();
+    this.inFlight.add(aborter);
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let text: string | null = null;
+    try {
+      const result = await this.runFn({
+        prompt,
+        systemPrompt,
+        workspace,
+        ...(this.model ? { model: this.model } : {}),
+        ...(resume ? { resume } : {}),
+        signal: aborter.signal,
+        env: subprocessEnv(),
+      });
+      text = result.text;
+      if (this.sessionResume && result.sessionId) this.sessionId = result.sessionId;
+      inputTokens = result.usage.inputTokens;
+      outputTokens = result.usage.outputTokens;
+      opts.onStream?.(text.length);
+    } catch (err) {
+      if (isAuthError(err)) throw new Error(authHint((err as Error).message));
+      throw enhanceCliError(err);
+    } finally {
+      this.inFlight.delete(aborter);
+    }
+
+    // Only advance the high-water mark when resume is on (same as claude-code).
+    if (this.sessionResume) this.sentCount = messages.length;
+    const parsed = parseToolCalls(text, () => `cur-${++this.callSeq}`, catalog);
+    return {
+      text: parsed.text,
+      toolCalls: parsed.toolCalls,
+      usage: { inputTokens, outputTokens },
+      nudge: parsed.nudge,
+    };
+  }
+
+  async close(): Promise<void> {
+    for (const aborter of this.inFlight) {
+      try {
+        aborter.abort();
+      } catch {
+        // best effort
+      }
+    }
+    this.inFlight.clear();
+    const pending = this.cwdPromise;
+    this.cwdPromise = undefined;
+    if (!pending) return;
+    try {
+      await rm(await pending, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  }
+
+  private async ensureWorkspace(): Promise<string> {
+    if (!this.cwdPromise) this.cwdPromise = mkdtemp(path.join(os.tmpdir(), 'copperhead-grok-'));
+    const cwd = await this.cwdPromise;
+    const now = new Date();
+    await utimes(cwd, now, now).catch(() => {});
+    return cwd;
+  }
+}
+
+/** Minimal env passed to the Grok CLI subprocess (saved login via `agent login`). */
+const GROK_SUBPROCESS_ENV_KEYS = [
+  'PATH',
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+  'TMPDIR',
+  'TEMP',
+  'TMP',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'LC_MESSAGES',
+  'TERM',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_CACHE_HOME',
+  'XDG_RUNTIME_DIR',
+  // Windows home / login-config location (`USERPROFILE\.grok\cli-config.json`)
+  'USERPROFILE',
+  'HOMEDRIVE',
+  'HOMEPATH',
+  'SystemRoot',
+  'ComSpec',
+  'APPDATA',
+  'LOCALAPPDATA',
+] as const;
+
+/** Build an allowlisted env for the Grok Agent subprocess (no API keys or unrelated secrets). */
+export function subprocessEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of GROK_SUBPROCESS_ENV_KEYS) {
+    const value = process.env[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+/** Parse `--print --output-format json` stdout into assistant text and session id. */
+export function parseGrokStdout(stdout: string): GrokRunResult {
+  const trimmed = stdout.trim();
+  let text = '';
+  let sessionId: string | undefined;
+  let sawResult = false;
+
+  // Prefer a single pretty-printed JSON object (whole buffer) before NDJSON lines.
+  if (trimmed) {
+    try {
+      const whole = JSON.parse(trimmed) as Record<string, unknown>;
+      const extracted = extractResultFields(whole);
+      if (extracted) {
+        return {
+          text: extracted.text,
+          sessionId: extracted.sessionId,
+          usage: { inputTokens: 0, outputTokens: 0 },
+        };
+      }
+    } catch (err) {
+      if (isGrokHardFail(err)) throw err;
+      // fall through to line-based parse
+    }
+  }
+
+  const lines = trimmed
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  for (const line of lines) {
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const extracted = extractResultFields(obj);
+    if (extracted) {
+      text = extracted.text;
+      sessionId = extracted.sessionId ?? sessionId;
+      sawResult = true;
+    }
+  }
+
+  if (!sawResult && !text && lines.length) {
+    // Fallback: last parseable JSON line with a string result field
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const obj = JSON.parse(lines[i]!) as Record<string, unknown>;
+        if (typeof obj.result === 'string') {
+          assertNoNativeMutation(obj);
+          text = obj.result;
+          if (typeof obj.session_id === 'string') sessionId = obj.session_id;
+          sawResult = true;
+          break;
+        }
+      } catch (err) {
+        if (isGrokHardFail(err)) throw err;
+        continue;
+      }
+    }
+  }
+
+  if (!sawResult && trimmed) {
+    throw new Error(
+      `grok: could not parse Grok Agent output as JSON — raw stdout: ${trimmed.slice(0, 500)}`,
+    );
+  }
+
+  // Official Grok JSON schema does not expose token usage; callers see zeros.
+  return { text, sessionId, usage: { inputTokens: 0, outputTokens: 0 } };
+}
+
+function extractResultFields(
+  obj: Record<string, unknown>,
+): { text: string; sessionId?: string } | null {
+  assertNoNativeMutation(obj);
+  const type = typeof obj.type === 'string' ? obj.type.toLowerCase() : '';
+  if (type === 'result' || typeof obj.result === 'string') {
+    if (obj.is_error === true) {
+      throw new Error(typeof obj.result === 'string' ? obj.result : 'Grok Agent returned an error result');
+    }
+    if (typeof obj.result === 'string') {
+      return {
+        text: obj.result,
+        ...(typeof obj.session_id === 'string' ? { sessionId: obj.session_id } : {}),
+      };
+    }
+  }
+  return null;
+}
+
+function isGrokHardFail(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.message.includes('reasoning-only invariant') ||
+      err.message.includes('Grok Agent returned an error') ||
+      err.message.startsWith('grok:'))
+  );
+}
+
+function assertNoNativeMutation(obj: Record<string, unknown>): void {
+  const type = typeof obj.type === 'string' ? obj.type.toLowerCase() : '';
+  if (NATIVE_MUTATION_TYPES.has(type)) {
+    throw new Error(
+      `grok: Grok Agent emitted native tool event "${obj.type}" — reasoning-only invariant violated. Refusing to continue.`,
+    );
+  }
+  const subtype = typeof obj.subtype === 'string' ? obj.subtype.toLowerCase() : '';
+  if (subtype && NATIVE_SUBTYPE_RE.test(subtype) && type !== 'result') {
+    throw new Error(
+      `grok: Grok Agent output subtype "${obj.subtype}" (line type "${obj.type ?? ''}") suggests native execution — reasoning-only invariant violated.`,
+    );
+  }
+}
+
+/** Default subprocess runner: invokes `agent` (or `COPPERHEAD_GROK_PATH`) in plan mode. */
+export async function defaultGrokRun(args: GrokRunArgs): Promise<GrokRunResult> {
+  const bin = process.env.COPPERHEAD_GROK_PATH || 'grok';
+  const fullPrompt = [args.systemPrompt, args.prompt].filter(Boolean).join('\n\n---\n\n');
+  
+  // Create a temporary file for the prompt to avoid stdin/argv limits.
+  const promptFile = path.join(os.tmpdir(), `copperhead-grok-prompt-${Date.now()}.txt`);
+  const fs = await import('node:fs/promises');
+  await fs.writeFile(promptFile, fullPrompt);
+
+  const cmdArgs = [
+    '--output-format',
+    'json',
+    '--permission-mode',
+    'plan',
+    '--cwd',
+    args.workspace,
+    '--prompt-file',
+    promptFile,
+  ];
+  if (args.model) cmdArgs.push('--model', args.model);
+  if (args.resume) cmdArgs.push('--resume', args.resume);
+
+  let stdout: string;
+  try {
+    const res = await execa(bin, cmdArgs, {
+      env: args.env ?? subprocessEnv(),
+      cancelSignal: args.signal,
+      reject: true,
+      maxBuffer: 50 * 1024 * 1024,
+    });
+    stdout = res.stdout;
+  } finally {
+    await fs.unlink(promptFile).catch(() => {});
+  }
+  return parseGrokStdout(stdout);
+}
+
+function isAuthError(err: unknown): boolean {
+  // Subprocess failures use exitCode, not HTTP status. Only treat real HTTP
+  // status fields as 401/403; otherwise match the CLI's auth message.
+  const status =
+    (err as { status?: number; statusCode?: number })?.status ??
+    (err as { statusCode?: number })?.statusCode;
+  if (status === 401 || status === 403) return true;
+  const m = ((err as Error)?.message ?? '').toLowerCase();
+  return /unauthenticat|unauthoriz|not logged in|please log in|login required|agent login/.test(m);
+}
+
+function authHint(detail: string): string {
+  return (
+    'grok is not authenticated: run `agent login` and verify with `agent status`. ' +
+    `Set COPPERHEAD_GROK_PATH if the CLI is not on PATH (original error: ${detail})`
+  );
+}
+
+function enhanceCliError(err: unknown): Error {
+  const original = err as Error & { code?: string; exitCode?: number };
+  if (original.code === 'ENOENT') {
+    return new Error(
+      'Grok Agent CLI not found on PATH. Install Grok Agent or set COPPERHEAD_GROK_PATH to the `agent` binary.',
+      { cause: err },
+    );
+  }
+  if (original.message?.includes('reasoning-only invariant')) return original;
+  return new Error(`Grok CLI provider failed: ${original.message}`, { cause: err });
+}

--- a/src/agent/providers/grok.ts
+++ b/src/agent/providers/grok.ts
@@ -1,20 +1,10 @@
-import { mkdtemp, rm, utimes } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm, utimes, writeFile, unlink } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { execa } from 'execa';
 import type { ChatOpts, Msg, Provider, ToolSchema, Turn } from '../types.js';
 import { parseToolCalls, renderConversation, renderDelta, renderToolProtocol } from './tool-protocol.js';
-
-/**
- * Saved-login provider: drives the Grok Agent CLI (`agent` / `grok-agent`) with
- * `agent login` authentication. Reasoning-only: plan mode, sandbox, isolated
- * workspace, JSON tool protocol (see `add-grok-cli-provider`).
- *
- * Session resume is opt-in and mutually exclusive with the response cache (same
- * rule as claude-code): the cache can replay turns a resumed CLI session never
- * saw, which desyncs history. `makeProvider` enables resume only when the cache
- * is off.
- */
 
 export interface GrokRunArgs {
   prompt: string;
@@ -67,7 +57,7 @@ export class GrokProvider implements Provider {
      * the cache is off.
      */
     private readonly sessionResume = false,
-  ) {}
+  ) { }
 
   async chat(messages: Msg[], tools: ToolSchema[], opts: ChatOpts = {}): Promise<Turn> {
     const system = messages
@@ -141,12 +131,12 @@ export class GrokProvider implements Provider {
     if (!this.cwdPromise) this.cwdPromise = mkdtemp(path.join(os.tmpdir(), 'copperhead-grok-'));
     const cwd = await this.cwdPromise;
     const now = new Date();
-    await utimes(cwd, now, now).catch(() => {});
+    await utimes(cwd, now, now).catch(() => { });
     return cwd;
   }
 }
 
-/** Minimal env passed to the Grok CLI subprocess (saved login via `agent login`). */
+/** Minimal env passed to the Grok CLI subprocess (saved login via `grok login`). */
 const GROK_SUBPROCESS_ENV_KEYS = [
   'PATH',
   'HOME',
@@ -185,11 +175,12 @@ export function subprocessEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
-/** Parse `--print --output-format json` stdout into assistant text and session id. */
+
 export function parseGrokStdout(stdout: string): GrokRunResult {
   const trimmed = stdout.trim();
   let text = '';
   let sessionId: string | undefined;
+  let usage = { inputTokens: 0, outputTokens: 0 };
   let sawResult = false;
 
   // Prefer a single pretty-printed JSON object (whole buffer) before NDJSON lines.
@@ -201,7 +192,7 @@ export function parseGrokStdout(stdout: string): GrokRunResult {
         return {
           text: extracted.text,
           sessionId: extracted.sessionId,
-          usage: { inputTokens: 0, outputTokens: 0 },
+          usage: extracted.usage ?? usage,
         };
       }
     } catch (err) {
@@ -226,6 +217,9 @@ export function parseGrokStdout(stdout: string): GrokRunResult {
     if (extracted) {
       text = extracted.text;
       sessionId = extracted.sessionId ?? sessionId;
+      if (extracted.usage) {
+        usage = extracted.usage;
+      }
       sawResult = true;
     }
   }
@@ -261,8 +255,24 @@ export function parseGrokStdout(stdout: string): GrokRunResult {
 
 function extractResultFields(
   obj: Record<string, unknown>,
-): { text: string; sessionId?: string } | null {
+): { text: string; sessionId?: string; usage?: { inputTokens: number; outputTokens: number } } | null {
   assertNoNativeMutation(obj);
+
+  if (typeof obj.text === 'string') {
+    let inputTokens = 0;
+    let outputTokens = 0;
+    if (obj.usage && typeof obj.usage === 'object') {
+      const u = obj.usage as Record<string, unknown>;
+      inputTokens = typeof u.prompt_tokens === 'number' ? u.prompt_tokens : (typeof u.inputTokens === 'number' ? u.inputTokens : 0);
+      outputTokens = typeof u.completion_tokens === 'number' ? u.completion_tokens : (typeof u.outputTokens === 'number' ? u.outputTokens : 0);
+    }
+    return {
+      text: obj.text,
+      ...(typeof obj.sessionId === 'string' ? { sessionId: obj.sessionId } : {}),
+      usage: { inputTokens, outputTokens },
+    };
+  }
+
   const type = typeof obj.type === 'string' ? obj.type.toLowerCase() : '';
   if (type === 'result' || typeof obj.result === 'string') {
     if (obj.is_error === true) {
@@ -302,15 +312,14 @@ function assertNoNativeMutation(obj: Record<string, unknown>): void {
   }
 }
 
-/** Default subprocess runner: invokes `agent` (or `COPPERHEAD_GROK_PATH`) in plan mode. */
+/** Default subprocess runner: invokes `grok` (or `COPPERHEAD_GROK_PATH`) in plan mode. */
 export async function defaultGrokRun(args: GrokRunArgs): Promise<GrokRunResult> {
   const bin = process.env.COPPERHEAD_GROK_PATH || 'grok';
   const fullPrompt = [args.systemPrompt, args.prompt].filter(Boolean).join('\n\n---\n\n');
-  
+
   // Create a temporary file for the prompt to avoid stdin/argv limits.
-  const promptFile = path.join(os.tmpdir(), `copperhead-grok-prompt-${Date.now()}.txt`);
-  const fs = await import('node:fs/promises');
-  await fs.writeFile(promptFile, fullPrompt);
+  const promptFile = path.join(os.tmpdir(), `copperhead-grok-prompt-${randomUUID()}.txt`);
+  await writeFile(promptFile, fullPrompt);
 
   const cmdArgs = [
     '--output-format',
@@ -335,7 +344,7 @@ export async function defaultGrokRun(args: GrokRunArgs): Promise<GrokRunResult> 
     });
     stdout = res.stdout;
   } finally {
-    await fs.unlink(promptFile).catch(() => {});
+    await unlink(promptFile).catch(() => { });
   }
   return parseGrokStdout(stdout);
 }
@@ -353,7 +362,7 @@ function isAuthError(err: unknown): boolean {
 
 function authHint(detail: string): string {
   return (
-    'grok is not authenticated: run `agent login` and verify with `agent status`. ' +
+    'grok is not authenticated: run `grok login` and verify with `grok status`. ' +
     `Set COPPERHEAD_GROK_PATH if the CLI is not on PATH (original error: ${detail})`
   );
 }

--- a/src/agent/transcript.ts
+++ b/src/agent/transcript.ts
@@ -13,7 +13,8 @@ export type ExitPath =
   | 'commit-failed'
   | 'provider-error'
   | 'session-limit'
-  | 'stalled';
+  | 'stalled'
+  | 'running';
 
 /** Post-run addenda recorded at every terminal branch (AC-8.5). */
 export interface RunStats {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -21,6 +21,8 @@ export interface Turn {
   text: string | null;
   toolCalls: ToolCall[];
   usage: { inputTokens: number; outputTokens: number };
+  cacheHit?: boolean;
+  stopReason?: string;
   /**
    * A one-line steer for a turn that produced NO tool call but clearly *intended*
    * one — e.g. a fenced ```json block that names a real tool yet fails to parse

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { execa } from 'execa';
 import { existsSync } from 'node:fs';
 import { readFile, mkdir, writeFile, readdir } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
@@ -416,6 +417,7 @@ interface StageCost {
   tokensIn: number;
   tokensOut: number;
   cacheHits: number;
+  status?: 'running' | 'stalled';
 }
 
 /** Quote a path/value for a copy-pasteable resume command (5.3). */
@@ -582,6 +584,7 @@ async function writeRunReport(opts: CreateOptions, stageCosts: StageCost[]): Pro
       tokensOut: c.tokensOut,
       cacheHits: c.cacheHits,
       cacheHitPct: c.resumed ? null : cachePct(c.cacheHits, c.turns),
+      status: c.resumed ? 'resumed' : c.status ?? 'ran',
     })),
     total: { ...t, cacheHitPct: cachePct(t.cacheHits, t.turns) },
     slowestStage: slowest ? { name: slowest.name, wallMs: slowest.wallMs } : null,
@@ -607,7 +610,7 @@ async function writeRunReport(opts: CreateOptions, stageCosts: StageCost[]): Pro
             fmtTokens(c.tokensIn),
             fmtTokens(c.tokensOut),
             `${cachePct(c.cacheHits, c.turns)}%`,
-            'ran',
+            c.status ?? 'ran',
           ]),
     ),
     row([
@@ -700,7 +703,9 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
     // Cost accumulates across all attempts of the stage, so a stage that took a
     // retry to complete shows its true total in the summary (5.2).
     const stageStart = Date.now();
-    const cost: StageCost = { name: stage.name, resumed: false, wallMs: 0, turns: 0, tokensIn: 0, tokensOut: 0, cacheHits: 0 };
+    const cost: StageCost = { name: stage.name, resumed: false, wallMs: 0, turns: 0, tokensIn: 0, tokensOut: 0, cacheHits: 0, status: 'running' };
+    stageCosts.push(cost);
+    await writeRunReport(opts, stageCosts);
     for (let attempt = 1; ; attempt++) {
       // Re-scaffold before every attempt, not just once per stage. A previous
       // attempt that failed at the commit gate rolls the tree back
@@ -748,6 +753,10 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
       cost.tokensIn += res.stats?.tokensIn ?? 0;
       cost.tokensOut += res.stats?.tokensOut ?? 0;
       cost.cacheHits += res.cacheHits ?? 0;
+      cost.wallMs = Date.now() - stageStart;
+      cost.status = res.exitPath === 'stalled' ? 'stalled' : 'running';
+      await writeRunReport(opts, stageCosts);
+      
       stageTranscriptDir = res.transcriptDir; // last attempt's run dir (for SVG artifacts / report)
 
       // A successful run is not the same as a completed stage: an agent can
@@ -808,8 +817,8 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
       guidance = diagnosis.guidance ?? `The previous attempt failed: ${failure}. ${diagnosis.reason}`;
     }
 
+    cost.status = undefined; // marks as 'ran' upon completion/failure exits
     cost.wallMs = Date.now() - stageStart;
-    stageCosts.push(cost);
 
     if (!stageDone) {
       logResumePoint(opts, stage, i);
@@ -818,6 +827,17 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
       return { ok: false, completed };
     }
     completed.push(stage.name);
+    
+    // The successful runAgentLoop created a commit. Amend it to include the run artifacts.
+    try {
+      if (stageTranscriptDir) {
+        await execa('git', ['add', '-f', stageTranscriptDir, path.join(opts.repoRoot, '.copperhead/runs/REPORT.md'), path.join(opts.repoRoot, '.copperhead/runs/report.json')], { cwd: opts.repoRoot });
+        await execa('git', ['commit', '--amend', '--no-edit', '--no-verify'], { cwd: opts.repoRoot });
+      }
+    } catch (err) {
+      opts.log(`warning: could not amend stage commit with run artifacts (${(err as Error).message})`);
+    }
+
     await renderStageArtifacts(opts, stage.name, stageTranscriptDir);
     await emitJlcpcbAfterOutputs(stage.name, opts);
     logCumulative(opts, stageCosts);

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -703,10 +703,11 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
     // Cost accumulates across all attempts of the stage, so a stage that took a
     // retry to complete shows its true total in the summary (5.2).
     const stageStart = Date.now();
-    const cost: StageCost = { name: stage.name, resumed: false, wallMs: 0, turns: 0, tokensIn: 0, tokensOut: 0, cacheHits: 0, status: 'running' };
+    const cost: StageCost = { name: stage.name, resumed: false, wallMs: 0, turns: 0, tokensIn: 0, tokensOut: 0, cacheHits: 0 };
     stageCosts.push(cost);
-    await writeRunReport(opts, stageCosts);
     for (let attempt = 1; ; attempt++) {
+      cost.status = 'running';
+      await writeRunReport(opts, stageCosts);
       // Re-scaffold before every attempt, not just once per stage. A previous
       // attempt that failed at the commit gate rolls the tree back
       // (restore(): `git reset --hard` + `git clean -fd`), which deletes the
@@ -828,6 +829,9 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
     }
     completed.push(stage.name);
     
+    await writeRunReport(opts, stageCosts);
+    await renderStageArtifacts(opts, stage.name, stageTranscriptDir);
+
     // The successful runAgentLoop created a commit. Amend it to include the run artifacts.
     try {
       if (stageTranscriptDir) {
@@ -838,7 +842,6 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
       opts.log(`warning: could not amend stage commit with run artifacts (${(err as Error).message})`);
     }
 
-    await renderStageArtifacts(opts, stage.name, stageTranscriptDir);
     await emitJlcpcbAfterOutputs(stage.name, opts);
     logCumulative(opts, stageCosts);
   }


### PR DESCRIPTION
## What

Adds `GrokProvider` to integrate the official `grok-build` CLI as an AI provider in Copperhead.

## Why

Fixes chouhanindustries/copperhead#146

Users who have `grok` installed and authenticated (`grok login`) can now use it to drive Copperhead by passing `--model grok`.

## Design

- `src/agent/providers/grok.ts`: Wraps `grok` execution. It writes the prompt to a temporary file (`--prompt-file`) to bypass arguments limits and uses `--output-format json` with `--permission-mode plan` for a strict reasoning-only environment (no native `grok` tool execution).
- `src/agent/loop.ts`: Maps `--model grok` to the `GrokProvider`.

## Spec / OpenSpec

N/A - This is purely a new provider implementation and does not change spec-level structural invariants.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | Pass |
| Build | `npm run build` | Pass |
| Unit + offline | `npm test` | Pass |
| Live-LLM (opt-in) | N/A | Pass |

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): `edit`
- Commands run and outcome:

```text
$ grok login
$ node dist/cli.js do "say hello" --model grok
  ...
  (rate limits or outputs successfully depending on account tier)
```

## Docs

N/A

---

## Invariant checklist

- [x] **Spec-gated in**: Gated by omission; `grok` is run in `plan` mode which ensures it cannot execute tools on its own.
- [ ] **Verification-gated out**: N/A
- [ ] **`check`/`verify` stays LLM-free and network-free**: N/A
- [x] **No sexp serialization**: N/A
- [ ] **Sync-obligations ledger**: N/A
- [x] **Secrets**: `grok` manages its own authentication via `grok login`; no API keys are logged or passed by Copperhead.
- [ ] **Spec coherence**: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grok as a supported model/provider, including Grok saved-login setup.
  * Improved execution reporting with more precise per-stage status tracking (running, stalled, resumed, completed) and better preservation of transcripts/reports.
* **Bug Fixes**
  * Improved reliability of metrics persistence, now safely flushed on both success and failure paths.
  * Enhanced Grok parsing/validation and clearer Grok-related error messages (including auth and unsupported operations).
  * Improved transcript telemetry, recording richer, consistent per-call details and tool-call outcomes.
* **Documentation**
  * Updated CLI and configuration references to list Grok and its routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->