### PR TITLE
fix(sync): parse PINOUT.md structurally for pins.h check (#105)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -6,6 +6,7 @@ import { checkDrift } from '../memory/drift.js';
 import { loadConstraints, checkForbiddenPins } from '../memory/constraints.js';
 import { pinNets } from '../kicad/sexp.js';
 import { openspecValidate } from '../openspec/cli.js';
+import { parseCanonicalTables } from '../memory/bom-table.js';
 import { runAgentLoop } from '../agent/loop.js';
 import type { RunMetaInput } from '../agent/runmeta.js';
 import type { ProgressRenderer } from '../agent/render.js';
@@ -90,13 +91,23 @@ export async function syncVerify(repoRoot: string): Promise<SyncReport> {
   if (existsSync(pinsH) && existsSync(path.join(docsDir, 'PINOUT.md'))) {
     const header = await readFile(pinsH, 'utf8');
     const pinout = await readFile(path.join(docsDir, 'PINOUT.md'), 'utf8');
+    const validNames = new Set<string>();
+    for (const { rows: tRows } of parseCanonicalTables(pinout)) {
+      for (const r of tRows) {
+        for (const cell of r.cells) {
+          const val = cell.replace(/`/g, '').trim();
+          if (val) validNames.add(val.toLowerCase());
+        }
+      }
+    }
     for (const m of header.matchAll(/#define\s+PIN_(\w+)\s+(\S+)/g)) {
-      if (!pinout.includes(m[1]!)) {
+      const pinName = m[1]!;
+      if (!validNames.has(pinName.toLowerCase())) {
         resolvable.push({
           kind: 'pins-h',
           doc: 'firmware/src/pins.h',
-          claim: `defines PIN_${m[1]}`,
-          actual: 'PINOUT.md does not mention it',
+          claim: `defines PIN_${pinName}`,
+          actual: 'PINOUT.md does not assign it',
           resolution: 'regenerate pins.h from PINOUT.md (PINOUT.md is the single source of truth)',
         });
       }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -92,11 +92,20 @@ export async function syncVerify(repoRoot: string): Promise<SyncReport> {
     const header = await readFile(pinsH, 'utf8');
     const pinout = await readFile(path.join(docsDir, 'PINOUT.md'), 'utf8');
     const validNames = new Set<string>();
-    for (const { rows: tRows } of parseCanonicalTables(pinout)) {
+    const strip = (s: string | undefined): string => (s ?? '').replace(/`/g, '').trim();
+    for (const { header: tHeader, rows: tRows } of parseCanonicalTables(pinout)) {
+      const col = (re: RegExp): number => tHeader.cells.findIndex((c) => re.test(c));
+      const netI = col(/^net$/i);
+      const nameI = col(/^name$/i);
+      const signalI = col(/^signal$/i);
+      const pinI = col(/^pin$/i);
+      if (pinI < 0 || (netI < 0 && nameI < 0 && signalI < 0)) continue; // only read canonical pin-assignment tables
       for (const r of tRows) {
-        for (const cell of r.cells) {
-          const val = cell.replace(/`/g, '').trim();
-          if (val) validNames.add(val.toLowerCase());
+        for (const idx of [netI, nameI, signalI]) {
+          if (idx >= 0 && r.cells[idx]) {
+            const val = strip(r.cells[idx]);
+            if (val) validNames.add(val.toLowerCase());
+          }
         }
       }
     }

--- a/test/gating-sync.test.ts
+++ b/test/gating-sync.test.ts
@@ -409,4 +409,30 @@ describe('copperhead sync verify phase (AC-7)', () => {
       await cleanup();
     }
   });
+
+  it('pins-h check ignores Notes column text when verifying pin names (#105)', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const pinoutPath = path.join(repo, 'docs', 'PINOUT.md');
+      await writeFile(
+        pinoutPath,
+        '| Refdes | Pin | Net | Notes |\n|---|---|---|---|\n| U1 | 5 | KEY_DAH | KEY notes here |\n',
+        'utf8',
+      );
+      const firmwareDir = path.join(repo, 'firmware', 'src');
+      await mkdir(firmwareDir, { recursive: true });
+      await writeFile(
+        path.join(firmwareDir, 'pins.h'),
+        '#define PIN_KEY 5\n',
+        'utf8',
+      );
+      const report = await syncVerify(repo);
+      const pinsHItems = report.resolvable.filter((i) => i.kind === 'pins-h');
+      expect(pinsHItems).toHaveLength(1);
+      expect(pinsHItems[0]!.claim).toBe('defines PIN_KEY');
+    } finally {
+      await cleanup();
+    }
+  });
 });

--- a/test/gating-sync.test.ts
+++ b/test/gating-sync.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import path from 'node:path';
-import { writeFile, readFile } from 'node:fs/promises';
+import { writeFile, readFile, mkdir } from 'node:fs/promises';
 import { runInit } from '../src/memory/scaffold.js';
 import { loadConfig } from '../src/config.js';
 import { availableTools, dispatchTool, type RunContext } from '../src/agent/tools.js';
@@ -381,6 +381,30 @@ describe('copperhead sync verify phase (AC-7)', () => {
       expect(report.violations).toHaveLength(1);
       expect(report.violations[0]!.description).toContain('GPIO14');
       expect(report.violations[0]!.governedBy).toBe('esp32-s3 datasheet');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('pins-h check verifies structurally against PINOUT.md table, rejecting substring matches (#105)', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const firmwareDir = path.join(repo, 'firmware', 'src');
+      await mkdir(firmwareDir, { recursive: true });
+      await writeFile(
+        path.join(firmwareDir, 'pins.h'),
+        '#define PIN_KEY 5\n#define PIN_GPIO 21\n#define PIN_3V 8\n',
+        'utf8',
+      );
+      const report = await syncVerify(repo);
+      const pinsHItems = report.resolvable.filter((i) => i.kind === 'pins-h');
+      expect(pinsHItems).toHaveLength(3);
+      expect(pinsHItems.map((i) => i.claim)).toEqual([
+        'defines PIN_KEY',
+        'defines PIN_GPIO',
+        'defines PIN_3V',
+      ]);
     } finally {
       await cleanup();
     }

--- a/test/gating-sync.test.ts
+++ b/test/gating-sync.test.ts
@@ -410,27 +410,31 @@ describe('copperhead sync verify phase (AC-7)', () => {
     }
   });
 
-  it('pins-h check ignores Notes column text when verifying pin names (#105)', async () => {
+  it('pins-h check ignores Notes, Refdes, and Pin number columns when verifying pin names (#105)', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await runInit({ repoRoot: repo });
       const pinoutPath = path.join(repo, 'docs', 'PINOUT.md');
       await writeFile(
         pinoutPath,
-        '| Refdes | Pin | Net | Notes |\n|---|---|---|---|\n| U1 | 5 | KEY_DAH | KEY notes here |\n',
+        '| Refdes | Pin | Net | Notes |\n|---|---|---|---|\n| U1 | 5 | KEY_DAH | KEY |\n',
         'utf8',
       );
       const firmwareDir = path.join(repo, 'firmware', 'src');
       await mkdir(firmwareDir, { recursive: true });
       await writeFile(
         path.join(firmwareDir, 'pins.h'),
-        '#define PIN_KEY 5\n',
+        '#define PIN_KEY_DAH 5\n#define PIN_KEY 5\n#define PIN_5 21\n#define PIN_U1 1\n',
         'utf8',
       );
       const report = await syncVerify(repo);
       const pinsHItems = report.resolvable.filter((i) => i.kind === 'pins-h');
-      expect(pinsHItems).toHaveLength(1);
-      expect(pinsHItems[0]!.claim).toBe('defines PIN_KEY');
+      expect(pinsHItems).toHaveLength(3);
+      expect(pinsHItems.map((i) => i.claim)).toEqual([
+        'defines PIN_KEY',
+        'defines PIN_5',
+        'defines PIN_U1',
+      ]);
     } finally {
       await cleanup();
     }


### PR DESCRIPTION
## What

Updates `pins-h` check in `src/commands/sync.ts` to parse `PINOUT.md` structurally via `parseCanonicalTables` instead of raw substring matching.

## Why

Addresses #105. Previously, `sync` checked `#define PIN_<NAME>` by raw `pinout.includes(name)`. Any word appearing anywhere in `PINOUT.md` (e.g. `KEY` inside `KEY_DAH`, `GPIO` inside `GPIO14`, or `RTC` inside prose text) would falsely pass non-existent pin definitions.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npx vitest run test/gating-sync.test.ts` | pass (17/17) |

### Manual test log

Added regression test `pins-h check verifies structurally against PINOUT.md table, rejecting substring matches (#105)` in `test/gating-sync.test.ts`. Confirmed 3 unassigned `#define`s (`PIN_KEY`, `PIN_GPIO`, `PIN_3V`) produce 3 resolvable inconsistencies instead of false-pass.

## Docs

No documentation changes required; internal sync check fix.

---

## Invariant checklist

- [x] **Spec-gated in**. Unaffected.
- [x] **Verification-gated out**. Unaffected.
- [x] **`check`/`verify` stays LLM-free and network-free**. `copperhead sync` verify phase stays 100% LLM-free and offline.
- [x] **No sexp serialization**. Unaffected.
- [x] **Sync-obligations ledger**. Fixes `pins-h` sync check false negative.
- [x] **Secrets**. Unaffected.
- [x] **Spec coherence**. Unaffected.

Closes #105.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization validation between firmware `PIN_*` definitions and the canonical pin-assignment tables in `PINOUT.md`.
  * Pin matching is now more robust, correctly handling capitalization, spacing, and formatting differences across table entries.
  * Updated feedback to state when a pin is not assigned in `PINOUT.md` (instead of being “not mentioned”).

* **Tests**
  * Added sync verification coverage for multiple firmware pin definitions.
  * Added a test ensuring pin validation ignores `Notes` text in `PINOUT.md` and still resolves the correct pin entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->