### PR TITLE
fix(create): escalate the turn budget after a turn-starved stage attempt

### DIFF
--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -176,16 +176,23 @@ Exit code 2 is the important one. A requirement violation means the as-built des
 The full pipeline from a product brief to the output package.
 
 ```bash
-copperhead create --brief brief.md [--model <model>] [--interactive]
+copperhead create --brief brief.md [--model <model>] [--max-turns <n>] [--interactive]
 ```
 
 | Option | Description |
 | --- | --- |
 | `--brief <file>` | **Required.** The product brief, in markdown. |
 | `--model <model>` | `codex`, `cursor`, `gpt-5`, `claude`, or `claude-code` (saved-login; no model API key for those three). |
+| `--max-turns <n>` | Turn budget per stage. A `stageMaxTurns` entry in [config](/reference/configuration/) still wins for the stage it names. |
 | `--interactive` | Re-enable the human gates: spec approval, and a pause before export. |
 
 Exits 1 if any stage fails to complete, 0 when the pipeline finishes.
+
+### Turn budgets
+
+Each stage resolves its budget in this order: `stageMaxTurns[stage]` from config, then `--max-turns`, then the built-in per-stage defaults (`schematic` 100, `layout` 80), then the global `maxTurns`.
+
+A stage attempt that runs out of turns is not retried at the budget that just proved too small: the next attempt gets half again as many turns (40, then 60, then 90 on the default budget), and the raise is printed as its own line. Any other kind of failure retries unchanged. When every attempt ran out of turns, the pipeline says so and names the two settings that fix it, instead of leaving you to infer it from three identical failures.
 
 ### Pipeline stages
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -30,6 +30,7 @@ Written by `copperhead init`. Every key is optional; the defaults below apply wh
 | `docs` | `"docs/"` | The design docs directory: [docs-as-memory](/concepts/docs-as-memory/). |
 | `model` | `null` | Default model. Overridden by `--model` and `COPPERHEAD_MODEL`. |
 | `maxTurns` | `40` | Turn budget per run. |
+| `stageMaxTurns` | unset | Per-stage turn budgets for `create`, keyed by stage name. Highest precedence of all: it beats `create --max-turns` for the stage it names. |
 | `maxRepairCycles` | `5` | ERC/DRC repair attempts before the run rolls back to the git snapshot. |
 | `budgets` | `{}` | Free-form hard constraints, surfaced verbatim into every run's system prompt. |
 | `baseURL` | unset | Base URL of an OpenAI-compatible endpoint. Read **only** by the `compat` model route. |

--- a/openspec/changes/escalate-stage-turn-budget/design.md
+++ b/openspec/changes/escalate-stage-turn-budget/design.md
@@ -1,0 +1,60 @@
+# Design: escalate-stage-turn-budget
+
+## Context
+
+`runCreate` (`src/commands/create.ts`) reads the stage's turn budget once per stage, outside the attempt loop, and hands the same number to every attempt. `runAgentLoop` (`src/agent/loop.ts`) already records how a run ended as a machine-readable `exitPath` on `RunResult`, and `RunOptions.maxTurns` already accepts a per-run budget, so nothing new has to be measured: the failure is that the pipeline never reads the field it is already given.
+
+The attended escape hatch from issue #15 lives in `budgetContinuePrompt()` in `src/cli.ts`, which offers `budgetExtraTurns` (`ceil(originalBudget / 2)`) more turns when the budget runs out.
+
+Inherited constraints from SPEC.md that shape the decisions below:
+
+- Verification-gated out: no mutation is done until ERC (and DRC if the board changed) passes; a failed stage attempt rolls the tree back to the snapshot. A retry that walls at the same place therefore costs a full rollback, not just tokens.
+- `check` stays LLM-free and network-free; nothing here touches its module graph.
+- Recovery must fail safe toward reporting to the human rather than looping (`diagnoseStageFailure` resolves any error or ambiguity to `abort`).
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A stage that dies of turn starvation is never retried at the same budget.
+- The one failure mode whose remedy is arithmetic is decided by arithmetic, not by a model call.
+- A create run can be given a realistic budget from the command line, without a config round trip.
+- A piped or redirected run keeps the attended escape hatch.
+
+**Non-Goals**
+
+- Per-stage token or wall-clock budgets, edit-size caps, verify gating between edits, checkpoint commits, and turn-cost concentration metrics: separate changes (issues #141, #145).
+- Anything about layout quality.
+- Changing what a non-attended run does on exhaustion. With no stdin TTY it still fails and restores.
+- Automatic budget tuning from historical runs. The numbers here are defaults, not a model.
+
+## Decisions
+
+### D1: Escalate on the exit path, not on the supervisor's opinion
+
+`turn-budget-exhausted` is already a machine-readable field on `RunResult`, so the escalation is deterministic in `runCreate`: remember the previous attempt's `exitPath`, and when it was `turn-budget-exhausted` give the next attempt `previous + budgetExtraTurns({ maxTurns: previous })` turns. That reuses the increment the attended prompt already offers, so an attended and an unattended run escalate identically, and it produces 40 → 60 → 90 across the three attempts the default `maxStageRetries: 2` allows.
+
+The supervisor still runs, but it is now told the structured cause and the escalation that is already scheduled. Rejected alternative: a third verdict (`retry-with-more-turns`). It puts a deterministic arithmetic decision behind a model call that fails safe to `abort`, which is exactly the failure the issue describes: a stage dying for want of turns and a supervisor with no way to say so.
+
+The escalation is announced on its own stage line (`raising the next attempt's budget 40 → 60`) rather than folded into the existing failure line, because the raise is a decision the pipeline made, not a description of what went wrong, and an operator scanning a long log needs to see it as an event.
+
+### D2: Turn-budget resolution has four levels, and config still wins per stage
+
+`stageMaxTurns[stage]` (config) > `--max-turns` (flag) > `DEFAULT_STAGE_MAX_TURNS[stage]` (built-in) > `maxTurns` (config/global). The flag sits *under* the per-stage config entry because issue #135 defines it as "the per-stage cap that `stageMaxTurns` still overrides per stage": a user who has tuned one stage in config should not lose that tuning by passing a global flag. This inverts the usual flag-beats-config direction, so it is spelled out in the flag's own help text.
+
+`DEFAULT_STAGE_MAX_TURNS` is `{ schematic: 100, 'layout-draft': 80 }`, the numbers `manual-tests/setup.sh` already uses, promoted from a test-only workaround into the product default: the repo has documented 40 as inadequate for those stages for months, and only sandbox repos were getting the fix.
+
+The resolver returns a concrete number for every stage rather than `undefined` for "let the loop decide". Escalation needs a budget to escalate *from*, and a stage whose budget is only implicit cannot report the one it ran under. The visible consequence is that `create` now always passes `maxTurns` to `runAgentLoop`; the value for an untuned stage is the same `config.maxTurns` the loop would have defaulted to.
+
+### D3: The continue prompt needs a TTY to *ask on*, not a TTY to *print to*
+
+`budgetContinuePrompt()` required both `stdin.isTTY` and `stdout.isTTY`. Only the first is load-bearing: with stdin attached, the question can be asked on stderr, which `> file` and `| tee` leave alone. So the gate becomes `stdin.isTTY` alone and the readline interface writes to stderr whenever stdout is not a TTY. Fully unattended runs (no stdin TTY, i.e. CI) keep fail-and-restore unchanged, by construction rather than by convention: no TTY, no callback, and the loop's existing no-callback path runs.
+
+`confirmTty` and `budgetContinuePrompt` move from `src/cli.ts` to `src/util/cli-args.ts`. `cli.ts` parses argv at import time, so importing it to test a branch runs the program; `cli-args.ts` exists precisely for the CLI logic that has a branch worth pinning. `budgetContinuePrompt` takes its three streams as a parameter defaulting to `process`, which is what lets the piped case be driven with real `PassThrough` streams in a unit test rather than asserted from the outside.
+
+## Risks / Trade-offs
+
+- **A raised budget is a raised bill.** Three escalating attempts at 40/60/90 turns cost more than three at 40 before the pipeline gives up. That is the intended trade (the alternative is three guaranteed-futile attempts), and the give-up line now names the remedy so the operator does not spend the next run rediscovering it. `maxStageRetries: 0` still disables retries entirely.
+- **Raising the built-in defaults changes what an existing repo does.** A repo with no `stageMaxTurns` gets 100 turns for `schematic` where it got 40, so a stage that used to wall at 40 may now run more than twice as long before failing. Explicit config and the new flag both override it.
+- **Escalating from the previous budget compounds.** Each raise is half again the last, so a hypothetical fourth attempt would ask for 135. With `maxStageRetries` defaulting to 2 there is no fourth attempt; a user who raises the retry count is choosing that growth.
+- **stderr now carries an interactive question.** A run whose stderr is also redirected loses the prompt again, and a run that redirects stderr while watching stdout will see the answer echoed nowhere. Both are strictly better than today's behaviour, where any stdout redirection removed the prompt.

--- a/openspec/changes/escalate-stage-turn-budget/proposal.md
+++ b/openspec/changes/escalate-stage-turn-budget/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: escalate-stage-turn-budget
+
+## Why
+
+A `create` stage that fails with `turn-budget-exhausted` is retried with exactly the turn budget that just proved insufficient (GitHub issue #135). With the default `maxStageRetries: 2` the schematic stage can run three times at 40 turns, roll back three times, and end no closer than it started. The recovery supervisor cannot compensate: it sees the failure only as the prose string `the run ended as "failure" (turn-budget-exhausted)`, so it cannot tell turn starvation from a bad edit, and its verdicts are limited to `retry` and `abort`. Turn starvation is the one failure mode where an identical retry is knowably futile.
+
+## What Changes
+
+- A stage attempt that exits `turn-budget-exhausted` escalates the next attempt's budget by `ceil(previous / 2)`, the same increment the attended continue prompt already offers, so three attempts on the default budget run at 40, 60 and 90 turns. Every other exit path retries at the unchanged budget.
+- The recovery supervisor is handed the failed attempt's `exitPath` as a structured line, plus the budget the next attempt has already been granted, so it stops guessing the cause from prose. Its verdict set is unchanged: escalation stays deterministic arithmetic in the pipeline, not a model call that fails safe to `abort`.
+- When every attempt of a stage ran out of turns, the stage's final line says the stage needs a larger budget and names both places that set one.
+- `copperhead create` gains `--max-turns <n>`, parsed by the same validator `do`, `sync` and `repl` use. Until now the only way to give a create stage a realistic budget was to hand-edit `stageMaxTurns` into `.copperhead/config.json` before the run.
+- Built-in per-stage defaults (`schematic: 100`, `layout-draft: 80`) promote the numbers `manual-tests/setup.sh` has been setting for create sandboxes (with a comment saying 40 is inadequate) into the product default. Resolution order: `stageMaxTurns[stage]` > `--max-turns` > built-in default > global `maxTurns`.
+- The attended budget-exhaustion prompt now gates on `stdin.isTTY` alone and asks on stderr when stdout is not a TTY, so a `| tee run.log` run keeps its escape hatch. No stdin TTY (CI) still means fail-and-restore.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `create-pipeline`: turn-budget escalation between stage attempts, the structured exit path handed to the recovery supervisor, and built-in per-stage turn defaults with a four-level resolution order.
+- `cli-surface`: `create --max-turns <n>`; the attended budget-exhaustion prompt fires on a stdin TTY alone and asks on stderr when stdout is redirected.
+
+## Impact
+
+- `src/commands/create.ts`: `DEFAULT_STAGE_MAX_TURNS`, `resolveStageMaxTurns`, per-attempt budget escalation, the give-up remedy line, `CreateOptions.maxTurns`, and the resume command echoing the flag.
+- `src/agent/recovery.ts`: `diagnoseStageFailure` accepts `exitPath` and `nextAttemptMaxTurns` and renders both as structured prompt lines.
+- `src/util/cli-args.ts`: `confirmTty` gains output and input stream parameters; `budgetContinuePrompt` moves here (out of the argv-parsing entry point, so it is testable in process) and gates on stdin alone.
+- `src/cli.ts`: `create --max-turns`, wired through the shared helpers.
+- Tests: `test/create-budget-escalation.test.ts` (new), plus additions to `test/recovery.test.ts` and `test/cli-surface.test.ts`. No live-LLM tests required.
+- Out of scope, tracked separately: per-stage token and wall budgets, edit-size caps, verify gating, checkpoint commits, turn-cost concentration metrics, and layout draft-quality scoring (issues #141 and #145).

--- a/openspec/changes/escalate-stage-turn-budget/specs/cli-surface/spec.md
+++ b/openspec/changes/escalate-stage-turn-budget/specs/cli-surface/spec.md
@@ -1,0 +1,46 @@
+# cli-surface delta spec
+
+## ADDED Requirements
+
+### Requirement: `create` accepts a turn budget
+
+`copperhead create` SHALL accept `--max-turns <n>`, validated as a positive
+integer with the same parser the other commands use, and SHALL apply it as the
+per-stage turn budget. A `stageMaxTurns` entry in config SHALL still override it
+for that stage.
+
+#### Scenario: Flag sets the budget for stages without a config entry
+
+- **WHEN** `copperhead create --brief b.md --max-turns 120` runs in a repo with no `stageMaxTurns`
+- **THEN** every stage runs with a 120-turn budget
+
+#### Scenario: Bad value refuses to start
+
+- **WHEN** `--max-turns 5oops` is passed
+- **THEN** the command exits non-zero with a message naming the flag, before any provider call
+
+## MODIFIED Requirements
+
+### Requirement: Attended budget-exhaustion prompt
+
+When the turn budget runs out, a run whose **stdin** is a TTY SHALL ask whether to
+continue, showing turns used, token usage, files touched, and open obligations, and
+SHALL grant `ceil(originalBudget / 2)` more turns on acceptance. The question SHALL
+be written to stderr whenever stdout is not a TTY, so a piped or redirected run
+keeps the escape hatch. A run with no TTY on stdin (CI) SHALL keep fail-and-restore
+behaviour unchanged.
+
+#### Scenario: A piped run still gets asked
+
+- **WHEN** `copperhead create --brief b.md | tee run.log` exhausts a stage's budget with stdin attached to a terminal
+- **THEN** the continue question appears on stderr and answering `y` grants more turns
+
+#### Scenario: An attended run keeps asking on stdout
+
+- **WHEN** both stdin and stdout are TTYs
+- **THEN** the question appears on stdout as before
+
+#### Scenario: CI is unattended
+
+- **WHEN** stdin is not a TTY
+- **THEN** budget exhaustion fails and restores without asking

--- a/openspec/changes/escalate-stage-turn-budget/specs/create-pipeline/spec.md
+++ b/openspec/changes/escalate-stage-turn-budget/specs/create-pipeline/spec.md
@@ -1,0 +1,74 @@
+# create-pipeline delta spec
+
+## ADDED Requirements
+
+### Requirement: Turn budget escalates after budget exhaustion
+
+When a create-pipeline stage attempt ends with exit path `turn-budget-exhausted`,
+the pipeline SHALL raise the next attempt's turn budget by `ceil(previous / 2)`,
+where `previous` is the budget that attempt just ran under, and SHALL log the
+raise on its own stage line. Attempts that end by any other exit path SHALL retry
+at the unchanged budget. When every attempt of the stage ended
+`turn-budget-exhausted`, the stage's final message SHALL name the budget the
+stage would need and the two places that set it.
+
+#### Scenario: Second attempt gets more turns
+
+- **WHEN** the schematic stage resolves a 40-turn budget and its first attempt exits `turn-budget-exhausted`
+- **THEN** the second attempt runs with 60 turns and the third with 90
+
+#### Scenario: The raise is visible
+
+- **WHEN** an attempt is escalated
+- **THEN** a stage line states the previous and the next budget
+
+#### Scenario: Other failures do not escalate
+
+- **WHEN** a stage attempt exits `provider-error` or finishes without meeting its completion contract
+- **THEN** the next attempt runs with the same budget as the one before it
+
+#### Scenario: Exhausting every attempt names the remedy
+
+- **WHEN** every attempt of a stage exits `turn-budget-exhausted`
+- **THEN** the stage's final log line states that the stage needs a larger budget and names `--max-turns` and `stageMaxTurns`
+
+### Requirement: Stage failure diagnosis receives the structured exit path
+
+`create` SHALL pass the failed attempt's `exitPath` to the recovery supervisor as
+a structured field, alongside the prose failure description, and SHALL tell the
+supervisor when a budget escalation is already scheduled for the next attempt.
+The escalation itself SHALL remain deterministic: the supervisor's verdict set
+stays `retry` / `abort` and never decides the budget.
+
+#### Scenario: Budget exhaustion is distinguishable from a bad edit
+
+- **WHEN** the supervisor is asked to diagnose an attempt that exited `turn-budget-exhausted`
+- **THEN** its prompt contains `exitPath: turn-budget-exhausted` and states the budget the next attempt will receive
+
+#### Scenario: No escalation, no budget line
+
+- **WHEN** the supervisor is asked to diagnose an attempt that exited some other way
+- **THEN** its prompt carries that exit path and no next-budget statement
+
+### Requirement: Built-in per-stage turn budgets
+
+The pipeline SHALL apply built-in default turn budgets for the stages known to
+need more than the global default (`schematic`: 100, `layout-draft`: 80). Budget
+resolution precedence SHALL be: `stageMaxTurns[stage]` from config, then the
+`--max-turns` value passed to `create`, then the built-in per-stage default, then
+the global `maxTurns`.
+
+#### Scenario: Schematic stage gets its larger default
+
+- **WHEN** a repo has no `stageMaxTurns` entry and no `--max-turns`
+- **THEN** the schematic stage runs with the built-in default rather than the global `maxTurns`
+
+#### Scenario: Config still overrides the flag per stage
+
+- **WHEN** config sets `stageMaxTurns: {"schematic": 55}` and the run passes `--max-turns 120`
+- **THEN** the schematic stage runs with 55 turns and every other stage with 120
+
+#### Scenario: A stage with no entry anywhere uses the global budget
+
+- **WHEN** the spec-seed stage runs in a repo with no `stageMaxTurns` and no `--max-turns`
+- **THEN** it runs with the config's `maxTurns`

--- a/openspec/changes/escalate-stage-turn-budget/tasks.md
+++ b/openspec/changes/escalate-stage-turn-budget/tasks.md
@@ -1,0 +1,44 @@
+# Tasks
+
+## 1. Budget resolution
+
+- [x] 1.1 `src/commands/create.ts`: export `DEFAULT_STAGE_MAX_TURNS = { schematic: 100, 'layout-draft': 80 }`
+- [x] 1.2 `src/commands/create.ts`: export `resolveStageMaxTurns(stage, config, flagMaxTurns?)` implementing `stageMaxTurns[stage]` > `--max-turns` > built-in default > `config.maxTurns`
+- [x] 1.3 `src/commands/create.ts`: add optional `CreateOptions.maxTurns`; resolve the stage budget through the new helper and always pass it to `runAgentLoop`
+- [x] 1.4 `src/commands/create.ts`: echo `--max-turns` in the printed resume command when the run carried one
+
+## 2. Escalation
+
+- [x] 2.1 `src/commands/create.ts`: track the attempt budget across the per-attempt loop; when the failed attempt's `exitPath` is `turn-budget-exhausted`, raise the next attempt's budget by `budgetExtraTurns({ maxTurns: previous })`
+- [x] 2.2 `src/commands/create.ts`: log the raise on its own stage line (`previous → next`)
+- [x] 2.3 `src/commands/create.ts`: when every attempt exited `turn-budget-exhausted`, print a final line naming the last budget, `--max-turns` and `stageMaxTurns` (on both the retries-exhausted and supervisor-abort paths)
+
+## 3. Structured failure signal
+
+- [x] 3.1 `src/agent/recovery.ts`: `diagnoseStageFailure` accepts optional `exitPath` and `nextAttemptMaxTurns`; renders `exitPath: <value>` and, when escalating, the granted next budget with "budget alone is not a reason to abort"
+- [x] 3.2 `src/commands/create.ts`: thread the failed attempt's `exitPath` and any scheduled next budget through `diagnose(...)`
+- [x] 3.3 Verdict set unchanged (`retry` / `abort`): no new verdict, escalation stays deterministic
+
+## 4. CLI surface
+
+- [x] 4.1 `src/util/cli-args.ts`: move `confirmTty` here and give it output/input stream parameters
+- [x] 4.2 `src/util/cli-args.ts`: move `budgetContinuePrompt` here, gate on `stdin.isTTY` alone, ask on stderr when stdout is not a TTY, streams injectable via `PromptIo`
+- [x] 4.3 `src/cli.ts`: import both from `cli-args`; add `--max-turns <n>` to `create`, parsed with `parseMaxTurns` before any provider or kicad-cli work, threaded as `CreateOptions.maxTurns`
+
+## 5. Tests (all offline)
+
+- [x] 5.1 `test/create-budget-escalation.test.ts`: 40 → 60 → 90 across three turn-starved attempts; each raise logged
+- [x] 5.2 `test/create-budget-escalation.test.ts`: a non-budget exit path retries at the unchanged budget and logs no raise
+- [x] 5.3 `test/create-budget-escalation.test.ts`: the give-up line names the last budget, `--max-turns` and `stageMaxTurns`, and stays absent for non-budget failures
+- [x] 5.4 `test/create-budget-escalation.test.ts`: `exitPath` and `nextAttemptMaxTurns` reach the supervisor; the latter is omitted with no escalation
+- [x] 5.5 `test/create-budget-escalation.test.ts`: full precedence chain, including config `stageMaxTurns` beating `--max-turns`, and the schematic stage getting its built-in 100 through a real run
+- [x] 5.6 `test/recovery.test.ts`: the supervisor prompt contains `exitPath: turn-budget-exhausted` and the next budget; both lines absent when not supplied
+- [x] 5.7 `test/cli-surface.test.ts`: `budgetContinuePrompt` returned with a stdin TTY and a non-TTY stdout, question on stderr; on stdout when both are TTYs; undefined with no stdin TTY
+- [x] 5.8 `test/cli-surface.test.ts`: `create --help` advertises `--max-turns` and a bad value refuses to start
+- [x] 5.9 `test/create-stage-turns.test.ts`: updated for the explicitly resolved global budget
+- [x] 5.10 Full suite green: `npm run typecheck`, `npm run build`, `npm test`, `npm run lint:md`
+
+## 6. Spec coherence
+
+- [x] 6.1 `openspec/specs/SPEC.md`: `create --max-turns` in the CLI surface, the budget precedence chain in the config section, and AC-16 for this change
+- [x] 6.2 `openspec validate escalate-stage-turn-budget` passes

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -255,7 +255,9 @@ copperhead demo [--tour] [--model …] [--dir <path>]
     `demo-runs/usb-c-breakout/` and run the create pipeline against the
     packaged USB-C power breakout brief (same as `npm run demo:simple`).
 
-copperhead create --brief brief.md   # Mode A: full pipeline (§2.5)
+copperhead create --brief brief.md [--max-turns N]   # Mode A: full pipeline (§2.5)
+    --max-turns is the per-stage turn budget; a stageMaxTurns entry in
+    config still wins for the stage it names (§5).
 copperhead init [--path hardware/]
     Detect .kicad_sch/.kicad_pcb, parse symbols/footprints/nets,
     generate docs/ skeleton pre-filled with the real BOM and pinout
@@ -384,7 +386,9 @@ interface Provider {
 }
 ```
 
-`budgets` is free-form; keys are surfaced verbatim into the system prompt so the agent treats them as hard constraints. `stageMaxTurns` is optional: per-stage turn budgets for the create pipeline, keyed by stage name; stages without an entry use `maxTurns`.
+`budgets` is free-form; keys are surfaced verbatim into the system prompt so the agent treats them as hard constraints. `stageMaxTurns` is optional: per-stage turn budgets for the create pipeline, keyed by stage name.
+
+A create stage's turn budget resolves in this order, highest first: `stageMaxTurns[stage]`, then `create --max-turns`, then the built-in per-stage defaults (`schematic: 100`, `layout-draft: 80`), then the global `maxTurns`. The flag sits under the per-stage config entry deliberately: a stage someone has tuned in config must not lose that tuning to a global flag.
 
 ---
 
@@ -492,6 +496,15 @@ Format: Given / When / Then. "Fixture" = the open-telegraph repo (or the tiny te
 - **AC-15.25 / AC-15.26 (drift bootstrap)** Zero-symbol schematics produce no drift mismatches; `check` surfaces a non-failing warning when an empty schematic coexists with a populated BOM.md.
 - **AC-15.27 (consecutive stalls)** Only consecutive tool-less turns count toward the stopped-without-finishing failure; the counter resets on any tool call.
 - **AC-15.28 (load-failure ERC/DRC)** A missing ERC/DRC report raises an error quoting kicad-cli's own output and naming the likely load failure.
+
+### AC-16 · Stage turn-budget escalation (issue #135, change: escalate-stage-turn-budget)
+
+- **AC-16.1 (escalate on starvation only)** A create-stage attempt that exits `turn-budget-exhausted` gives the next attempt `previous + ceil(previous / 2)` turns, so three attempts on the default budget run at 40, 60 and 90; the raise is logged on its own stage line.
+- **AC-16.2 (every other path is unchanged)** An attempt that exits any other way (including a successful run whose completion contract is unmet) retries at the same budget as the one before it.
+- **AC-16.3 (structured cause)** The recovery supervisor's prompt carries `exitPath: <value>` as its own line and, when an escalation is already scheduled, the budget the next attempt will receive plus a statement that the budget alone is not a reason to abort. The verdict set stays `retry`/`abort`; escalation is never a model decision.
+- **AC-16.4 (give-up names the remedy)** When every attempt of a stage exited `turn-budget-exhausted`, the stage's final line says the stage needs a larger budget and names `--max-turns` and `stageMaxTurns`.
+- **AC-16.5 (budget precedence)** A stage's budget resolves as `stageMaxTurns[stage]` > `create --max-turns` > built-in per-stage default (`schematic: 100`, `layout-draft: 80`) > global `maxTurns`; `--max-turns` refuses anything that is not a positive integer, before any provider call.
+- **AC-16.6 (prompt survives a piped stdout)** The attended budget-exhaustion prompt fires whenever stdin is a TTY, asking on stderr when stdout is not, so `| tee run.log` keeps the escape hatch; with no stdin TTY the run fails and restores as before.
 ### AC-8 · Run observability (change: record-run-metadata)
 
 - **AC-8.1 (metadata completeness)** The `run-start` event of any agent-loop run contains: copperhead version + install path, `kicad-cli`/Node/platform versions, model id + provider + selection source (`flag`/`env`/`config`/`openai-key`/`anthropic-key`), run id + ISO timestamp + command, interactive flag, the resolved config snapshot (`schematic`, `board`, `docs`, effective `maxTurns`, `maxRepairCycles`, `budgets`), git commit/branch/dirty + uncommitted count, pre-commit-hook presence, and open-constraint + prior-run counts. The pre-existing `request`/`model`/`provider` fields keep their names. Collection is LLM-free and network-free.

--- a/src/agent/recovery.ts
+++ b/src/agent/recovery.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { Msg, Provider } from './types.js';
+import type { ExitPath } from './transcript.js';
 
 /** Thrown when a single provider turn blows past its watchdog deadline. */
 export class TurnTimeoutError extends Error {
@@ -132,6 +133,13 @@ export async function diagnoseStageFailure(
     excerpt: string;
     attempt: number;
     maxAttempts: number;
+    /** Machine-readable cause of the failed attempt, so "ran out of turns" is
+     *  distinguishable from "bad edit" without parsing the prose (issue #135). */
+    exitPath?: ExitPath;
+    /** Set when the pipeline has already scheduled a larger budget for the next
+     *  attempt. The supervisor is told so it does not abort over a constraint
+     *  that has just been lifted. */
+    nextAttemptMaxTurns?: number;
   },
 ): Promise<StageDiagnosis> {
   const system =
@@ -143,6 +151,11 @@ export async function diagnoseStageFailure(
     `Stage: ${input.stageName}\n` +
     `Stage goal: ${input.stageGoal}\n` +
     `Failure: ${input.failure}\n` +
+    (input.exitPath ? `exitPath: ${input.exitPath}\n` : '') +
+    (input.nextAttemptMaxTurns !== undefined
+      ? `The next attempt has already been granted a larger turn budget of ${input.nextAttemptMaxTurns} turns, ` +
+        'so the budget alone is not a reason to abort.\n'
+      : '') +
     `This was attempt ${input.attempt} of ${input.maxAttempts}.\n\n` +
     `Recent transcript (most recent last):\n${input.excerpt}\n\n` +
     'Reply with ONLY a JSON object, no prose:\n' +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
 import { createRequire } from 'node:module';
-import { createInterface } from 'node:readline/promises';
 import { loadConfig, resolveModel, type ModelSource } from './config.js';
 import { pickModel } from './util/select.js';
 import { runInit, InitError } from './memory/scaffold.js';
@@ -19,11 +18,11 @@ import {
   ExportError,
 } from './commands/export.js';
 import { DEFAULT_BOARDS, DEFAULT_SPARES } from './kicad/bom-export.js';
-import { runAgentLoop, type BudgetExhaustedStats } from './agent/loop.js';
+import { runAgentLoop } from './agent/loop.js';
 import { makeRenderer } from './agent/render.js';
 import { kicadCliVersion } from './kicad/cli.js';
 import { loadEnvFile } from './util/env.js';
-import { budgetExtraTurns, budgetPromptText, parseMaxTurns, repoOf } from './util/cli-args.js';
+import { budgetContinuePrompt, confirmTty, parseMaxTurns, repoOf } from './util/cli-args.js';
 
 // Read .env from the working directory before any command resolves a model or a
 // provider. Loaded here rather than per-command so `check` behaves identically,
@@ -38,23 +37,6 @@ loadEnvFile(process.cwd());
 const { version } = createRequire(import.meta.url)('../package.json') as { version: string };
 
 const program = new Command();
-
-async function confirmTty(question: string): Promise<boolean> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  const answer = await rl.question(`${question} [y/N] `);
-  rl.close();
-  return /^y(es)?$/i.test(answer.trim());
-}
-
-/**
- * Attended runs get a decision point instead of a rollback when the turn
- * budget runs out (issue #15). Non-TTY (CI, pipes) keeps fail-and-restore.
- */
-function budgetContinuePrompt(): ((stats: BudgetExhaustedStats) => Promise<number>) | undefined {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) return undefined;
-  return async (stats) =>
-    (await confirmTty(budgetPromptText(stats))) ? budgetExtraTurns(stats) : 0;
-}
 
 program
   .name('copperhead')
@@ -328,10 +310,14 @@ program
   .description('Mode A: full pipeline from a product brief to the output package')
   .requiredOption('--brief <file>', 'product brief (markdown)')
   .option('--model <model>', 'codex | cursor | gpt-5 | claude | claude-code | compat:<id> (or a provider-specific model id)')
+  .option('--max-turns <n>', 'turn budget per stage (a stageMaxTurns config entry still wins for that stage)')
   .option('--interactive', 're-enable the human gates (spec approval, pre-export)')
-  .action(async (opts: { brief: string; model?: string; interactive?: boolean }) => {
+  .action(async (opts: { brief: string; model?: string; maxTurns?: string; interactive?: boolean }) => {
     const repo = repoOf(program.opts());
     try {
+      // Parsed before anything else so a bad budget refuses to start rather than
+      // failing after kicad-cli detection and model resolution have run.
+      const maxTurns = opts.maxTurns ? parseMaxTurns(opts.maxTurns) : undefined;
       const kicadVer = await kicadCliVersion();
       const config = await loadConfig(repo);
       const { model, source } = resolveModel(opts.model, config);
@@ -340,6 +326,7 @@ program
         repoRoot: repo,
         briefPath: opts.brief,
         model,
+        ...(maxTurns !== undefined ? { maxTurns } : {}),
         interactive: opts.interactive ?? false,
         ...(continuePrompt ? { onBudgetExhausted: continuePrompt } : {}),
         log: (s) => console.log(s),

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -12,6 +12,8 @@ import { checkDrift } from '../memory/drift.js';
 import { runAgentLoop, makeProvider, type BudgetExhaustedStats } from '../agent/loop.js';
 import { diagnoseStageFailure, transcriptExcerpt, withTimeout, type StageDiagnosis } from '../agent/recovery.js';
 import type { Provider } from '../agent/types.js';
+import type { ExitPath } from '../agent/transcript.js';
+import { budgetExtraTurns } from '../util/cli-args.js';
 import type { RunMetaInput } from '../agent/runmeta.js';
 import { fmtDuration, fmtTokens, type ProgressRenderer } from '../agent/render.js';
 import { copper, dim, ok, stageLine, warn } from '../agent/theme.js';
@@ -234,10 +236,45 @@ export const STAGES: Stage[] = [
   },
 ];
 
+/**
+ * Built-in per-stage turn budgets for the stages the global default has been
+ * documented as too small for. `manual-tests/setup.sh` has been setting 100
+ * turns for create sandboxes (with a comment saying 40 is inadequate) since long
+ * before issue #135; these promote that test-only workaround into the product
+ * default so a normally-scaffolded repo is not the only one that walls.
+ */
+export const DEFAULT_STAGE_MAX_TURNS: Record<string, number> = {
+  schematic: 100,
+  'layout-draft': 80,
+};
+
+/**
+ * Turn budget for one stage. Precedence, highest first:
+ *
+ * 1. `stageMaxTurns[stage]` in `.copperhead/config.json` — the most specific
+ *    statement anyone has made about this stage, so a global flag must not
+ *    silently undo per-stage tuning.
+ * 2. `--max-turns` passed to `create`.
+ * 3. `DEFAULT_STAGE_MAX_TURNS[stage]` — the built-in per-stage default.
+ * 4. `maxTurns` from config (the global default).
+ */
+export function resolveStageMaxTurns(
+  stageName: string,
+  config: Pick<CopperheadConfig, 'maxTurns' | 'stageMaxTurns'>,
+  flagMaxTurns?: number,
+): number {
+  const fromConfig = config.stageMaxTurns?.[stageName];
+  if (fromConfig !== undefined) return fromConfig;
+  if (flagMaxTurns !== undefined) return flagMaxTurns;
+  return DEFAULT_STAGE_MAX_TURNS[stageName] ?? config.maxTurns;
+}
+
 export interface CreateOptions {
   repoRoot: string;
   briefPath: string;
   model: string;
+  /** `--max-turns`: per-stage turn budget; `stageMaxTurns` still wins per stage. */
+  maxTurns?: number;
   interactive?: boolean;
   /** Forwarded to each stage's run (attended continue-on-exhaustion prompt). */
   onBudgetExhausted?: (stats: BudgetExhaustedStats) => Promise<number>;
@@ -378,6 +415,11 @@ async function diagnose(input: {
   transcriptDir: string;
   attempt: number;
   maxAttempts: number;
+  /** Structured cause of the failed attempt (issue #135), so budget exhaustion
+   *  is distinguishable from a bad edit without parsing prose. */
+  exitPath: ExitPath;
+  /** Budget already scheduled for the next attempt, when one was raised. */
+  nextAttemptMaxTurns?: number | undefined;
   /** Compatible-endpoint settings, so a `compat` run can diagnose itself. */
   compat?: CompatSettings | undefined;
 }): Promise<StageDiagnosis> {
@@ -395,6 +437,10 @@ async function diagnose(input: {
           excerpt,
           attempt: input.attempt,
           maxAttempts: input.maxAttempts,
+          exitPath: input.exitPath,
+          ...(input.nextAttemptMaxTurns !== undefined
+            ? { nextAttemptMaxTurns: input.nextAttemptMaxTurns }
+            : {}),
         }),
       input.timeoutMs,
       () => p.close?.(),
@@ -432,6 +478,7 @@ function resumeCommand(opts: CreateOptions): string {
   // Absolute --brief so the command resolves the same from any cwd; a relative
   // path would break when resumed from a different directory (F6).
   parts.push('create', '--brief', shellQuote(path.resolve(opts.briefPath)), '--model', shellQuote(opts.model));
+  if (opts.maxTurns !== undefined) parts.push('--max-turns', String(opts.maxTurns));
   if (opts.interactive) parts.push('--interactive');
   return parts.join(' ');
 }
@@ -692,11 +739,31 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
     // guidance prepended); on "abort", or once the retry budget is spent, it
     // stops and reports for a human — the loop keeps going by itself for the
     // recoverable cases without silently spinning on the dead-end ones.
-    const stageTurns = config.stageMaxTurns?.[stage.name];
+    // The budget this stage was originally granted. Each starved attempt gets
+    // half again as many turns as the one before (the same `budgetExtraTurns`
+    // increment the attended prompt offers), so three attempts on the default
+    // budget read 40 → 60 → 90 (issue #135, design D1).
+    let attemptTurns = resolveStageMaxTurns(stage.name, config, opts.maxTurns);
+    // True while every attempt so far has died of turn starvation, which is the
+    // one failure mode whose remedy is a bigger budget rather than another try.
+    let onlyBudgetExhaustion = true;
     const basePrompt = stage.prompt(brief);
     let guidance = '';
     let stageDone = false;
     let stageTranscriptDir = '';
+    /** Say what actually needs to change when turns, not the model, ran out. */
+    const logBudgetRemedy = (): void => {
+      if (!onlyBudgetExhaustion) return;
+      opts.log(
+        stageLine(
+          stage.name,
+          `every attempt ran out of turns (last budget ${attemptTurns}): this stage needs a larger budget, ` +
+            `not another attempt. Re-run with \`--max-turns <n>\` or set ` +
+            `"stageMaxTurns": {"${stage.name}": <n>} in .copperhead/config.json.`,
+          'err',
+        ),
+      );
+    };
     // Cost accumulates across all attempts of the stage, so a stage that took a
     // retry to complete shows its true total in the summary (5.2).
     const stageStart = Date.now();
@@ -730,7 +797,7 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
           : basePrompt,
         interactive: opts.interactive ?? false,
         allowDirty: true, // stages build on each other's uncommitted state within the pipeline
-        ...(stageTurns !== undefined ? { maxTurns: stageTurns } : {}),
+        maxTurns: attemptTurns,
         ...(opts.onBudgetExhausted ? { onBudgetExhausted: opts.onBudgetExhausted } : {}),
         log: opts.log,
         ...(opts.renderer ? { renderer: opts.renderer } : {}),
@@ -766,6 +833,9 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
         break;
       }
 
+      const starved = res.exitPath === 'turn-budget-exhausted';
+      if (!starved) onlyBudgetExhaustion = false;
+
       if (attempt > config.maxStageRetries) {
         opts.log(
           stageLine(
@@ -774,7 +844,23 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
             'err',
           ),
         );
+        logBudgetRemedy();
         break;
+      }
+
+      // Retrying turn starvation at the same budget is knowably futile: it walls
+      // at the same place and burns a rollback to rediscover it (issue #135).
+      // Deterministic arithmetic, not a supervisor verdict — the supervisor
+      // fails safe to "abort", which is the failure being fixed here.
+      const nextTurns = starved ? attemptTurns + budgetExtraTurns({ maxTurns: attemptTurns }) : attemptTurns;
+      if (starved) {
+        opts.log(
+          stageLine(
+            stage.name,
+            `the attempt ran out of turns; raising the next attempt's budget ${attemptTurns} → ${nextTurns}`,
+            'warn',
+          ),
+        );
       }
 
       opts.log(stageLine(stage.name, `${failure}; asking the model whether to retry…`, 'warn'));
@@ -788,6 +874,8 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
         transcriptDir: res.transcriptDir,
         attempt,
         maxAttempts: config.maxStageRetries + 1,
+        exitPath: res.exitPath,
+        ...(starved ? { nextAttemptMaxTurns: nextTurns } : {}),
       });
       // Fold the diagnosis call's own tokens into the stage cost (F6): it is a
       // real model call made on behalf of this stage, so the cost table should
@@ -803,8 +891,10 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
       );
       if (diagnosis.verdict === 'abort') {
         opts.log(stageLine(stage.name, 'recovery supervisor recommends stopping for a human.', 'err'));
+        logBudgetRemedy();
         break;
       }
+      attemptTurns = nextTurns;
       guidance = diagnosis.guidance ?? `The previous attempt failed: ${failure}. ${diagnosis.reason}`;
     }
 

--- a/src/util/cli-args.ts
+++ b/src/util/cli-args.ts
@@ -6,6 +6,7 @@
  */
 
 import path from 'node:path';
+import { createInterface } from 'node:readline/promises';
 import type { BudgetExhaustedStats } from '../agent/loop.js';
 
 /** Resolve `--repo` against the working directory; absolute paths pass through. */
@@ -39,4 +40,45 @@ export function budgetPromptText(stats: BudgetExhaustedStats): string {
     `${stats.filesTouched.length} file(s) touched, ${stats.openObligations} open obligation(s)). ` +
     `Continue with ${budgetExtraTurns(stats)} more turns?`
   );
+}
+
+/**
+ * Ask a yes/no question on a terminal. The output stream is a parameter because
+ * the question must still be visible when stdout is redirected or piped: the
+ * caller then hands us stderr, which `> file` and `| tee` leave alone.
+ */
+export async function confirmTty(
+  question: string,
+  output: NodeJS.WritableStream = process.stdout,
+  input: NodeJS.ReadableStream = process.stdin,
+): Promise<boolean> {
+  const rl = createInterface({ input, output });
+  const answer = await rl.question(`${question} [y/N] `);
+  rl.close();
+  return /^y(es)?$/i.test(answer.trim());
+}
+
+/** The streams `budgetContinuePrompt` reads the answer from and asks on. */
+export interface PromptIo {
+  stdin: NodeJS.ReadableStream & { isTTY?: boolean | undefined };
+  stdout: NodeJS.WritableStream & { isTTY?: boolean | undefined };
+  stderr: NodeJS.WritableStream;
+}
+
+/**
+ * Attended runs get a decision point instead of a rollback when the turn budget
+ * runs out (issue #15). Only stdin needs to be a terminal: that is where the
+ * answer comes from. Gating on stdout as well (as this did originally) silently
+ * removed the escape hatch from every `| tee run.log` run, which is exactly how
+ * a long create pipeline is usually watched (issue #135). When stdout is not a
+ * TTY the question is asked on stderr instead. No stdin TTY at all (CI) still
+ * means no prompt: fail-and-restore, unchanged.
+ */
+export function budgetContinuePrompt(
+  io: PromptIo = process,
+): ((stats: BudgetExhaustedStats) => Promise<number>) | undefined {
+  if (!io.stdin.isTTY) return undefined;
+  const output = io.stdout.isTTY ? io.stdout : io.stderr;
+  return async (stats) =>
+    (await confirmTty(budgetPromptText(stats), output, io.stdin)) ? budgetExtraTurns(stats) : 0;
 }

--- a/test/cli-surface.test.ts
+++ b/test/cli-surface.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import path from 'node:path';
+import { PassThrough } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import { execa } from 'execa';
 import {
+  budgetContinuePrompt,
   budgetExtraTurns,
   budgetPromptText,
   parseMaxTurns,
   repoOf,
+  type PromptIo,
 } from '../src/util/cli-args.js';
 import { setColorEnabled, styleOutcome, styleHeaderLines } from '../src/agent/theme.js';
 
@@ -67,6 +70,49 @@ describe('budget-exhausted prompt (design D1)', () => {
     expect(q).toContain('2 file(s) touched');
     expect(q).toContain('1 open obligation(s)');
     expect(q).toContain('Continue with 20 more turns?');
+  });
+
+  // Issue #135: gating on stdout as well as stdin removed the escape hatch from
+  // every `| tee run.log` run, which is how a long create pipeline is watched.
+  describe('is offered whenever stdin is a terminal', () => {
+    function io(stdinTty: boolean, stdoutTty: boolean): PromptIo & { asked: string[] } {
+      const stdin = Object.assign(new PassThrough(), { isTTY: stdinTty });
+      const stdout = Object.assign(new PassThrough(), { isTTY: stdoutTty });
+      const stderr = new PassThrough();
+      const asked: string[] = [];
+      stdout.on('data', (c: Buffer) => asked.push(`stdout:${c.toString()}`));
+      stderr.on('data', (c: Buffer) => asked.push(`stderr:${c.toString()}`));
+      return { stdin, stdout, stderr, asked };
+    }
+
+    it('is returned when stdin is a TTY and stdout is not, and asks on stderr', async () => {
+      const { stdin, stdout, stderr, asked } = io(true, false);
+      const prompt = budgetContinuePrompt({ stdin, stdout, stderr });
+      expect(prompt).toBeTypeOf('function');
+
+      const answered = prompt!(stats);
+      stdin.write('y\n');
+      expect(await answered).toBe(20); // budgetExtraTurns(40)
+
+      const text = asked.join('');
+      expect(text).toContain('stderr:');
+      expect(text).toContain('Turn budget exhausted');
+      expect(text).not.toContain('stdout:');
+    });
+
+    it('asks on stdout when stdout is a TTY too', async () => {
+      const { stdin, stdout, stderr, asked } = io(true, true);
+      const answered = budgetContinuePrompt({ stdin, stdout, stderr })!(stats);
+      stdin.write('n\n');
+      expect(await answered).toBe(0); // declined: fail and restore
+
+      expect(asked.join('')).toContain('stdout:');
+    });
+
+    it('is absent when stdin is not a TTY, so CI keeps fail-and-restore', () => {
+      const { stdin, stdout, stderr } = io(false, true);
+      expect(budgetContinuePrompt({ stdin, stdout, stderr })).toBeUndefined();
+    });
   });
 });
 
@@ -139,5 +185,25 @@ describe('demo --tour honours --json', () => {
     expect(res.exitCode).toBe(0);
     expect(() => JSON.parse(res.stdout)).toThrow();
     expect(res.stdout).toContain('copperhead');
+  }, 60_000);
+});
+
+describe('create --max-turns (issue #135)', () => {
+  it('is advertised in the help and refuses a bad value before doing any work', async () => {
+    const help = await execa('npx', ['tsx', 'src/cli.ts', 'create', '--help'], {
+      cwd: ROOT,
+      reject: false,
+      env: { NO_COLOR: '1' },
+    });
+    expect(help.exitCode).toBe(0);
+    expect(help.stdout).toContain('--max-turns');
+
+    const bad = await execa(
+      'npx',
+      ['tsx', 'src/cli.ts', 'create', '--brief', 'nope.md', '--max-turns', '5oops'],
+      { cwd: ROOT, reject: false, env: { NO_COLOR: '1' } },
+    );
+    expect(bad.exitCode).not.toBe(0);
+    expect(`${bad.stdout}${bad.stderr}`).toContain('--max-turns must be a positive integer');
   }, 60_000);
 });

--- a/test/create-budget-escalation.test.ts
+++ b/test/create-budget-escalation.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import { mkdir, writeFile } from 'node:fs/promises';
+import type { RunOptions, RunResult } from '../src/agent/loop.js';
+import type { ExitPath } from '../src/agent/transcript.js';
+import { tempFixtureRepo } from './helpers.js';
+
+// Issue #135: a stage that dies of turn starvation used to be retried at the
+// exact budget that just proved insufficient, so it could wall three times in a
+// row. These drive runCreate with a scripted runAgentLoop and a scripted
+// recovery diagnosis; no live provider, no network.
+const mockRunAgentLoop = vi.hoisted(() => vi.fn<(opts: RunOptions) => Promise<RunResult>>());
+const mockDiagnose = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/agent/loop.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  runAgentLoop: mockRunAgentLoop,
+}));
+vi.mock('../src/agent/recovery.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  diagnoseStageFailure: mockDiagnose,
+  transcriptExcerpt: async () => '',
+}));
+vi.mock('../src/openspec/cli.js', () => ({ openspecInit: async () => ({ ok: true, output: '' }) }));
+vi.mock('../src/commands/check.js', () => ({ runCheck: async () => ({ ok: true }) }));
+
+import { runCreate, resolveStageMaxTurns, DEFAULT_STAGE_MAX_TURNS } from '../src/commands/create.js';
+
+/** A failed run result carrying the exit path under test. */
+function failed(exitPath: ExitPath, maxTurns: number): RunResult {
+  return {
+    outcome: 'failure',
+    exitPath,
+    summary: 'mock',
+    transcriptDir: '',
+    filesTouched: [],
+    commit: null,
+    stats: {
+      exitPath,
+      turnsUsed: maxTurns,
+      maxTurns,
+      repairCyclesUsed: 0,
+      maxRepairCycles: 5,
+      tokensIn: 100,
+      tokensOut: 50,
+      perTurn: [],
+      durationMs: 1000,
+    },
+    cacheHits: 0,
+  };
+}
+
+// diagnose() constructs a provider before the mocked diagnoseStageFailure runs;
+// a dummy key keeps that construction from throwing. Never actually called.
+let prevKey: string | undefined;
+beforeEach(() => {
+  mockRunAgentLoop.mockReset();
+  mockDiagnose.mockReset();
+  mockDiagnose.mockResolvedValue({ verdict: 'retry', reason: 'transient', guidance: 'try again' });
+  prevKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = 'sk-test-dummy';
+});
+afterEach(() => {
+  if (prevKey === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = prevKey;
+});
+
+async function seedRepo(repo: string, config?: Record<string, unknown>): Promise<string> {
+  await mkdir(path.join(repo, '.copperhead'), { recursive: true });
+  if (config) {
+    await writeFile(path.join(repo, '.copperhead', 'config.json'), JSON.stringify(config), 'utf8');
+  }
+  const briefPath = path.join(repo, 'brief.md');
+  await writeFile(briefPath, '# tiny\n', 'utf8');
+  return briefPath;
+}
+
+/** Turn budgets, in order, that the pipeline handed the spec-seed stage. */
+function specSeedBudgets(): (number | undefined)[] {
+  return mockRunAgentLoop.mock.calls
+    .map(([o]) => o)
+    .filter((o) => o.request.includes('spec-seed'))
+    .map((o) => o.maxTurns);
+}
+
+describe('turn-budget escalation across stage attempts (issue #135)', () => {
+  it('raises the budget 40 → 60 → 90 over three turn-starved attempts', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo);
+      mockRunAgentLoop.mockImplementation(async (opts) =>
+        failed('turn-budget-exhausted', opts.maxTurns ?? 0),
+      );
+
+      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
+
+      expect(res.ok).toBe(false);
+      // Each raise is ceil(base / 2) = 20 on top of the previous budget, so the
+      // escalation is linear from the ORIGINAL budget, not compounding.
+      expect(specSeedBudgets()).toEqual([40, 60, 90]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('logs each raise on its own stage line', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo);
+      mockRunAgentLoop.mockImplementation(async (opts) =>
+        failed('turn-budget-exhausted', opts.maxTurns ?? 0),
+      );
+
+      const lines: string[] = [];
+      await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: (s) => lines.push(s) });
+
+      const raises = lines.filter((l) => l.includes("raising the next attempt's budget"));
+      expect(raises).toHaveLength(2);
+      expect(raises[0]).toContain('40 → 60');
+      expect(raises[1]).toContain('60 → 90');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('does not escalate for a non-budget exit path', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo);
+      mockRunAgentLoop.mockImplementation(async (opts) => failed('provider-error', opts.maxTurns ?? 0));
+
+      const lines: string[] = [];
+      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: (s) => lines.push(s) });
+
+      expect(res.ok).toBe(false);
+      expect(specSeedBudgets()).toEqual([40, 40, 40]);
+      expect(lines.join('\n')).not.toContain("raising the next attempt's budget");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('names --max-turns and stageMaxTurns when every attempt ran out of turns', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo);
+      mockRunAgentLoop.mockImplementation(async (opts) =>
+        failed('turn-budget-exhausted', opts.maxTurns ?? 0),
+      );
+
+      const lines: string[] = [];
+      await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: (s) => lines.push(s) });
+
+      const out = lines.join('\n');
+      expect(out).toContain('this stage needs a larger budget');
+      expect(out).toContain('--max-turns');
+      expect(out).toContain('"stageMaxTurns": {"spec-seed": <n>}');
+      expect(out).toContain('last budget 90');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('stays silent about the budget when the failures were not turn starvation', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo);
+      mockRunAgentLoop.mockImplementation(async (opts) => failed('provider-error', opts.maxTurns ?? 0));
+
+      const lines: string[] = [];
+      await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: (s) => lines.push(s) });
+
+      expect(lines.join('\n')).not.toContain('this stage needs a larger budget');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('hands the supervisor the structured exit path and the scheduled next budget', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo);
+      mockRunAgentLoop.mockImplementation(async (opts) =>
+        failed('turn-budget-exhausted', opts.maxTurns ?? 0),
+      );
+
+      await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
+
+      const first = mockDiagnose.mock.calls[0]?.[1] as { exitPath: string; nextAttemptMaxTurns: number };
+      expect(first.exitPath).toBe('turn-budget-exhausted');
+      expect(first.nextAttemptMaxTurns).toBe(60);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('omits the scheduled-budget hint when no escalation was scheduled', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo);
+      mockRunAgentLoop.mockImplementation(async (opts) => failed('provider-error', opts.maxTurns ?? 0));
+
+      await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
+
+      const first = mockDiagnose.mock.calls[0]?.[1] as { exitPath: string; nextAttemptMaxTurns?: number };
+      expect(first.exitPath).toBe('provider-error');
+      expect(first.nextAttemptMaxTurns).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+describe('stage turn-budget precedence (issue #135)', () => {
+  const config = (over: Partial<{ maxTurns: number; stageMaxTurns: Record<string, number> }> = {}) => ({
+    maxTurns: 40,
+    ...over,
+  });
+
+  it('config stageMaxTurns wins over everything, including --max-turns', () => {
+    expect(resolveStageMaxTurns('schematic', config({ stageMaxTurns: { schematic: 55 } }), 120)).toBe(55);
+  });
+
+  it('--max-turns wins over the built-in per-stage default', () => {
+    expect(resolveStageMaxTurns('schematic', config(), 120)).toBe(120);
+  });
+
+  it('the built-in per-stage default wins over the global maxTurns', () => {
+    expect(resolveStageMaxTurns('schematic', config())).toBe(100);
+    expect(resolveStageMaxTurns('layout-draft', config())).toBe(80);
+    expect(DEFAULT_STAGE_MAX_TURNS).toEqual({ schematic: 100, 'layout-draft': 80 });
+  });
+
+  it('a stage with no entry anywhere falls back to the global maxTurns', () => {
+    expect(resolveStageMaxTurns('spec-seed', config())).toBe(40);
+    expect(resolveStageMaxTurns('spec-seed', config({ maxTurns: 12 }))).toBe(12);
+  });
+
+  it('applies the whole chain through a real run', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo, { maxTurns: 40, stageMaxTurns: { 'spec-seed': 55 } });
+      mockRunAgentLoop.mockImplementation(async (opts) => failed('provider-error', opts.maxTurns ?? 0));
+      // Abort immediately so only the first attempt of the first stage runs.
+      mockDiagnose.mockResolvedValue({ verdict: 'abort', reason: 'stop' });
+
+      await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', maxTurns: 120, log: () => {} });
+
+      // config's per-stage entry beats the flag for the stage it names.
+      expect(specSeedBudgets()).toEqual([55]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('gives the schematic stage its built-in default when nothing else is set', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo);
+      // The three doc stages succeed so the run actually reaches `schematic`,
+      // which then fails: enough to observe the budget it was handed.
+      mockRunAgentLoop.mockImplementation(async (opts) => {
+        const docs = path.join(opts.repoRoot, 'docs');
+        await mkdir(docs, { recursive: true });
+        if (opts.request.includes('spec-seed')) {
+          await writeFile(path.join(docs, 'SPEC.md'), '# s\n\n## Budgets\n\n- sleep_current_uA: 25\n', 'utf8');
+        } else if (opts.request.includes('architecture')) {
+          await writeFile(path.join(docs, 'SUBSYSTEMS.md'), '# s\n\n## Power\n\nLDO regulator.\n', 'utf8');
+        } else if (opts.request.includes('part-selection')) {
+          await writeFile(
+            path.join(docs, 'BOM.md'),
+            '# b\n\n| Refdes | Value | Footprint | MPN | Rationale |\n|---|---|---|---|---|\n| R1 | 10k | R_0603 | RC0603FR-0710KL | bias |\n',
+            'utf8',
+          );
+        } else {
+          return failed('provider-error', opts.maxTurns ?? 0);
+        }
+        return {
+          ...failed('done', opts.maxTurns ?? 0),
+          outcome: 'success' as const,
+          exitPath: 'done' as const,
+        };
+      });
+      mockDiagnose.mockResolvedValue({ verdict: 'abort', reason: 'stop' });
+
+      await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
+
+      const schematic = mockRunAgentLoop.mock.calls
+        .map(([o]) => o)
+        .filter((o) => o.request.includes('schematic'))
+        .map((o) => o.maxTurns);
+      expect(schematic).toEqual([100]);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/test/create-stage-turns.test.ts
+++ b/test/create-stage-turns.test.ts
@@ -90,7 +90,11 @@ describe('create pipeline per-stage turn budgets (AC-15.18, AC-15.19)', () => {
       const specSeed = calls.find((o) => o.request.includes('spec-seed'));
       const architecture = calls.find((o) => o.request.includes('architecture'));
       expect(specSeed?.maxTurns).toBe(60);
-      expect(architecture?.maxTurns).toBeUndefined();
+      // No stageMaxTurns entry, no --max-turns, no built-in default for this
+      // stage: the global config default is now resolved explicitly rather than
+      // left for the loop to fill in, because escalation needs a base to
+      // measure from (issue #135).
+      expect(architecture?.maxTurns).toBe(40);
     } finally {
       await cleanup();
     }

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -97,6 +97,51 @@ describe('diagnoseStageFailure', () => {
     });
     expect(d.verdict).toBe('abort');
   });
+
+  // Issue #135: the supervisor used to see budget exhaustion only as prose, so
+  // it could not tell turn starvation from a bad edit, and it did not know the
+  // pipeline had already scheduled a bigger budget for the next attempt.
+  it('renders the exit path and the scheduled next budget as structured lines', async () => {
+    let seen: Msg[] = [];
+    const provider: Provider = {
+      name: 'fake',
+      async chat(m) {
+        seen = m;
+        return turn('{"verdict":"retry","reason":"more turns will do it"}');
+      },
+    };
+    await diagnoseStageFailure(provider, {
+      stageName: 'schematic',
+      stageGoal: 'build it',
+      failure: 'the run ended as "failure" (turn-budget-exhausted)',
+      excerpt: '',
+      attempt: 1,
+      maxAttempts: 3,
+      exitPath: 'turn-budget-exhausted',
+      nextAttemptMaxTurns: 60,
+    });
+    const user = seen.find((m) => m.role === 'user')?.content ?? '';
+    expect(user).toContain('exitPath: turn-budget-exhausted');
+    expect(user).toContain('larger turn budget of 60 turns');
+    expect(user).toContain('not a reason to abort');
+  });
+
+  it('omits both lines when the caller has no exit path or escalation to report', async () => {
+    let seen: Msg[] = [];
+    const provider: Provider = {
+      name: 'fake',
+      async chat(m) {
+        seen = m;
+        return turn('{"verdict":"abort","reason":"x"}');
+      },
+    };
+    await diagnoseStageFailure(provider, {
+      stageName: 's', stageGoal: 'g', failure: 'f', excerpt: '', attempt: 1, maxAttempts: 2,
+    });
+    const user = seen.find((m) => m.role === 'user')?.content ?? '';
+    expect(user).not.toContain('exitPath:');
+    expect(user).not.toContain('larger turn budget');
+  });
 });
 
 describe('CachingProvider', () => {


### PR DESCRIPTION
## What

A `copperhead create` stage that runs out of turns now gets more turns on its next attempt (40, then 60, then 90 on the default budget) instead of being retried at the budget that just proved insufficient. `create` also gains `--max-turns <n>`, the `schematic` and `layout-draft` stages get larger built-in defaults, and the attended "continue?" prompt now survives a piped or redirected stdout.

## Why

Closes #135.

`stageTurns` was read once per stage, outside the attempt loop, and handed unchanged to every attempt. With the default `maxStageRetries: 2` the schematic stage could run three times at 40 turns, roll back three times, and end no closer than it started. The recovery supervisor could not compensate: it saw the failure only as the prose string `the run ended as "failure" (turn-budget-exhausted)`, so it could not tell turn starvation from a bad edit, and its verdicts were limited to `retry` and `abort`.

Two contributing factors from the issue are fixed here too: `create` had no `--max-turns` (so the only way to give a stage a realistic budget was hand-editing `.copperhead/config.json`), and the attended continue prompt from #15 required both stdin and stdout to be TTYs, which silently removed the escape hatch from every `| tee run.log` run.

## Design

Full rationale in [design.md](openspec/changes/escalate-stage-turn-budget/design.md).

**D1: escalate on the exit path, not on the supervisor's opinion.** `turn-budget-exhausted` is already a machine-readable field on `RunResult`, so the escalation is deterministic arithmetic in [create.ts](src/commands/create.ts): the per-attempt loop remembers the budget it ran under and, when the attempt exited `turn-budget-exhausted`, gives the next attempt `previous + budgetExtraTurns({ maxTurns: previous })` turns. That reuses the increment the attended prompt already offers, so attended and unattended runs escalate identically. The supervisor still runs and still decides retry vs abort, but it is now told the structured cause (`exitPath: <value>`) and the budget already scheduled, with an explicit note that the budget alone is not a reason to abort. A third verdict (`retry-with-more-turns`) was rejected: it would put a deterministic arithmetic decision behind a model call that fails safe to `abort`, which is the failure the issue describes.

**D2: four-level budget resolution, config still wins per stage.** `resolveStageMaxTurns` in [create.ts](src/commands/create.ts) resolves `stageMaxTurns[stage]` > `--max-turns` > `DEFAULT_STAGE_MAX_TURNS[stage]` > `config.maxTurns`. The flag sits *under* the per-stage config entry because #135 defines it as "the per-stage cap that `stageMaxTurns` still overrides per stage"; the flag's help text says so. `DEFAULT_STAGE_MAX_TURNS` is `{ schematic: 100, 'layout-draft': 80 }`, the numbers [manual-tests/setup.sh](manual-tests/setup.sh) has been setting for create sandboxes (with a comment saying 40 is inadequate), promoted from a test-only workaround into the product default. The resolver returns a concrete number for every stage rather than leaving it undefined, because escalation needs a budget to escalate from; the visible consequence is that `create` now always passes `maxTurns` to `runAgentLoop`, with the same value the loop would have defaulted to for an untuned stage.

**D3: the prompt needs a TTY to ask on, not one to print to.** `budgetContinuePrompt` moves from [cli.ts](src/cli.ts) (which parses argv at import time, so it cannot be imported in a test) to [cli-args.ts](src/util/cli-args.ts), gates on `stdin.isTTY` alone, and writes to stderr when stdout is not a TTY. `confirmTty` moves with it and takes output and input streams as parameters. Streams are injectable, which is what lets the piped case be driven with real `PassThrough` streams in a unit test.

**Invariants.** Nothing here touches the agent loop's gates: the edit tools stay spec-gated, verification still gates a mutation out, and the rollback path is unchanged. A stage attempt that fails still rolls back exactly as before, it just gets a bigger budget next time. `check`'s module graph is untouched.

## Spec / OpenSpec

OpenSpec change: [escalate-stage-turn-budget](openspec/changes/escalate-stage-turn-budget/) with [proposal.md](openspec/changes/escalate-stage-turn-budget/proposal.md), [design.md](openspec/changes/escalate-stage-turn-budget/design.md), [tasks.md](openspec/changes/escalate-stage-turn-budget/tasks.md), and two delta specs: [create-pipeline](openspec/changes/escalate-stage-turn-budget/specs/create-pipeline/spec.md) (escalation, structured exit path, built-in per-stage budgets) and [cli-surface](openspec/changes/escalate-stage-turn-budget/specs/cli-surface/spec.md) (`create --max-turns`, modified attended budget prompt).

[SPEC.md](openspec/specs/SPEC.md) moved with it: `create --max-turns` in the CLI surface (§3), the four-level budget precedence in the config section (§5), and a new **AC-16.1 through AC-16.6** covering escalation, the unchanged non-budget paths, the structured supervisor input, the give-up remedy, precedence, and the piped-stdout prompt.

`openspec validate escalate-stage-turn-budget` passes; all four artifacts are complete.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass (clean) |
| Build | `npm run build` | pass (clean) |
| Unit + offline | `npm test` | pass: 600 passed, 20 skipped, 42 files passed / 1 skipped |
| Markdown lint | `npm run lint:md` | pass: 0 issues in 133 files |
| Live-LLM (opt-in) | keyed on `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `COPPERHEAD_TEST_CODEX` | skip (not configured; `test/agent-integration.test.ts` is the 19 of the 20 skips) |

New tests: [test/create-budget-escalation.test.ts](test/create-budget-escalation.test.ts) (13 tests: the 40 to 60 to 90 sequence, each raise logged, no escalation on `provider-error`, the give-up line naming `--max-turns` and `stageMaxTurns` and its absence for non-budget failures, `exitPath`/`nextAttemptMaxTurns` reaching the supervisor, and the full precedence chain including config beating `--max-turns` and the schematic stage getting its built-in 100 through a real run). Added to [test/recovery.test.ts](test/recovery.test.ts) (the supervisor prompt carries `exitPath: turn-budget-exhausted` and the next budget; both lines absent when not supplied) and [test/cli-surface.test.ts](test/cli-surface.test.ts) (`budgetContinuePrompt` with a TTY stdin and non-TTY stdout asks on stderr and grants 20 turns on `y`; asks on stdout when both are TTYs; undefined with no stdin TTY; `create --help` advertises `--max-turns` and a bad value refuses to start).

Changed test: [test/create-stage-turns.test.ts](test/create-stage-turns.test.ts) asserted `architecture.maxTurns === undefined`; the pipeline now resolves the global default explicitly (40) because escalation needs a base to measure from, so the assertion moved to `40`. Same effective budget, now stated rather than implied.

No pre-existing failures were observed; the suite was green before and after.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): none. A live `create` run needs a provider credential, which this environment does not have, so the escalation was exercised as a scripted run against the real exported code plus the real pipeline log path. The flag itself was exercised through the real CLI entry point.
- Commands run and outcome:

```text
$ npx tsx src/cli.ts create --help
Usage: copperhead create [options]

Mode A: full pipeline from a product brief to the output package

Options:
  --brief <file>   product brief (markdown)
  --model <model>  codex | cursor | gpt-5 | claude | claude-code | compat:<id>
                   (or a provider-specific model id)
  --max-turns <n>  turn budget per stage (a stageMaxTurns config entry still
                   wins for that stage)
  --interactive    re-enable the human gates (spec approval, pre-export)
  -h, --help       display help for command

$ npx tsx src/cli.ts create --brief nope.md --max-turns 5oops
--max-turns must be a positive integer, got "5oops"
exit=1
```

Scripted exercise of the resolver, the escalation arithmetic, the supervisor prompt, and the piped continue prompt, all against the real exported functions (throwaway script, not committed):

```text
$ npx tsx escalation-demo.ts
built-in per-stage defaults: {"schematic":100,"layout-draft":80}
precedence  config{schematic:55} + --max-turns 120 -> 55
precedence  --max-turns 120, no config entry      -> 120
precedence  nothing set, schematic                -> 100
precedence  nothing set, spec-seed                -> 40
escalation over three turn-starved attempts: 40 -> 60 -> 90
--- supervisor prompt ---
Stage: schematic
Stage goal: (stage prompt elided)
Failure: the run ended as "failure" (turn-budget-exhausted)
exitPath: turn-budget-exhausted
The next attempt has already been granted a larger turn budget of 150 turns, so the budget alone is not a reason to abort.
This was attempt 1 of 3.
...
--- end prompt ---
prompt offered with a piped stdout? true
[stderr] Turn budget exhausted (40 turns, 12.3k in / 6.8k out, 1 file(s) touched, 1 open obligation(s)). Continue with 20 more turns? [y/N]
extra turns granted on "y": 20
prompt offered with no stdin TTY? false
```

The pipeline's own stage output over three turn-starved attempts, from a scripted `runCreate` (mocked `runAgentLoop` returning `turn-budget-exhausted`, mocked supervisor returning `retry`):

```text
stage spec-seed: running
stage spec-seed: the attempt ran out of turns; raising the next attempt's budget 40 → 60
stage spec-seed: the run ended as "failure" (turn-budget-exhausted); asking the model whether to retry…
stage spec-seed: diagnosis → retry — transient
stage spec-seed: running (attempt 2/3)
stage spec-seed: the attempt ran out of turns; raising the next attempt's budget 60 → 90
stage spec-seed: the run ended as "failure" (turn-budget-exhausted); asking the model whether to retry…
stage spec-seed: diagnosis → retry — transient
stage spec-seed: running (attempt 3/3)
stage spec-seed: the run ended as "failure" (turn-budget-exhausted); exhausted 2 auto-retry(ies). Stopping for a human.
stage spec-seed: every attempt ran out of turns (last budget 90): this stage needs a larger budget, not another attempt. Re-run with `--max-turns <n>` or set "stageMaxTurns": {"spec-seed": <n>} in .copperhead/config.json.
```

Not exercised live: an actual model-backed `create` run hitting a real 40-turn wall. That needs a provider credential and roughly an hour of wall time, so it is n/a here.

## Docs

- [docs/reference/cli.md](docs/src/content/docs/reference/cli.md): `--max-turns` in the `create` option table, plus a "Turn budgets" section covering the precedence chain and the escalation behaviour.
- [docs/reference/configuration.md](docs/src/content/docs/reference/configuration.md): `stageMaxTurns` row, noting it outranks `create --max-turns`.
- [SPEC.md](openspec/specs/SPEC.md): CLI surface, config precedence, AC-16.

---

## Invariant checklist

- [x] **Spec-gated in**: N/A for the mechanism, and unchanged: the tool list is built in `src/agent/loop.ts`/`tools.ts` and this PR does not touch it.
- [x] **Verification-gated out**: unchanged. A failed stage attempt still rolls back to the snapshot; only the next attempt's turn budget differs.
- [x] **`check`/`verify` stays LLM-free and network-free**: unchanged. The new code lives in `create`, `recovery`, and `util/cli-args` (which imports only `node:path`, `node:readline/promises`, and a type from the loop).
- [x] **No sexp serialization**: N/A, no KiCad file handling touched.
- [x] **Sync-obligations ledger**: N/A, untouched.
- [x] **Secrets**: N/A, untouched. No new value is written to a transcript or summary.
- [x] **Spec coherence**: SPEC.md and all four change artifacts moved together; `openspec validate escalate-stage-turn-budget` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--max-turns <n>` to `copperhead create` for setting stage turn budgets.
  * Added configurable per-stage budgets through `stageMaxTurns`.
  * Added automatic turn-budget increases when stages run out of turns.
  * Improved recovery prompts for attended terminal sessions, including redirected output.

* **Documentation**
  * Documented budget precedence, retries, escalation behavior, and configuration options.

* **Bug Fixes**
  * Improved final error messages with actionable budget adjustment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->