### PR TITLE
fix(test): harden cross-platform test harness and IO stream determinism

### DIFF
--- a/test/cli-surface.test.ts
+++ b/test/cli-surface.test.ts
@@ -36,7 +36,8 @@ describe('--repo resolution', () => {
   });
 
   it('passes an absolute path through unchanged', () => {
-    expect(repoOf({ repo: '/tmp/some-repo' })).toBe('/tmp/some-repo');
+    const absPath = path.resolve('/tmp/some-repo');
+    expect(repoOf({ repo: absPath })).toBe(absPath);
   });
 
   it('defaults to the working directory', () => {
@@ -71,8 +72,6 @@ describe('budget-exhausted prompt (design D1)', () => {
 });
 
 describe('theme styling (color on)', () => {
-  // These branches early-return when color is off, which is how every other
-  // suite runs them, so they need their own explicit color-on coverage.
   beforeEach(() => setColorEnabled(true));
 
   it('colors a successful outcome differently from a refusal', () => {
@@ -81,7 +80,6 @@ describe('theme styling (color on)', () => {
     expect(done).toContain('done');
     expect(refused).toContain('refused');
     expect(done).not.toBe(refused);
-    // The head is painted and the tail dimmed, so both carry SGR.
     expect(done).toMatch(/\x1b\[/);
     expect(refused).toMatch(/\x1b\[/);
   });
@@ -113,9 +111,6 @@ describe('theme styling (color on)', () => {
 });
 
 describe('demo --tour honours --json', () => {
-  // The only end-to-end check of the CLI wiring: --tour short-circuits before
-  // the try block, so it used to print prose even under --json. Runs the real
-  // entry point through tsx; --tour touches no network and no kicad-cli.
   it('emits structured JSON, not prose, under --json', async () => {
     const res = await execa('npx', ['tsx', 'src/cli.ts', '--json', 'demo', '--tour'], {
       cwd: ROOT,
@@ -126,7 +121,6 @@ describe('demo --tour honours --json', () => {
     const parsed = JSON.parse(res.stdout) as { tour: string[] };
     expect(Array.isArray(parsed.tour)).toBe(true);
     expect(parsed.tour.join('\n')).toContain('copperhead');
-    // Machine-readable means no leftover SGR in the payload.
     expect(res.stdout).not.toMatch(/\x1b\[/);
   }, 60_000);
 

--- a/test/cli-surface.test.ts
+++ b/test/cli-surface.test.ts
@@ -72,6 +72,8 @@ describe('budget-exhausted prompt (design D1)', () => {
 });
 
 describe('theme styling (color on)', () => {
+  // These branches early-return when color is off, which is how every other
+  // suite runs them, so they need their own explicit color-on coverage.
   beforeEach(() => setColorEnabled(true));
 
   it('colors a successful outcome differently from a refusal', () => {
@@ -80,6 +82,7 @@ describe('theme styling (color on)', () => {
     expect(done).toContain('done');
     expect(refused).toContain('refused');
     expect(done).not.toBe(refused);
+    // The head is painted and the tail dimmed, so both carry SGR.
     expect(done).toMatch(/\x1b\[/);
     expect(refused).toMatch(/\x1b\[/);
   });
@@ -111,6 +114,9 @@ describe('theme styling (color on)', () => {
 });
 
 describe('demo --tour honours --json', () => {
+  // The only end-to-end check of the CLI wiring: --tour short-circuits before
+  // the try block, so it used to print prose even under --json. Runs the real
+  // entry point through tsx; --tour touches no network and no kicad-cli.
   it('emits structured JSON, not prose, under --json', async () => {
     const res = await execa('npx', ['tsx', 'src/cli.ts', '--json', 'demo', '--tour'], {
       cwd: ROOT,
@@ -121,6 +127,7 @@ describe('demo --tour honours --json', () => {
     const parsed = JSON.parse(res.stdout) as { tour: string[] };
     expect(Array.isArray(parsed.tour)).toBe(true);
     expect(parsed.tour.join('\n')).toContain('copperhead');
+    // Machine-readable means no leftover SGR in the payload.
     expect(res.stdout).not.toMatch(/\x1b\[/);
   }, 60_000);
 

--- a/test/gating-sync.test.ts
+++ b/test/gating-sync.test.ts
@@ -77,6 +77,7 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       const ctx = await makeCtx(repo);
       ctx.editsUnlocked = true;
 
+      // touch the schematic via edit_file: opens erc/drift/changelog obligations
       const sch = 'hardware/open-key.kicad_sch';
       const text = await readFile(path.join(repo, sch), 'utf8');
       expect(text).toContain('"Value" "1k"');
@@ -87,6 +88,7 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       expect(blocked).toContain('ERC');
       expect(ctx.finishRequest).toBeNull();
 
+      // satisfy the gates: ERC + drift (BOM must be updated to match)
       await dispatchTool(ctx, 'run_erc', {});
       const bom = await readFile(path.join(repo, 'docs', 'BOM.md'), 'utf8');
       await writeFile(path.join(repo, 'docs', 'BOM.md'), bom.replace('| R2 | 1k |', '| R2 | 2.2k |'), 'utf8');
@@ -118,6 +120,10 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
   });
 
   it('check_drift clears the drift obligation when no schematic exists yet', async () => {
+    // Regression: the create pipeline's first three stages are docs-only and run
+    // before a schematic exists. check_drift used to early-return without
+    // clearing, and since it is the only tool that clears drift, a doc edit
+    // opened an obligation that could never close and finish refused forever.
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await runInit({ repoRoot: repo });
@@ -170,6 +176,7 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
         source: 'docs/SPEC.md#budgets',
         affects: ['CC1', 'CC2'],
       });
+      // Both items in one call matches neither obligation.
       const res = await dispatchTool(ctx, 'resolve_affected', {
         constraint_key: 'power.cc_rd_ohms',
         item: 'CC1/CC2',
@@ -178,6 +185,7 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       expect(res).toMatch(/^error:/);
       expect(res).toContain('power.cc_rd_ohms affects CC1');
       expect(res).toContain('power.cc_rd_ohms affects CC2');
+      // The obligations stay open, and no decision is logged for a failed resolve.
       expect(ctx.ledger.openOfKind('affects-revisit')).toHaveLength(2);
       expect(ctx.decisions.some((d) => d.includes('CC1/CC2'))).toBe(false);
     } finally {
@@ -186,6 +194,10 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
   });
 
   it('record_constraint defers affects items whose artifact does not exist yet', async () => {
+    // Regression: during the docs-only create stages every affects item that
+    // targets the future schematic/board opened an obligation the model could
+    // only close with a ceremonial "no change needed: not yet created" call —
+    // 13 of them burned ~25 turns in a live spec-seed run.
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await runInit({ repoRoot: repo });
@@ -198,12 +210,14 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
         source: 'brief',
         affects: ['layout', 'stackup', 'R1'],
       });
+      // R1 names a concrete part: opens now. layout/stackup wait for the board.
       const open = ctx.ledger.openOfKind('affects-revisit').map((o) => o.detail);
       expect(open).toEqual(['manufacturing.copper_weight_oz affects R1']);
       expect(res).toContain('deferred until the target artifact exists');
       expect(res).toContain('layout, stackup');
       const registry = await loadConstraints(repo);
       expect(registry['manufacturing.copper_weight_oz']!.deferred).toEqual(['layout', 'stackup']);
+      // the full affects list is preserved for propagation regardless
       expect(registry['manufacturing.copper_weight_oz']!.affects).toEqual(['layout', 'stackup', 'R1']);
     } finally {
       await cleanup();
@@ -225,11 +239,13 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       });
       expect(ctx.ledger.openOfKind('affects-revisit')).toHaveLength(0);
 
+      // board still absent: nothing re-opens, marker stays
       const none = await reopenDeferredAffects(repo, ctx.config, () => {
         throw new Error('should not open anything');
       });
       expect(none).toEqual([]);
 
+      // a later run has the board configured: the revisit re-opens in its ledger
       const laterConfig = { ...ctx.config, board: 'hardware/x.kicad_pcb' };
       const ledger = new ObligationsLedger();
       const reopened = await reopenDeferredAffects(repo, laterConfig, (key, item) =>
@@ -239,6 +255,7 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       expect(ledger.openOfKind('affects-revisit').map((o) => o.detail)).toEqual([
         'mechanical.mounting_holes affects layout',
       ]);
+      // the marker is consumed: a third run re-opens nothing
       expect((await loadConstraints(repo))['mechanical.mounting_holes']!.deferred).toBeUndefined();
       expect(await reopenDeferredAffects(repo, laterConfig, () => {})).toEqual([]);
     } finally {
@@ -254,6 +271,7 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
     expect(classifyAffectsTarget('schematic')).toBe('schematic');
     expect(classifyAffectsTarget('pin assignment')).toBe('schematic');
     expect(classifyAffectsTarget('BOM')).toBe('bom');
+    // concrete refdes/nets are never deferrable
     expect(classifyAffectsTarget('R1')).toBeNull();
     expect(classifyAffectsTarget('U2 EN pullup')).toBeNull();
   });
@@ -310,7 +328,7 @@ describe('copperhead sync verify phase (AC-7)', () => {
     try {
       await runInit({ repoRoot: repo });
       expect((await syncVerify(repo)).resolvable).toEqual([]);
-      expect((await syncVerify(repo)).resolvable).toEqual([]);
+      expect((await syncVerify(repo)).resolvable).toEqual([]); // second run: still nothing
     } finally {
       await cleanup();
     }
@@ -353,6 +371,7 @@ describe('copperhead sync verify phase (AC-7)', () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await runInit({ repoRoot: repo });
+      // GPIO14 carries KEY_DAH in the fixture; forbid it and sync must flag, not fix
       await saveConstraint(repo, 'pins.forbidden_gpio14', {
         forbidden: ['GPIO14'],
         source: 'esp32-s3 datasheet',

--- a/test/gating-sync.test.ts
+++ b/test/gating-sync.test.ts
@@ -77,7 +77,6 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       const ctx = await makeCtx(repo);
       ctx.editsUnlocked = true;
 
-      // touch the schematic via edit_file: opens erc/drift/changelog obligations
       const sch = 'hardware/open-key.kicad_sch';
       const text = await readFile(path.join(repo, sch), 'utf8');
       expect(text).toContain('"Value" "1k"');
@@ -88,7 +87,6 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       expect(blocked).toContain('ERC');
       expect(ctx.finishRequest).toBeNull();
 
-      // satisfy the gates: ERC + drift (BOM must be updated to match)
       await dispatchTool(ctx, 'run_erc', {});
       const bom = await readFile(path.join(repo, 'docs', 'BOM.md'), 'utf8');
       await writeFile(path.join(repo, 'docs', 'BOM.md'), bom.replace('| R2 | 1k |', '| R2 | 2.2k |'), 'utf8');
@@ -101,7 +99,7 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
     } finally {
       await cleanup();
     }
-  }, 60_000);
+  }, 300_000);
 
   it('refuse outcome needs no gates (AC-3.4 mechanism)', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
@@ -120,10 +118,6 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
   });
 
   it('check_drift clears the drift obligation when no schematic exists yet', async () => {
-    // Regression: the create pipeline's first three stages are docs-only and run
-    // before a schematic exists. check_drift used to early-return without
-    // clearing, and since it is the only tool that clears drift, a doc edit
-    // opened an obligation that could never close and finish refused forever.
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await runInit({ repoRoot: repo });
@@ -176,7 +170,6 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
         source: 'docs/SPEC.md#budgets',
         affects: ['CC1', 'CC2'],
       });
-      // Both items in one call matches neither obligation.
       const res = await dispatchTool(ctx, 'resolve_affected', {
         constraint_key: 'power.cc_rd_ohms',
         item: 'CC1/CC2',
@@ -185,7 +178,6 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       expect(res).toMatch(/^error:/);
       expect(res).toContain('power.cc_rd_ohms affects CC1');
       expect(res).toContain('power.cc_rd_ohms affects CC2');
-      // The obligations stay open, and no decision is logged for a failed resolve.
       expect(ctx.ledger.openOfKind('affects-revisit')).toHaveLength(2);
       expect(ctx.decisions.some((d) => d.includes('CC1/CC2'))).toBe(false);
     } finally {
@@ -194,10 +186,6 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
   });
 
   it('record_constraint defers affects items whose artifact does not exist yet', async () => {
-    // Regression: during the docs-only create stages every affects item that
-    // targets the future schematic/board opened an obligation the model could
-    // only close with a ceremonial "no change needed: not yet created" call —
-    // 13 of them burned ~25 turns in a live spec-seed run.
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await runInit({ repoRoot: repo });
@@ -210,14 +198,12 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
         source: 'brief',
         affects: ['layout', 'stackup', 'R1'],
       });
-      // R1 names a concrete part: opens now. layout/stackup wait for the board.
       const open = ctx.ledger.openOfKind('affects-revisit').map((o) => o.detail);
       expect(open).toEqual(['manufacturing.copper_weight_oz affects R1']);
       expect(res).toContain('deferred until the target artifact exists');
       expect(res).toContain('layout, stackup');
       const registry = await loadConstraints(repo);
       expect(registry['manufacturing.copper_weight_oz']!.deferred).toEqual(['layout', 'stackup']);
-      // the full affects list is preserved for propagation regardless
       expect(registry['manufacturing.copper_weight_oz']!.affects).toEqual(['layout', 'stackup', 'R1']);
     } finally {
       await cleanup();
@@ -239,13 +225,11 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       });
       expect(ctx.ledger.openOfKind('affects-revisit')).toHaveLength(0);
 
-      // board still absent: nothing re-opens, marker stays
       const none = await reopenDeferredAffects(repo, ctx.config, () => {
         throw new Error('should not open anything');
       });
       expect(none).toEqual([]);
 
-      // a later run has the board configured: the revisit re-opens in its ledger
       const laterConfig = { ...ctx.config, board: 'hardware/x.kicad_pcb' };
       const ledger = new ObligationsLedger();
       const reopened = await reopenDeferredAffects(repo, laterConfig, (key, item) =>
@@ -255,7 +239,6 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       expect(ledger.openOfKind('affects-revisit').map((o) => o.detail)).toEqual([
         'mechanical.mounting_holes affects layout',
       ]);
-      // the marker is consumed: a third run re-opens nothing
       expect((await loadConstraints(repo))['mechanical.mounting_holes']!.deferred).toBeUndefined();
       expect(await reopenDeferredAffects(repo, laterConfig, () => {})).toEqual([]);
     } finally {
@@ -271,7 +254,6 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
     expect(classifyAffectsTarget('schematic')).toBe('schematic');
     expect(classifyAffectsTarget('pin assignment')).toBe('schematic');
     expect(classifyAffectsTarget('BOM')).toBe('bom');
-    // concrete refdes/nets are never deferrable
     expect(classifyAffectsTarget('R1')).toBeNull();
     expect(classifyAffectsTarget('U2 EN pullup')).toBeNull();
   });
@@ -328,7 +310,7 @@ describe('copperhead sync verify phase (AC-7)', () => {
     try {
       await runInit({ repoRoot: repo });
       expect((await syncVerify(repo)).resolvable).toEqual([]);
-      expect((await syncVerify(repo)).resolvable).toEqual([]); // second run: still nothing
+      expect((await syncVerify(repo)).resolvable).toEqual([]);
     } finally {
       await cleanup();
     }
@@ -371,7 +353,6 @@ describe('copperhead sync verify phase (AC-7)', () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await runInit({ repoRoot: repo });
-      // GPIO14 carries KEY_DAH in the fixture; forbid it and sync must flag, not fix
       await saveConstraint(repo, 'pins.forbidden_gpio14', {
         forbidden: ['GPIO14'],
         source: 'esp32-s3 datasheet',

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -14,6 +14,7 @@ export async function tempFixtureRepo(): Promise<{ repo: string; cleanup: () => 
   // the target-repo convention (AC-4.3): .env and the run audit trail ignored
   await writeFile(path.join(repo, '.gitignore'), '.env\n.copperhead/runs/\n', 'utf8');
   await execa('git', ['init', '-q'], { cwd: repo });
+  await execa('git', ['config', 'core.autocrlf', 'false'], { cwd: repo });
   await execa('git', ['config', 'user.email', 'test@copperhead.local'], { cwd: repo });
   await execa('git', ['config', 'user.name', 'copperhead-test'], { cwd: repo });
   await execa('git', ['add', '-A'], { cwd: repo });

--- a/test/init-check.test.ts
+++ b/test/init-check.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, rm, mkdtemp, mkdir, chmod } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { execa } from 'execa';
 import { runInit, InitError } from '../src/memory/scaffold.js';
@@ -69,8 +70,6 @@ describe('copperhead init (AC-1)', () => {
   });
 
   it('fails clearly with no .kicad_sch (AC-1.5)', async () => {
-    const { mkdtemp } = await import('node:fs/promises');
-    const { tmpdir } = await import('node:os');
     const dir = await mkdtemp(path.join(tmpdir(), 'ch-empty-'));
     await expect(runInit({ repoRoot: dir })).rejects.toThrow(InitError);
     await expect(runInit({ repoRoot: dir })).rejects.toThrow(/no \.kicad_sch found/);
@@ -99,6 +98,7 @@ describe('copperhead check (AC-2)', () => {
       await runInit({ repoRoot: repo });
       const sch = path.join(repo, 'hardware', 'open-key.kicad_sch');
       const text = await readFile(sch, 'utf8');
+      // detach the GPIO0 no_connect flag: pin becomes unconnected
       await writeFile(sch, text.replace('(no_connect (at 127 96.52)', '(no_connect (at 127 50.8)'), 'utf8');
       const res = await runCheck(repo, silent);
       expect(res.ok).toBe(false);
@@ -130,10 +130,12 @@ describe('copperhead check (AC-2)', () => {
       await runInit({ repoRoot: repo });
       await execa('git', ['add', '-A'], { cwd: repo });
       await execa('git', ['commit', '-q', '-m', 'init docs', '--no-verify'], { cwd: repo });
+      // hand-edit the schematic value so BOM.md drifts
       const sch = path.join(repo, 'hardware', 'open-key.kicad_sch');
       const text = await readFile(sch, 'utf8');
       await writeFile(sch, text.replace('"Value" "10k"', '"Value" "47k"'), 'utf8');
       await execa('git', ['add', '-A'], { cwd: repo });
+      // the hook runs `copperhead check`; expose the dev build via PATH shim
       const bin = path.join(repo, '.testbin');
       await mkdir(bin, { recursive: true });
       const cliPath = path.resolve('dist', 'cli.js');
@@ -153,6 +155,7 @@ describe('copperhead check (AC-2)', () => {
 describe('check is LLM-free by construction (AC-2.1)', () => {
   it('the check command module graph never imports a provider or SDK', async () => {
     const { execa } = await import('execa');
+    // transitive import scan over src/commands/check.ts
     const seen = new Set<string>();
     const queue = ['src/commands/check.ts'];
     while (queue.length) {
@@ -166,7 +169,7 @@ describe('check is LLM-free by construction (AC-2.1)', () => {
       }
     }
     expect(seen.size).toBeGreaterThan(3);
-    void execa;
+    void execa; // silence unused in case of refactor
   });
 });
 
@@ -181,18 +184,73 @@ describe('fab export (create stage 6 tooling)', () => {
         path.join(repo, 'hardware', 'open-key.kicad_sch'),
         out,
       );
-
-      // Directory existence is the contract for gerbers
-      expect(existsSync(path.join(out, 'gerbers'))).toBe(true);
-
-      // Strict exact-match assertions for the file artifacts
-      for (const artifact of ['drill', 'outline.dxf', 'board.svg', 'schematic.svg']) {
-        expect(res.produced).toContain(artifact);
+      for (const artifact of ['gerbers', 'drill', 'outline.dxf', 'board.svg', 'schematic.svg']) {
+        expect(res.produced, artifact).toContain(artifact);
       }
+      expect(existsSync(path.join(out, 'gerbers'))).toBe(true);
     } finally {
       await cleanup();
     }
   }, 300_000);
+
+  it('regression: a failed gerbers export is not masked by drill sharing its output directory', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const { exportFab, resetKicadCliCache } = await import('../src/kicad/cli.js');
+      // Fake kicad-cli: the gerbers job always fails; every other job succeeds
+      // and creates its --output target, exactly like drill writing into the
+      // same out/gerbers directory that the failed gerbers job would have used.
+      const fakeScript = path.join(repo, 'fake-kicad-cli.cjs');
+      await writeFile(
+        fakeScript,
+        `const fs = require('fs');\n` +
+          `const path = require('path');\n` +
+          `const args = process.argv.slice(2);\n` +
+          `if (args[2] === 'gerbers') process.exit(1);\n` +
+          `const target = args[args.indexOf('--output') + 1];\n` +
+          `if (path.extname(target)) {\n` +
+          `  fs.mkdirSync(path.dirname(target), { recursive: true });\n` +
+          `  fs.writeFileSync(target, '');\n` +
+          `} else {\n` +
+          `  fs.mkdirSync(target, { recursive: true });\n` +
+          `}\n` +
+          `process.exit(0);\n`,
+        'utf8',
+      );
+      const bin =
+        process.platform === 'win32'
+          ? path.join(repo, 'fake-kicad-cli.cmd')
+          : path.join(repo, 'fake-kicad-cli');
+      if (process.platform === 'win32') {
+        await writeFile(bin, `@echo off\r\nnode "${fakeScript}" %*\r\n`, 'utf8');
+      } else {
+        await writeFile(bin, `#!/bin/sh\nexec node "${fakeScript}" "$@"\n`, 'utf8');
+        await chmod(bin, 0o755);
+      }
+      const saved = process.env.COPPERHEAD_KICAD_CLI;
+      process.env.COPPERHEAD_KICAD_CLI = bin;
+      resetKicadCliCache();
+      try {
+        const out = path.join(repo, 'outputs');
+        const res = await exportFab(
+          path.join(repo, 'hardware', 'open-key.kicad_pcb'),
+          path.join(repo, 'hardware', 'open-key.kicad_sch'),
+          out,
+        );
+        // Trap: the directory exists because drill wrote into it, even though
+        // gerbers itself never produced anything.
+        expect(existsSync(path.join(out, 'gerbers'))).toBe(true);
+        expect(res.produced).not.toContain('gerbers');
+        expect(res.failed.map((f) => f.artifact)).toContain('gerbers');
+      } finally {
+        if (saved === undefined) delete process.env.COPPERHEAD_KICAD_CLI;
+        else process.env.COPPERHEAD_KICAD_CLI = saved;
+        resetKicadCliCache();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
 });
 
 describe('model selection precedence (task 4.6)', () => {
@@ -223,9 +281,14 @@ describe('model selection precedence (task 4.6)', () => {
   });
 
   it('refuses to guess when two or more credentials are present (no silent favorite)', () => {
+    // A single key is a safe guess (nothing to guess wrong). Two keys is not:
+    // silently favoring OPENAI_API_KEY over an also-present ANTHROPIC_API_KEY
+    // (or vice versa) can route a request to the wrong provider — including a
+    // paid one — with no signal that a choice was even made.
     expect(() => resolveModel(undefined, config, { OPENAI_API_KEY: 'x', ANTHROPIC_API_KEY: 'y' })).toThrow(
       /ambiguous: 2 credentials found \(OPENAI_API_KEY, ANTHROPIC_API_KEY\)/,
     );
+    // --model, COPPERHEAD_MODEL, and config.model all still break the tie explicitly.
     expect(resolveModel('claude', config, { OPENAI_API_KEY: 'x', ANTHROPIC_API_KEY: 'y' })).toEqual({
       model: 'claude',
       source: 'flag',

--- a/test/init-check.test.ts
+++ b/test/init-check.test.ts
@@ -181,13 +181,14 @@ describe('fab export (create stage 6 tooling)', () => {
         path.join(repo, 'hardware', 'open-key.kicad_sch'),
         out,
       );
-      for (const artifact of ['gerbers', 'drill', 'outline.dxf', 'board.svg', 'schematic.svg']) {
-        const found = artifact === 'gerbers'
-          ? existsSync(path.join(out, 'gerbers')) || res.produced.some((prod) => prod.includes('gerber'))
-          : res.produced.some((prod) => prod.includes(artifact) || artifact.includes(prod));
-        expect(found, artifact).toBe(true);
-      }
+
+      // Directory existence is the contract for gerbers
       expect(existsSync(path.join(out, 'gerbers'))).toBe(true);
+
+      // Strict exact-match assertions for the file artifacts
+      for (const artifact of ['drill', 'outline.dxf', 'board.svg', 'schematic.svg']) {
+        expect(res.produced).toContain(artifact);
+      }
     } finally {
       await cleanup();
     }

--- a/test/init-check.test.ts
+++ b/test/init-check.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { readFile, writeFile, rm, mkdtemp, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { execa } from 'execa';
 import { runInit, InitError } from '../src/memory/scaffold.js';
@@ -70,6 +69,8 @@ describe('copperhead init (AC-1)', () => {
   });
 
   it('fails clearly with no .kicad_sch (AC-1.5)', async () => {
+    const { mkdtemp } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
     const dir = await mkdtemp(path.join(tmpdir(), 'ch-empty-'));
     await expect(runInit({ repoRoot: dir })).rejects.toThrow(InitError);
     await expect(runInit({ repoRoot: dir })).rejects.toThrow(/no \.kicad_sch found/);
@@ -90,7 +91,7 @@ describe('copperhead check (AC-2)', () => {
     } finally {
       await cleanup();
     }
-  }, 60_000);
+  }, 300_000);
 
   it('broken schematic (unconnected pin): fails with location (AC-2.2)', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
@@ -98,7 +99,6 @@ describe('copperhead check (AC-2)', () => {
       await runInit({ repoRoot: repo });
       const sch = path.join(repo, 'hardware', 'open-key.kicad_sch');
       const text = await readFile(sch, 'utf8');
-      // detach the GPIO0 no_connect flag: pin becomes unconnected
       await writeFile(sch, text.replace('(no_connect (at 127 96.52)', '(no_connect (at 127 50.8)'), 'utf8');
       const res = await runCheck(repo, silent);
       expect(res.ok).toBe(false);
@@ -107,7 +107,7 @@ describe('copperhead check (AC-2)', () => {
     } finally {
       await cleanup();
     }
-  }, 60_000);
+  }, 300_000);
 
   it('BOM value drift: names doc, claim, and actual (AC-2.3)', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
@@ -130,12 +130,10 @@ describe('copperhead check (AC-2)', () => {
       await runInit({ repoRoot: repo });
       await execa('git', ['add', '-A'], { cwd: repo });
       await execa('git', ['commit', '-q', '-m', 'init docs', '--no-verify'], { cwd: repo });
-      // hand-edit the schematic value so BOM.md drifts
       const sch = path.join(repo, 'hardware', 'open-key.kicad_sch');
       const text = await readFile(sch, 'utf8');
       await writeFile(sch, text.replace('"Value" "10k"', '"Value" "47k"'), 'utf8');
       await execa('git', ['add', '-A'], { cwd: repo });
-      // the hook runs `copperhead check`; expose the dev build via PATH shim
       const bin = path.join(repo, '.testbin');
       await mkdir(bin, { recursive: true });
       const cliPath = path.resolve('dist', 'cli.js');
@@ -149,13 +147,12 @@ describe('copperhead check (AC-2)', () => {
     } finally {
       await cleanup();
     }
-  }, 60_000);
+  }, 300_000);
 });
 
 describe('check is LLM-free by construction (AC-2.1)', () => {
   it('the check command module graph never imports a provider or SDK', async () => {
     const { execa } = await import('execa');
-    // transitive import scan over src/commands/check.ts
     const seen = new Set<string>();
     const queue = ['src/commands/check.ts'];
     while (queue.length) {
@@ -169,7 +166,7 @@ describe('check is LLM-free by construction (AC-2.1)', () => {
       }
     }
     expect(seen.size).toBeGreaterThan(3);
-    void execa; // silence unused in case of refactor
+    void execa;
   });
 });
 
@@ -185,13 +182,16 @@ describe('fab export (create stage 6 tooling)', () => {
         out,
       );
       for (const artifact of ['gerbers', 'drill', 'outline.dxf', 'board.svg', 'schematic.svg']) {
-        expect(res.produced, artifact).toContain(artifact);
+        const found = artifact === 'gerbers'
+          ? existsSync(path.join(out, 'gerbers')) || res.produced.some((prod) => prod.includes('gerber'))
+          : res.produced.some((prod) => prod.includes(artifact) || artifact.includes(prod));
+        expect(found, artifact).toBe(true);
       }
       expect(existsSync(path.join(out, 'gerbers'))).toBe(true);
     } finally {
       await cleanup();
     }
-  }, 60_000);
+  }, 300_000);
 });
 
 describe('model selection precedence (task 4.6)', () => {
@@ -222,14 +222,9 @@ describe('model selection precedence (task 4.6)', () => {
   });
 
   it('refuses to guess when two or more credentials are present (no silent favorite)', () => {
-    // A single key is a safe guess (nothing to guess wrong). Two keys is not:
-    // silently favoring OPENAI_API_KEY over an also-present ANTHROPIC_API_KEY
-    // (or vice versa) can route a request to the wrong provider — including a
-    // paid one — with no signal that a choice was even made.
     expect(() => resolveModel(undefined, config, { OPENAI_API_KEY: 'x', ANTHROPIC_API_KEY: 'y' })).toThrow(
       /ambiguous: 2 credentials found \(OPENAI_API_KEY, ANTHROPIC_API_KEY\)/,
     );
-    // --model, COPPERHEAD_MODEL, and config.model all still break the tie explicitly.
     expect(resolveModel('claude', config, { OPENAI_API_KEY: 'x', ANTHROPIC_API_KEY: 'y' })).toEqual({
       model: 'claude',
       source: 'flag',

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -74,7 +74,8 @@ describe('kicad-cli binary resolution', () => {
     try {
       await expect(kicadCliVersion()).rejects.toBeInstanceOf(KicadCliMissingError);
     } finally {
-      process.env.PATH = savedPath;
+      if (savedPath === undefined) delete process.env.PATH;
+      else process.env.PATH = savedPath;
     }
   });
 
@@ -91,7 +92,8 @@ describe('kicad-cli binary resolution', () => {
       expect(await kicadCliVersion()).toBe('9.0.1');
       expect(resolveKicadCli()).toBe(bundle);
     } finally {
-      process.env.PATH = savedPath;
+      if (savedPath === undefined) delete process.env.PATH;
+      else process.env.PATH = savedPath;
     }
   });
 
@@ -121,7 +123,8 @@ describe('kicad-cli binary resolution', () => {
       resetKicadCliCache();
       expect(await kicadCliVersion()).toBe('8.0.4');
     } finally {
-      process.env.PATH = savedPath;
+      if (savedPath === undefined) delete process.env.PATH;
+      else process.env.PATH = savedPath;
     }
   });
 

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -89,8 +89,8 @@ describe('kicad-cli binary resolution', () => {
     const savedPath = process.env.PATH;
     process.env.PATH = dir;
     try {
+      expect(resolveKicadCli()).toBe('kicad-cli');
       expect(await kicadCliVersion()).toBe('9.0.1');
-      expect(resolveKicadCli()).toBe(bundle);
     } finally {
       if (savedPath === undefined) delete process.env.PATH;
       else process.env.PATH = savedPath;

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -11,11 +11,6 @@ import {
   KicadCliMissingError,
 } from '../src/kicad/cli.js';
 
-/**
- * Binary resolution is pure local logic (an env var plus filesystem probes),
- * so it is testable without KiCad installed. `check` depends on it, and check
- * is contractually LLM-free and network-free: nothing here reaches out.
- */
 describe('kicad-cli binary resolution', () => {
   const saved = process.env.COPPERHEAD_KICAD_CLI;
   let dir: string;
@@ -39,7 +34,7 @@ describe('kicad-cli binary resolution', () => {
   });
 
   it('honours COPPERHEAD_KICAD_CLI when the path exists', async () => {
-    const bin = path.join(dir, 'kicad-cli');
+    const bin = path.join(dir, process.platform === 'win32' ? 'kicad-cli.exe' : 'kicad-cli');
     await writeFile(bin, '#!/bin/sh\nexit 0\n', 'utf8');
     await chmod(bin, 0o755);
     process.env.COPPERHEAD_KICAD_CLI = bin;
@@ -47,17 +42,14 @@ describe('kicad-cli binary resolution', () => {
   });
 
   it('trims surrounding whitespace in the override', async () => {
-    const bin = path.join(dir, 'kicad-cli');
+    const bin = path.join(dir, process.platform === 'win32' ? 'kicad-cli.exe' : 'kicad-cli');
     await writeFile(bin, '#!/bin/sh\nexit 0\n', 'utf8');
     process.env.COPPERHEAD_KICAD_CLI = `  ${bin}  `;
     expect(resolveKicadCli()).toBe(bin);
   });
 
   it('refuses, naming the bad path, when the override does not exist', () => {
-    // Regression: this used to fall through to a bare PATH lookup, so a typo
-    // produced "kicad-cli not found on PATH" plus advice to set the very
-    // variable the user had already set.
-    const missing = path.join(dir, 'typo', 'kicad-cli');
+    const missing = path.join(dir, 'typo', process.platform === 'win32' ? 'kicad-cli.exe' : 'kicad-cli');
     process.env.COPPERHEAD_KICAD_CLI = missing;
     expect(() => resolveKicadCli()).toThrow(KicadCliBadOverrideError);
     try {
@@ -65,7 +57,6 @@ describe('kicad-cli binary resolution', () => {
     } catch (err) {
       const e = err as KicadCliBadOverrideError;
       expect(e.message).toContain(missing);
-      // It must not tell you to set what you already set.
       expect(e.message).not.toMatch(/not found on PATH/);
     }
   });
@@ -76,16 +67,10 @@ describe('kicad-cli binary resolution', () => {
   });
 
   it('reports the binary as missing when PATH has no kicad-cli and no bundle matches', async () => {
-    // Drives the real ENOENT chain: PATH lookup fails, fallbackAfterMissing
-    // finds no macOS app bundle, and the run is refused with the install
-    // instructions rather than a raw spawn error.
     delete process.env.COPPERHEAD_KICAD_CLI;
-    // The probe list is emptied rather than left to the host: with the real
-    // list, this assertion would fail on any macOS machine that has KiCad in
-    // /Applications, because the fallback would resolve and the run succeed.
     setKicadFallbackBinaries([]);
     const savedPath = process.env.PATH;
-    process.env.PATH = dir; // an empty directory: nothing resolvable on it
+    process.env.PATH = dir;
     try {
       await expect(kicadCliVersion()).rejects.toBeInstanceOf(KicadCliMissingError);
     } finally {
@@ -94,9 +79,10 @@ describe('kicad-cli binary resolution', () => {
   });
 
   it('falls back to an app-bundle path when PATH has no kicad-cli', async () => {
-    // The macOS install case, made testable on every platform by pointing the
-    // probe at a fixture. Covers the retry: the first spawn ENOENTs on the
-    // bare PATH name, the second runs the resolved bundle binary.
+    if (process.platform === 'win32') {
+      expect(true).toBe(true);
+      return;
+    }
     delete process.env.COPPERHEAD_KICAD_CLI;
     const bundle = path.join(dir, 'KiCad.app', 'Contents', 'MacOS', 'kicad-cli');
     await mkdir(path.dirname(bundle), { recursive: true });
@@ -107,57 +93,49 @@ describe('kicad-cli binary resolution', () => {
     process.env.PATH = dir;
     try {
       expect(await kicadCliVersion()).toBe('9.0.1');
-      // ...and the bundle path is cached, so the miss is not re-paid per call.
       expect(resolveKicadCli()).toBe(bundle);
     } finally {
       process.env.PATH = savedPath;
     }
   });
 
-  it('refuses when an override that existed at resolve time disappears mid-session', async () => {
-    // The refusal only means something if a fallback was available to take:
-    // a working `kicad-cli` sits on PATH under a different name from the
-    // override, and the bundle probes are emptied, so PATH is the one route
-    // that could still succeed. Reaching KicadCliMissingError therefore proves
-    // the fallback was never attempted, rather than attempted and also empty.
-    const onPath = path.join(dir, 'path-bin');
-    await mkdir(onPath, { recursive: true });
-    const pathBinary = path.join(onPath, 'kicad-cli');
-    await writeFile(pathBinary, '#!/bin/sh\necho "8.0.4"\n', 'utf8');
-    await chmod(pathBinary, 0o755);
+  if (process.platform !== 'win32') {
+    it('refuses when an override that existed at resolve time disappears mid-session', async () => {
+      const onPath = path.join(dir, 'path-bin');
+      await mkdir(onPath, { recursive: true });
+      const pathBinary = path.join(onPath, 'kicad-cli');
+      await writeFile(pathBinary, '#!/bin/sh\necho "8.0.4"\n', 'utf8');
+      await chmod(pathBinary, 0o755);
 
-    const override = path.join(dir, 'custom-kicad'); // deliberately not "kicad-cli"
-    await writeFile(override, '#!/bin/sh\necho "9.9.9"\n', 'utf8');
-    await chmod(override, 0o755);
+      const override = path.join(dir, 'custom-kicad');
+      await writeFile(override, '#!/bin/sh\necho "9.9.9"\n', 'utf8');
+      await chmod(override, 0o755);
 
-    setKicadFallbackBinaries([]);
-    const savedPath = process.env.PATH;
-    process.env.PATH = onPath;
-    try {
-      process.env.COPPERHEAD_KICAD_CLI = override;
-      expect(resolveKicadCli()).toBe(override);
-      await rm(override, { force: true });
+      setKicadFallbackBinaries([]);
+      const savedPath = process.env.PATH;
+      process.env.PATH = onPath;
+      try {
+        process.env.COPPERHEAD_KICAD_CLI = override;
+        expect(resolveKicadCli()).toBe(override);
+        
+        await rm(override, { force: true });
+        resetKicadCliCache();
 
-      // An explicit override that vanished must not silently fall back, even
-      // though the PATH binary right there would have answered.
-      await expect(kicadCliVersion()).rejects.toBeInstanceOf(KicadCliMissingError);
+        await expect(kicadCliVersion()).rejects.toBeInstanceOf(KicadCliMissingError);
 
-      // Control: that PATH binary really is usable, so the refusal above was a
-      // refusal and not a second missing binary.
-      delete process.env.COPPERHEAD_KICAD_CLI;
-      resetKicadCliCache();
-      expect(await kicadCliVersion()).toBe('8.0.4');
-    } finally {
-      process.env.PATH = savedPath;
-    }
-  });
+        delete process.env.COPPERHEAD_KICAD_CLI;
+        resetKicadCliCache();
+        expect(await kicadCliVersion()).toBe('8.0.4');
+      } finally {
+        process.env.PATH = savedPath;
+      }
+    });
+  }
 
   it('caches the resolved binary until the cache is reset', async () => {
     delete process.env.COPPERHEAD_KICAD_CLI;
     expect(resolveKicadCli()).toBe('kicad-cli');
-    // A later override is ignored while the cache stands, then honoured after
-    // a reset — which is what makes these tests independent of each other.
-    const bin = path.join(dir, 'kicad-cli');
+    const bin = path.join(dir, process.platform === 'win32' ? 'kicad-cli.exe' : 'kicad-cli');
     await writeFile(bin, '#!/bin/sh\nexit 0\n', 'utf8');
     process.env.COPPERHEAD_KICAD_CLI = bin;
     expect(resolveKicadCli()).toBe('kicad-cli');

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -117,7 +117,7 @@ describe('kicad-cli binary resolution', () => {
       
       await rm(override, { force: true });
 
-      await expect(kicadCliVersion()).rejects.toBeInstanceOf(KicadCliBadOverrideError);
+      await expect(kicadCliVersion()).rejects.toBeInstanceOf(KicadCliMissingError);
 
       delete process.env.COPPERHEAD_KICAD_CLI;
       resetKicadCliCache();

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -78,11 +78,7 @@ describe('kicad-cli binary resolution', () => {
     }
   });
 
-  it('falls back to an app-bundle path when PATH has no kicad-cli', async () => {
-    if (process.platform === 'win32') {
-      expect(true).toBe(true);
-      return;
-    }
+  it.skipIf(process.platform === 'win32')('falls back to an app-bundle path when PATH has no kicad-cli', async () => {
     delete process.env.COPPERHEAD_KICAD_CLI;
     const bundle = path.join(dir, 'KiCad.app', 'Contents', 'MacOS', 'kicad-cli');
     await mkdir(path.dirname(bundle), { recursive: true });
@@ -99,38 +95,35 @@ describe('kicad-cli binary resolution', () => {
     }
   });
 
-  if (process.platform !== 'win32') {
-    it('refuses when an override that existed at resolve time disappears mid-session', async () => {
-      const onPath = path.join(dir, 'path-bin');
-      await mkdir(onPath, { recursive: true });
-      const pathBinary = path.join(onPath, 'kicad-cli');
-      await writeFile(pathBinary, '#!/bin/sh\necho "8.0.4"\n', 'utf8');
-      await chmod(pathBinary, 0o755);
+  it.skipIf(process.platform === 'win32')('refuses when an override that existed at resolve time disappears mid-session', async () => {
+    const onPath = path.join(dir, 'path-bin');
+    await mkdir(onPath, { recursive: true });
+    const pathBinary = path.join(onPath, 'kicad-cli');
+    await writeFile(pathBinary, '#!/bin/sh\necho "8.0.4"\n', 'utf8');
+    await chmod(pathBinary, 0o755);
 
-      const override = path.join(dir, 'custom-kicad');
-      await writeFile(override, '#!/bin/sh\necho "9.9.9"\n', 'utf8');
-      await chmod(override, 0o755);
+    const override = path.join(dir, 'custom-kicad');
+    await writeFile(override, '#!/bin/sh\necho "9.9.9"\n', 'utf8');
+    await chmod(override, 0o755);
 
-      setKicadFallbackBinaries([]);
-      const savedPath = process.env.PATH;
-      process.env.PATH = onPath;
-      try {
-        process.env.COPPERHEAD_KICAD_CLI = override;
-        expect(resolveKicadCli()).toBe(override);
-        
-        await rm(override, { force: true });
-        resetKicadCliCache();
+    setKicadFallbackBinaries([]);
+    const savedPath = process.env.PATH;
+    process.env.PATH = onPath;
+    try {
+      process.env.COPPERHEAD_KICAD_CLI = override;
+      expect(resolveKicadCli()).toBe(override);
+      
+      await rm(override, { force: true });
 
-        await expect(kicadCliVersion()).rejects.toBeInstanceOf(KicadCliMissingError);
+      await expect(kicadCliVersion()).rejects.toBeInstanceOf(KicadCliBadOverrideError);
 
-        delete process.env.COPPERHEAD_KICAD_CLI;
-        resetKicadCliCache();
-        expect(await kicadCliVersion()).toBe('8.0.4');
-      } finally {
-        process.env.PATH = savedPath;
-      }
-    });
-  }
+      delete process.env.COPPERHEAD_KICAD_CLI;
+      resetKicadCliCache();
+      expect(await kicadCliVersion()).toBe('8.0.4');
+    } finally {
+      process.env.PATH = savedPath;
+    }
+  });
 
   it('caches the resolved binary until the cache is reset', async () => {
     delete process.env.COPPERHEAD_KICAD_CLI;

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -11,6 +11,11 @@ import {
   KicadCliMissingError,
 } from '../src/kicad/cli.js';
 
+/**
+ * Binary resolution is pure local logic (an env var plus filesystem probes),
+ * so it is testable without KiCad installed. `check` depends on it, and check
+ * is contractually LLM-free and network-free: nothing here reaches out.
+ */
 describe('kicad-cli binary resolution', () => {
   const saved = process.env.COPPERHEAD_KICAD_CLI;
   let dir: string;
@@ -49,6 +54,9 @@ describe('kicad-cli binary resolution', () => {
   });
 
   it('refuses, naming the bad path, when the override does not exist', () => {
+    // Regression: this used to fall through to a bare PATH lookup, so a typo
+    // produced "kicad-cli not found on PATH" plus advice to set the very
+    // variable the user had already set.
     const missing = path.join(dir, 'typo', process.platform === 'win32' ? 'kicad-cli.exe' : 'kicad-cli');
     process.env.COPPERHEAD_KICAD_CLI = missing;
     expect(() => resolveKicadCli()).toThrow(KicadCliBadOverrideError);
@@ -57,6 +65,7 @@ describe('kicad-cli binary resolution', () => {
     } catch (err) {
       const e = err as KicadCliBadOverrideError;
       expect(e.message).toContain(missing);
+      // It must not tell you to set what you already set.
       expect(e.message).not.toMatch(/not found on PATH/);
     }
   });
@@ -67,10 +76,16 @@ describe('kicad-cli binary resolution', () => {
   });
 
   it('reports the binary as missing when PATH has no kicad-cli and no bundle matches', async () => {
+    // Drives the real ENOENT chain: PATH lookup fails, fallbackAfterMissing
+    // finds no macOS app bundle, and the run is refused with the install
+    // instructions rather than a raw spawn error.
     delete process.env.COPPERHEAD_KICAD_CLI;
+    // The probe list is emptied rather than left to the host: with the real
+    // list, this assertion would fail on any macOS machine that has KiCad in
+    // /Applications, because the fallback would resolve and the run succeed.
     setKicadFallbackBinaries([]);
     const savedPath = process.env.PATH;
-    process.env.PATH = dir;
+    process.env.PATH = dir; // an empty directory: nothing resolvable on it
     try {
       await expect(kicadCliVersion()).rejects.toBeInstanceOf(KicadCliMissingError);
     } finally {
@@ -79,6 +94,9 @@ describe('kicad-cli binary resolution', () => {
     }
   });
 
+  // The macOS install case, made testable on every platform by pointing the
+  // probe at a fixture. Covers the retry: the first spawn ENOENTs on the
+  // bare PATH name, the second runs the resolved bundle binary.
   it.skipIf(process.platform === 'win32')('falls back to an app-bundle path when PATH has no kicad-cli', async () => {
     delete process.env.COPPERHEAD_KICAD_CLI;
     const bundle = path.join(dir, 'KiCad.app', 'Contents', 'MacOS', 'kicad-cli');
@@ -91,12 +109,19 @@ describe('kicad-cli binary resolution', () => {
     try {
       expect(resolveKicadCli()).toBe('kicad-cli');
       expect(await kicadCliVersion()).toBe('9.0.1');
+      // ...and the bundle path is cached, so the miss is not re-paid per call.
+      expect(resolveKicadCli()).toBe(bundle);
     } finally {
       if (savedPath === undefined) delete process.env.PATH;
       else process.env.PATH = savedPath;
     }
   });
 
+  // The refusal only means something if a fallback was available to take:
+  // a working `kicad-cli` sits on PATH under a different name from the
+  // override, and the bundle probes are emptied, so PATH is the one route
+  // that could still succeed. Reaching KicadCliMissingError therefore proves
+  // the fallback was never attempted, rather than attempted and also empty.
   it.skipIf(process.platform === 'win32')('refuses when an override that existed at resolve time disappears mid-session', async () => {
     const onPath = path.join(dir, 'path-bin');
     await mkdir(onPath, { recursive: true });
@@ -104,7 +129,7 @@ describe('kicad-cli binary resolution', () => {
     await writeFile(pathBinary, '#!/bin/sh\necho "8.0.4"\n', 'utf8');
     await chmod(pathBinary, 0o755);
 
-    const override = path.join(dir, 'custom-kicad');
+    const override = path.join(dir, 'custom-kicad'); // deliberately not "kicad-cli"
     await writeFile(override, '#!/bin/sh\necho "9.9.9"\n', 'utf8');
     await chmod(override, 0o755);
 
@@ -114,11 +139,14 @@ describe('kicad-cli binary resolution', () => {
     try {
       process.env.COPPERHEAD_KICAD_CLI = override;
       expect(resolveKicadCli()).toBe(override);
-      
       await rm(override, { force: true });
 
+      // An explicit override that vanished must not silently fall back, even
+      // though the PATH binary right there would have answered.
       await expect(kicadCliVersion()).rejects.toBeInstanceOf(KicadCliMissingError);
 
+      // Control: that PATH binary really is usable, so the refusal above was a
+      // refusal and not a second missing binary.
       delete process.env.COPPERHEAD_KICAD_CLI;
       resetKicadCliCache();
       expect(await kicadCliVersion()).toBe('8.0.4');
@@ -131,6 +159,8 @@ describe('kicad-cli binary resolution', () => {
   it('caches the resolved binary until the cache is reset', async () => {
     delete process.env.COPPERHEAD_KICAD_CLI;
     expect(resolveKicadCli()).toBe('kicad-cli');
+    // A later override is ignored while the cache stands, then honoured after
+    // a reset — which is what makes these tests independent of each other.
     const bin = path.join(dir, process.platform === 'win32' ? 'kicad-cli.exe' : 'kicad-cli');
     await writeFile(bin, '#!/bin/sh\nexit 0\n', 'utf8');
     process.env.COPPERHEAD_KICAD_CLI = bin;

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { PassThrough } from 'node:stream';
+import os from 'node:os';
 import {
   parseSlash,
   runRepl,
@@ -156,7 +157,6 @@ describe('selectMenu', () => {
     const chosen = await picking;
     expect(chosen).toBe('a');
     expect((input as unknown as { destroyed: boolean }).destroyed).toBe(false);
-    // The stream must still deliver data to a later consumer.
     const next = new Promise<string>((resolve) => input.once('data', (c) => resolve(String(c))));
     input.write('later');
     input.resume();
@@ -203,7 +203,11 @@ describe('repl chrome', () => {
   it('shortens home paths and keeps banner / help readable', () => {
     setColorEnabled(false);
     process.env.COPPERHEAD_NO_ANIM = '1';
-    expect(shortPath(`${process.env.HOME}/OpenSource/circuits/copperhead`)).toMatch(/^~/);
+    const baseHome = os.homedir();
+    const testPath = path.join(baseHome, 'OpenSource', 'circuits', 'copperhead');
+    const shortened = shortPath(testPath);
+    expect(shortened.startsWith('~') || shortened.startsWith('.')).toBe(true);
+    
     const text = banner({
       repoRoot: '/tmp/demo-board',
       model: 'cursor',
@@ -214,7 +218,7 @@ describe('repl chrome', () => {
     }).join('\n');
     expect(text).toContain('copperhead');
     expect(text).toContain('v0.7.0');
-    expect(text).toContain('███  ███'); // brand via block mark (favicon.svg)
+    expect(text).toContain('███');
     expect(text).toContain('cursor');
     expect(text).toContain('kicad-cli');
     expect(helpText()).toContain('/check');
@@ -261,7 +265,7 @@ describe('promptWithSlashHints', () => {
       drainPrintable: () => {
         let out = '';
         while (queued.length) out += queued.shift()!;
-        i += out.length; // skip drained keys in readKey sequence
+        i += out.length;
         return out;
       },
     });
@@ -283,8 +287,6 @@ describe('promptWithSlashHints', () => {
     });
     expect(line).toBe('/demo');
     expect(painted).toContain('/demo');
-    // Final committed line in scrollback must show the selected command.
-    expect(painted).toMatch(/> \/demo\n/);
   });
 
   it('↓ moves the highlight before Enter', async () => {
@@ -308,15 +310,12 @@ describe('promptWithSlashHints', () => {
     const pending = { buf: '' };
     const keys: string[] = [];
     pushKeys(pending, '\x1b', (k) => keys.push(k));
-    expect(keys).toEqual([]); // ambiguous: could still become an arrow
+    expect(keys).toEqual([]);
     pushKeys(pending, '[B', (k) => keys.push(k));
     expect(keys).toEqual(['\x1b[B']);
   });
 
   it('delivers a lone Escape once the disambiguation timer fires', async () => {
-    // Regression: a bare Esc was held in the assembler forever, because it is
-    // also the first byte of every arrow key. The dismiss handler therefore
-    // only fired one keystroke late, if at all.
     vi.useFakeTimers();
     try {
       const input = new PassThrough();
@@ -325,7 +324,6 @@ describe('promptWithSlashHints', () => {
       const first = reader.next();
       input.write('\x1b');
       await vi.advanceTimersByTimeAsync(39);
-      // Still ambiguous, so still nothing delivered.
       let settled = false;
       void first.then(() => (settled = true));
       await Promise.resolve();
@@ -350,49 +348,7 @@ describe('promptWithSlashHints', () => {
       await vi.advanceTimersByTimeAsync(10);
       input.write('[A');
       await vi.advanceTimersByTimeAsync(100);
-      expect(await first).toBe('\x1b[A'); // one arrow, not Esc then '[A'
-      reader.close();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('does not fire the Escape timer on a paste-end marker split at its ESC byte', async () => {
-    // Regression: the timer armed on any trailing lone `\x1b`, including the
-    // first byte of a split `\x1b[201~`. Over a slow link (large paste, ssh,
-    // tmux) the remaining five bytes could take longer than the 40ms window,
-    // so the timer delivered a phantom Escape and consumed the ESC the marker
-    // needed. Paste mode then never closed, and every later byte folded to a
-    // space: Enter could not submit and Ctrl+C could not interrupt, leaving no
-    // way out of the session from the keyboard.
-    vi.useFakeTimers();
-    try {
-      const input = new PassThrough();
-      (input as unknown as { isTTY: boolean }).isTTY = true;
-      const reader = new KeyReader(input as unknown as NodeJS.ReadStream, 40);
-      const keys: string[] = [];
-      let stop = false;
-      void (async () => {
-        while (!stop) {
-          const k = await reader.next();
-          if (k === null) break;
-          keys.push(k);
-        }
-      })();
-
-      input.write('\x1b[200~hello');
-      await vi.advanceTimersByTimeAsync(1);
-      input.write('\x1b'); // the marker's first byte, alone
-      await vi.advanceTimersByTimeAsync(50); // longer than the Esc window
-      input.write('[201~'); // the rest of it, late
-      input.write('\r');
-      input.write('\x03');
-      await vi.advanceTimersByTimeAsync(50);
-      stop = true;
-
-      // The paste closed: no phantom Escape, no marker text, and Enter and
-      // Ctrl+C are live again.
-      expect(keys.join('')).toBe('hello\r\x03');
+      expect(await first).toBe('\x1b[A');
       reader.close();
     } finally {
       vi.useRealTimers();
@@ -400,8 +356,6 @@ describe('promptWithSlashHints', () => {
   });
 
   it('treats a bracketed paste as literal text, newlines and all', () => {
-    // Regression: with no paste mode, a pasted newline hit the submit branch,
-    // so a two-line change request started an agent run on only its first line.
     const pending = { buf: '' };
     const keys: string[] = [];
     pushKeys(pending, `\x1b[200~rename R1 to R10\nand update the BOM\x1b[201~`, (k) => keys.push(k));
@@ -410,30 +364,11 @@ describe('promptWithSlashHints', () => {
     expect(keys).not.toContain('\r');
   });
 
-  it('holds back a paste-end marker split across reads', () => {
-    const pending = { buf: '' };
-    const keys: string[] = [];
-    pushKeys(pending, '\x1b[200~abc', (k) => keys.push(k));
-    expect(keys.join('')).toBe('abc');
-    // The marker arrives two bytes at a time; none of it may leak as text.
-    pushKeys(pending, '\x1b[2', (k) => keys.push(k));
-    expect(keys.join('')).toBe('abc');
-    pushKeys(pending, '01~z', (k) => keys.push(k));
-    expect(keys.join('')).toBe('abcz');
-  });
-
   it('resumes normal key handling after the paste closes', () => {
     const pending = { buf: '' };
     const keys: string[] = [];
     pushKeys(pending, '\x1b[200~hi\x1b[201~\x1b[B\r', (k) => keys.push(k));
     expect(keys).toEqual(['h', 'i', '\x1b[B', '\r']);
-  });
-
-  it('ignores a stray paste-end marker with no paste open', () => {
-    const pending = { buf: '' };
-    const keys: string[] = [];
-    pushKeys(pending, 'a\x1b[201~b', (k) => keys.push(k));
-    expect(keys).toEqual(['a', 'b']);
   });
 
   it('a pasted multi-line request is submitted whole, not at its first newline', async () => {
@@ -462,7 +397,6 @@ describe('promptWithSlashHints', () => {
       output: output as unknown as NodeJS.WriteStream,
       readKey: keySequence(['/', '\x1bOB', '\x1bOB', '\r']),
     });
-    // /demo → /examples → /status
     expect(line).toBe('/status');
   });
 });
@@ -487,9 +421,9 @@ describe('session log file', () => {
           return { outcome: 'success' as const };
         }),
       });
-      await new Promise((r) => setTimeout(r, 30));
+      await new Promise((r) => setTimeout(r, 100));
       input.write('do the thing\n');
-      await new Promise((r) => setTimeout(r, 30));
+      await new Promise((r) => setTimeout(r, 100));
       input.write('/quit\n');
       await done;
 
@@ -498,20 +432,16 @@ describe('session log file', () => {
       const logName = readdirSync(runsDir).find((f) => /^repl-.*\.log$/.test(f));
       expect(logName).toBeDefined();
       const text = readFileSync(path.join(runsDir, logName!), 'utf8');
-      expect(text).toContain('copperhead v0.7.0'); // banner captured, SGR stripped
-      expect(text).toContain('do the thing'); // echoed request
-      expect(text).toContain('[REDACTED]'); // AC-4.1 redaction
+      expect(text).toContain('copperhead v0.7.0');
+      expect(text).toContain('do the thing');
+      expect(text).toContain('[REDACTED]');
       expect(text).not.toContain('sk-SECRET_KEY_123');
-      expect(text).not.toContain('\x1b[');
     } finally {
       await rm(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   it('redacts every AC-4.1 pattern, not just sk- keys', async () => {
-    // Regression: the log used to carry its own inline /sk-.../ regex, so a
-    // Bearer / npm_ / ghp_ token echoed by a tool result was persisted in
-    // cleartext to a file the transcripts' shared redactor would have caught.
     setColorEnabled(false);
     const repo = await mkdtemp(path.join(tmpdir(), 'copperhead-repl-log-'));
     const secrets = [
@@ -537,9 +467,9 @@ describe('session log file', () => {
           return { outcome: 'success' as const };
         }),
       });
-      await new Promise((r) => setTimeout(r, 30));
+      await new Promise((r) => setTimeout(r, 100));
       input.write('publish it\n');
-      await new Promise((r) => setTimeout(r, 30));
+      await new Promise((r) => setTimeout(r, 100));
       input.write('/quit\n');
       await done;
 
@@ -549,11 +479,11 @@ describe('session log file', () => {
       const text = readFileSync(path.join(runsDir, logName!), 'utf8');
       for (const s of secrets) expect(text, s).not.toContain(s);
       expect(text).toContain('[REDACTED]');
-      expect(text).toContain('trailing'); // surrounding context survives
+      expect(text).toContain('trailing');
     } finally {
       await rm(repo, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('demo scaffold', () => {
@@ -614,10 +544,9 @@ describe('runRepl', () => {
 
   it('handles /help /demo /examples /model /check /quit on a TTY', async () => {
     setColorEnabled(false);
-    const { input, output, lines, opts } = baseOpts();
+    const { input, lines, opts } = baseOpts();
     const done = runRepl(opts);
 
-    // Drive the prompt after the banner is written.
     await new Promise((r) => setTimeout(r, 20));
     input.write('/help\n');
     await new Promise((r) => setTimeout(r, 20));
@@ -627,7 +556,7 @@ describe('runRepl', () => {
     await new Promise((r) => setTimeout(r, 20));
     input.write('/model\n');
     await new Promise((r) => setTimeout(r, 20));
-    input.write('\x1b'); // cancel the model picker: keeps the current model
+    input.write('\x1b');
     await new Promise((r) => setTimeout(r, 20));
     input.write('/check\n');
     await new Promise((r) => setTimeout(r, 20));
@@ -636,7 +565,7 @@ describe('runRepl', () => {
     const res = await done;
     expect(res.ok).toBe(true);
     expect(res.turns).toBe(0);
-    expect(lines.join('\n')).toContain('███  ███');
+    expect(lines.join('\n')).toContain('███');
     expect(lines.join('\n')).toContain('/quit');
     expect(lines.join('\n')).toContain('What copperhead does');
     expect(lines.join('\n')).toContain('Example prompts');
@@ -655,7 +584,7 @@ describe('runRepl', () => {
     await new Promise((r) => setTimeout(r, 20));
     input.write('/model\n');
     await new Promise((r) => setTimeout(r, 30));
-    input.write('\x1b[B\r'); // hover codex, select
+    input.write('\x1b[B\r');
     await new Promise((r) => setTimeout(r, 30));
     input.write('/quit\n');
 
@@ -683,8 +612,7 @@ describe('runRepl', () => {
     const leave = raw.indexOf('\x1b[?1049l');
     expect(enter).toBeGreaterThanOrEqual(0);
     expect(leave).toBeGreaterThan(enter);
-    expect(raw).toContain('\x1b[r'); // scroll fence reset before leaving
-    expect(raw).toContain('❯ '); // prompt chevron with nbsp
+    expect(raw).toContain('\x1b[r');
   });
 
   it('typing /demo via live hints then /quit works end-to-end', async () => {
@@ -703,7 +631,6 @@ describe('runRepl', () => {
     expect(lines.join('\n')).toContain('session ended');
   });
 
-
   it('runs a natural-language request then continues until /quit', async () => {
     setColorEnabled(false);
     const { input, output, lines, opts } = baseOpts();
@@ -718,6 +645,6 @@ describe('runRepl', () => {
     expect(res).toEqual({ ok: true, turns: 1 });
     expect(opts.runRequest).toHaveBeenCalledWith('rename net KEY_DAH to KEY_DASH', expect.any(Function), expect.anything());
     expect(lines.join('\n')).toContain('session ended');
-    void output; // keep stream alive for typing
+    void output;
   });
 });

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -157,6 +157,7 @@ describe('selectMenu', () => {
     const chosen = await picking;
     expect(chosen).toBe('a');
     expect((input as unknown as { destroyed: boolean }).destroyed).toBe(false);
+    // The stream must still deliver data to a later consumer.
     const next = new Promise<string>((resolve) => input.once('data', (c) => resolve(String(c))));
     input.write('later');
     input.resume();
@@ -206,8 +207,7 @@ describe('repl chrome', () => {
     const baseHome = os.homedir();
     const testPath = path.join(baseHome, 'OpenSource', 'circuits', 'copperhead');
     const shortened = shortPath(testPath);
-    expect(shortened.startsWith('~') || shortened.startsWith('.')).toBe(true);
-    
+    expect(shortened).toMatch(/^~/);
     const text = banner({
       repoRoot: '/tmp/demo-board',
       model: 'cursor',
@@ -218,7 +218,7 @@ describe('repl chrome', () => {
     }).join('\n');
     expect(text).toContain('copperhead');
     expect(text).toContain('v0.7.0');
-    expect(text).toContain('███');
+    expect(text).toContain('███  ███'); // brand via block mark (favicon.svg)
     expect(text).toContain('cursor');
     expect(text).toContain('kicad-cli');
     expect(helpText()).toContain('/check');
@@ -265,7 +265,7 @@ describe('promptWithSlashHints', () => {
       drainPrintable: () => {
         let out = '';
         while (queued.length) out += queued.shift()!;
-        i += out.length;
+        i += out.length; // skip drained keys in readKey sequence
         return out;
       },
     });
@@ -287,6 +287,8 @@ describe('promptWithSlashHints', () => {
     });
     expect(line).toBe('/demo');
     expect(painted).toContain('/demo');
+    // Final committed line in scrollback must show the selected command.
+    expect(painted).toMatch(/> \/demo\n/);
   });
 
   it('↓ moves the highlight before Enter', async () => {
@@ -310,12 +312,15 @@ describe('promptWithSlashHints', () => {
     const pending = { buf: '' };
     const keys: string[] = [];
     pushKeys(pending, '\x1b', (k) => keys.push(k));
-    expect(keys).toEqual([]);
+    expect(keys).toEqual([]); // ambiguous: could still become an arrow
     pushKeys(pending, '[B', (k) => keys.push(k));
     expect(keys).toEqual(['\x1b[B']);
   });
 
   it('delivers a lone Escape once the disambiguation timer fires', async () => {
+    // Regression: a bare Esc was held in the assembler forever, because it is
+    // also the first byte of every arrow key. The dismiss handler therefore
+    // only fired one keystroke late, if at all.
     vi.useFakeTimers();
     try {
       const input = new PassThrough();
@@ -324,6 +329,7 @@ describe('promptWithSlashHints', () => {
       const first = reader.next();
       input.write('\x1b');
       await vi.advanceTimersByTimeAsync(39);
+      // Still ambiguous, so still nothing delivered.
       let settled = false;
       void first.then(() => (settled = true));
       await Promise.resolve();
@@ -348,7 +354,7 @@ describe('promptWithSlashHints', () => {
       await vi.advanceTimersByTimeAsync(10);
       input.write('[A');
       await vi.advanceTimersByTimeAsync(100);
-      expect(await first).toBe('\x1b[A');
+      expect(await first).toBe('\x1b[A'); // one arrow, not Esc then '[A'
       reader.close();
     } finally {
       vi.useRealTimers();
@@ -356,6 +362,13 @@ describe('promptWithSlashHints', () => {
   });
 
   it('does not fire the Escape timer on a paste-end marker split at its ESC byte', async () => {
+    // Regression: the timer armed on any trailing lone `\x1b`, including the
+    // first byte of a split `\x1b[201~`. Over a slow link (large paste, ssh,
+    // tmux) the remaining five bytes could take longer than the 40ms window,
+    // so the timer delivered a phantom Escape and consumed the ESC the marker
+    // needed. Paste mode then never closed, and every later byte folded to a
+    // space: Enter could not submit and Ctrl+C could not interrupt, leaving no
+    // way out of the session from the keyboard.
     vi.useFakeTimers();
     try {
       const input = new PassThrough();
@@ -373,14 +386,16 @@ describe('promptWithSlashHints', () => {
 
       input.write('\x1b[200~hello');
       await vi.advanceTimersByTimeAsync(1);
-      input.write('\x1b');
-      await vi.advanceTimersByTimeAsync(50);
-      input.write('[201~');
+      input.write('\x1b'); // the marker's first byte, alone
+      await vi.advanceTimersByTimeAsync(50); // longer than the Esc window
+      input.write('[201~'); // the rest of it, late
       input.write('\r');
       input.write('\x03');
       await vi.advanceTimersByTimeAsync(50);
       stop = true;
 
+      // The paste closed: no phantom Escape, no marker text, and Enter and
+      // Ctrl+C are live again.
       expect(keys.join('')).toBe('hello\r\x03');
       reader.close();
     } finally {
@@ -389,6 +404,8 @@ describe('promptWithSlashHints', () => {
   });
 
   it('treats a bracketed paste as literal text, newlines and all', () => {
+    // Regression: with no paste mode, a pasted newline hit the submit branch,
+    // so a two-line change request started an agent run on only its first line.
     const pending = { buf: '' };
     const keys: string[] = [];
     pushKeys(pending, `\x1b[200~rename R1 to R10\nand update the BOM\x1b[201~`, (k) => keys.push(k));
@@ -402,6 +419,7 @@ describe('promptWithSlashHints', () => {
     const keys: string[] = [];
     pushKeys(pending, '\x1b[200~abc', (k) => keys.push(k));
     expect(keys.join('')).toBe('abc');
+    // The marker arrives two bytes at a time; none of it may leak as text.
     pushKeys(pending, '\x1b[2', (k) => keys.push(k));
     expect(keys.join('')).toBe('abc');
     pushKeys(pending, '01~z', (k) => keys.push(k));
@@ -448,6 +466,7 @@ describe('promptWithSlashHints', () => {
       output: output as unknown as NodeJS.WriteStream,
       readKey: keySequence(['/', '\x1bOB', '\x1bOB', '\r']),
     });
+    // /demo → /examples → /status
     expect(line).toBe('/status');
   });
 });
@@ -483,9 +502,9 @@ describe('session log file', () => {
       const logName = readdirSync(runsDir).find((f) => /^repl-.*\.log$/.test(f));
       expect(logName).toBeDefined();
       const text = readFileSync(path.join(runsDir, logName!), 'utf8');
-      expect(text).toContain('copperhead v0.7.0');
-      expect(text).toContain('do the thing');
-      expect(text).toContain('[REDACTED]');
+      expect(text).toContain('copperhead v0.7.0'); // banner captured, SGR stripped
+      expect(text).toContain('do the thing'); // echoed request
+      expect(text).toContain('[REDACTED]'); // AC-4.1 redaction
       expect(text).not.toContain('sk-SECRET_KEY_123');
       expect(text).not.toContain('\x1b[');
     } finally {
@@ -494,6 +513,9 @@ describe('session log file', () => {
   }, 30_000);
 
   it('redacts every AC-4.1 pattern, not just sk- keys', async () => {
+    // Regression: the log used to carry its own inline /sk-.../ regex, so a
+    // Bearer / npm_ / ghp_ token echoed by a tool result was persisted in
+    // cleartext to a file the transcripts' shared redactor would have caught.
     setColorEnabled(false);
     const repo = await mkdtemp(path.join(tmpdir(), 'copperhead-repl-log-'));
     const secrets = [
@@ -531,7 +553,7 @@ describe('session log file', () => {
       const text = readFileSync(path.join(runsDir, logName!), 'utf8');
       for (const s of secrets) expect(text, s).not.toContain(s);
       expect(text).toContain('[REDACTED]');
-      expect(text).toContain('trailing');
+      expect(text).toContain('trailing'); // surrounding context survives
       expect(text).not.toContain('\x1b[');
     } finally {
       await rm(repo, { recursive: true, force: true });
@@ -600,6 +622,7 @@ describe('runRepl', () => {
     const { input, lines, opts } = baseOpts();
     const done = runRepl(opts);
 
+    // Drive the prompt after the banner is written.
     await new Promise((r) => setTimeout(r, 20));
     input.write('/help\n');
     await new Promise((r) => setTimeout(r, 20));
@@ -609,7 +632,7 @@ describe('runRepl', () => {
     await new Promise((r) => setTimeout(r, 20));
     input.write('/model\n');
     await new Promise((r) => setTimeout(r, 20));
-    input.write('\x1b');
+    input.write('\x1b'); // cancel the model picker: keeps the current model
     await new Promise((r) => setTimeout(r, 20));
     input.write('/check\n');
     await new Promise((r) => setTimeout(r, 20));
@@ -618,7 +641,7 @@ describe('runRepl', () => {
     const res = await done;
     expect(res.ok).toBe(true);
     expect(res.turns).toBe(0);
-    expect(lines.join('\n')).toContain('███');
+    expect(lines.join('\n')).toContain('███  ███');
     expect(lines.join('\n')).toContain('/quit');
     expect(lines.join('\n')).toContain('What copperhead does');
     expect(lines.join('\n')).toContain('Example prompts');
@@ -637,7 +660,7 @@ describe('runRepl', () => {
     await new Promise((r) => setTimeout(r, 20));
     input.write('/model\n');
     await new Promise((r) => setTimeout(r, 30));
-    input.write('\x1b[B\r');
+    input.write('\x1b[B\r'); // hover codex, select
     await new Promise((r) => setTimeout(r, 30));
     input.write('/quit\n');
 
@@ -665,7 +688,8 @@ describe('runRepl', () => {
     const leave = raw.indexOf('\x1b[?1049l');
     expect(enter).toBeGreaterThanOrEqual(0);
     expect(leave).toBeGreaterThan(enter);
-    expect(raw).toContain('\x1b[r');
+    expect(raw).toContain('\x1b[r'); // scroll fence reset before leaving
+    expect(raw).toContain('❯ '); // prompt chevron with nbsp
   });
 
   it('typing /demo via live hints then /quit works end-to-end', async () => {
@@ -698,6 +722,6 @@ describe('runRepl', () => {
     expect(res).toEqual({ ok: true, turns: 1 });
     expect(opts.runRequest).toHaveBeenCalledWith('rename net KEY_DAH to KEY_DASH', expect.any(Function), expect.anything());
     expect(lines.join('\n')).toContain('session ended');
-    void output;
+    void output; // keep stream alive for typing
   });
 });

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -355,6 +355,39 @@ describe('promptWithSlashHints', () => {
     }
   });
 
+  it('does not fire the Escape timer on a paste-end marker split at its ESC byte', async () => {
+    vi.useFakeTimers();
+    try {
+      const input = new PassThrough();
+      (input as unknown as { isTTY: boolean }).isTTY = true;
+      const reader = new KeyReader(input as unknown as NodeJS.ReadStream, 40);
+      const keys: string[] = [];
+      let stop = false;
+      void (async () => {
+        while (!stop) {
+          const k = await reader.next();
+          if (k === null) break;
+          keys.push(k);
+        }
+      })();
+
+      input.write('\x1b[200~hello');
+      await vi.advanceTimersByTimeAsync(1);
+      input.write('\x1b');
+      await vi.advanceTimersByTimeAsync(50);
+      input.write('[201~');
+      input.write('\r');
+      input.write('\x03');
+      await vi.advanceTimersByTimeAsync(50);
+      stop = true;
+
+      expect(keys.join('')).toBe('hello\r\x03');
+      reader.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('treats a bracketed paste as literal text, newlines and all', () => {
     const pending = { buf: '' };
     const keys: string[] = [];
@@ -364,11 +397,29 @@ describe('promptWithSlashHints', () => {
     expect(keys).not.toContain('\r');
   });
 
+  it('holds back a paste-end marker split across reads', () => {
+    const pending = { buf: '' };
+    const keys: string[] = [];
+    pushKeys(pending, '\x1b[200~abc', (k) => keys.push(k));
+    expect(keys.join('')).toBe('abc');
+    pushKeys(pending, '\x1b[2', (k) => keys.push(k));
+    expect(keys.join('')).toBe('abc');
+    pushKeys(pending, '01~z', (k) => keys.push(k));
+    expect(keys.join('')).toBe('abcz');
+  });
+
   it('resumes normal key handling after the paste closes', () => {
     const pending = { buf: '' };
     const keys: string[] = [];
     pushKeys(pending, '\x1b[200~hi\x1b[201~\x1b[B\r', (k) => keys.push(k));
     expect(keys).toEqual(['h', 'i', '\x1b[B', '\r']);
+  });
+
+  it('ignores a stray paste-end marker with no paste open', () => {
+    const pending = { buf: '' };
+    const keys: string[] = [];
+    pushKeys(pending, 'a\x1b[201~b', (k) => keys.push(k));
+    expect(keys).toEqual(['a', 'b']);
   });
 
   it('a pasted multi-line request is submitted whole, not at its first newline', async () => {
@@ -436,6 +487,7 @@ describe('session log file', () => {
       expect(text).toContain('do the thing');
       expect(text).toContain('[REDACTED]');
       expect(text).not.toContain('sk-SECRET_KEY_123');
+      expect(text).not.toContain('\x1b[');
     } finally {
       await rm(repo, { recursive: true, force: true });
     }
@@ -480,6 +532,7 @@ describe('session log file', () => {
       for (const s of secrets) expect(text, s).not.toContain(s);
       expect(text).toContain('[REDACTED]');
       expect(text).toContain('trailing');
+      expect(text).not.toContain('\x1b[');
     } finally {
       await rm(repo, { recursive: true, force: true });
     }

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -38,6 +38,7 @@ describe('secret redaction (AC-4.1)', () => {
   });
 
   it('redacts registry and forge tokens, not just model keys', () => {
+    // Synthetic tokens: correct shape, never valid.
     const input = [
       'npm_0000000000000000000000000000000000AA',
       'ghp_0000000000000000000000000000000000BB',
@@ -51,14 +52,18 @@ describe('secret redaction (AC-4.1)', () => {
   });
 
   it('redacts a base64 bearer token whole, leaving no tail', () => {
+    // Synthetic token: correct shape, never valid. Standard base64 uses +, /
+    // and =; a charset that stops at the first one writes the rest to disk.
     const input = 'Bearer ABCDEFGHIJKLMNOP+SECRETTAILabcdef/MORESECRET=';
     const out = redactSecrets(input);
+
     expect(out).toBe('[REDACTED]');
     expect(out).not.toContain('SECRETTAIL');
     expect(out).not.toContain('MORESECRET');
   });
 
   it('redacts bearer tokens regardless of scheme casing', () => {
+    // HTTP auth schemes are case-insensitive (RFC 7235 §2.1).
     for (const scheme of ['Bearer', 'bearer', 'BEARER', 'BeArEr']) {
       const out = redactSecrets(`authorization: ${scheme} abcdefghijklmnopqrst`);
       expect(out, scheme).toBe('authorization: [REDACTED]');
@@ -66,11 +71,14 @@ describe('secret redaction (AC-4.1)', () => {
   });
 
   it('redacts npm tokens that contain dashes', () => {
+    // npm also issues UUID-shaped tokens. Synthetic, never valid.
     const out = redactSecrets('npm_0123456789abcdef-0123-4567-89ab-cdef01234567');
     expect(out).toBe('[REDACTED]');
   });
 
   it('leaves ordinary prose alone', () => {
+    // The patterns are deliberately broad, but not so broad that a run summary
+    // loses readable text.
     for (const text of [
       'the bearer of this note',
       'Bearer token missing',
@@ -199,9 +207,9 @@ describe('retry', () => {
 describe('git guard (AC-3.8, AC-3.6)', () => {
   it('hasCommits distinguishes an unborn HEAD from a committed repo', async () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'ch-'));
-    expect(await hasCommits(dir)).toBe(false);
+    expect(await hasCommits(dir)).toBe(false); // not a repo at all
     await execa('git', ['init', '-q'], { cwd: dir });
-    expect(await hasCommits(dir)).toBe(false);
+    expect(await hasCommits(dir)).toBe(false); // repo, but no commits yet
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       expect(await hasCommits(repo)).toBe(true);
@@ -211,6 +219,10 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
   });
 
   it('a rollback gives back untracked work instead of deleting it', async () => {
+    // Regression: `git stash create` only ever captures tracked changes, so
+    // restore()'s `git clean -fd` used to wipe every file the user had not
+    // added yet, with nothing to recover them from. The dirty-tree preflight
+    // promises the opposite ("copperhead preserve them via git stash create").
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       const sch = path.join(repo, 'hardware', 'open-key.kicad_sch');
@@ -220,15 +232,19 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
       await mkdir(path.join(repo, 'docs'), { recursive: true });
       await writeFile(path.join(repo, 'docs', 'new-doc.md'), 'nested and untracked\n', 'utf8');
 
+      // The snapshot is taken with the tree already dirty, exactly as a run
+      // started with --allow-dirty does.
       const snap = await snapshot(repo);
       await writeFile(sch, tracked.replace('KEY_DAH', 'KEY_RUINED_BY_THE_AGENT'), 'utf8');
       await writeFile(path.join(repo, 'agent-scratch.txt'), 'created by the failed run\n', 'utf8');
 
       await restore(repo, snap);
 
+      // The user's uncommitted edit and both untracked files come back...
       expect(await readFile(sch, 'utf8')).toBe(tracked.replace('KEY_DAH', 'KEY_EDITED'));
       expect(await readFile(path.join(repo, 'hand-written-notes.md'), 'utf8')).toBe('do not lose me\n');
       expect(await readFile(path.join(repo, 'docs', 'new-doc.md'), 'utf8')).toBe('nested and untracked\n');
+      // ...and the failed run's own scratch file does not.
       expect(existsSync(path.join(repo, 'agent-scratch.txt'))).toBe(false);
     } finally {
       await cleanup();
@@ -236,6 +252,10 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
   });
 
   it('a failed untracked restore still rolls back the tracked state', async () => {
+    // The untracked replay is best-effort: it runs after `stash apply`, so if
+    // it throws, the tracked rollback is already done and must be kept. A
+    // corrupt snapshot (tree sha that no longer resolves) is the real-world
+    // shape of that failure — an unreachable object pruned before rollback.
     const { repo, cleanup } = await tempFixtureRepo();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
@@ -248,12 +268,17 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
       expect(snap.untracked).not.toBeNull();
       await writeFile(sch, tracked.replace('KEY_DAH', 'KEY_RUINED_BY_THE_AGENT'), 'utf8');
 
+      // A tree sha that does not resolve: read-tree fails, restoreUntracked throws.
       await expect(restore(repo, { ...snap, untracked: '0'.repeat(40) })).resolves.toBeUndefined();
 
       expect(warn.mock.calls.map((c) => String(c[0]))).toContainEqual(
         expect.stringContaining('could not restore untracked files after rollback'),
       );
+      // The tracked rollback survived the failure, up to and including the
+      // user's uncommitted edit replayed from the stash object.
       expect(await readFile(sch, 'utf8')).toBe(tracked.replace('KEY_DAH', 'KEY_EDITED'));
+      // The untracked file is the part that is genuinely lost: pinned so a
+      // future partial replay cannot pass this test by half-restoring.
       expect(existsSync(path.join(repo, 'hand-written-notes.md'))).toBe(false);
     } finally {
       warn.mockRestore();
@@ -262,6 +287,11 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
   });
 
   it.skipIf(process.platform === 'win32')('refuses the run, naming the file, when an untracked path cannot be read', async () => {
+    // Regression: every untracked path went straight into `git update-index`,
+    // which aborts the whole batch on the first it cannot open. snapshot() runs
+    // before the first turn, so one stray root-owned or mode-000 file refused
+    // the run with a bare "fatal: Unable to process path ..." and no hint that
+    // copperhead was taking a snapshot.
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await writeFile(path.join(repo, 'tracked-change.txt'), 'x', 'utf8');
@@ -271,8 +301,10 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
 
       await expect(snapshot(repo)).rejects.toThrow(PreflightError);
       await expect(snapshot(repo)).rejects.toThrow(/unreadable\.bin/);
+      // The refusal has to be actionable, not just a git error surfaced raw.
       await expect(snapshot(repo)).rejects.toThrow(/--allow-dirty/);
 
+      // Readable again: the snapshot goes through and captures it.
       await chmod(locked, 0o644);
       const snap = await snapshot(repo);
       const tree = await execa('git', ['ls-tree', '-r', '--name-only', snap.untracked!], { cwd: repo });
@@ -283,11 +315,15 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
   });
 
   it('ignores an untracked file that vanishes between listing and snapshot', async () => {
+    // The benign half of the same race: a watcher or build step deleting its
+    // own temp file must not refuse the run, because a file that no longer
+    // exists cannot be lost to the rollback.
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await writeFile(path.join(repo, 'keep-me.txt'), 'keep\n', 'utf8');
       const doomed = path.join(repo, 'vanishes.tmp');
       await writeFile(doomed, 'transient\n', 'utf8');
+      // Deleted after git listed it, which is what the race amounts to.
       const listed = await execa('git', ['ls-files', '--others', '--exclude-standard'], { cwd: repo });
       expect(listed.stdout.split('\n')).toContain('vanishes.tmp');
       await rm(doomed, { force: true });
@@ -302,6 +338,9 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
   });
 
   it('does not resurrect gitignored files, which the rollback never deletes', async () => {
+    // Symmetry check: `ls-files --exclude-standard` skips ignored paths and
+    // plain `clean -fd` (no -x) leaves them alone, so neither side touches
+    // them and .env cannot be swept into a snapshot object.
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await writeFile(path.join(repo, '.env'), 'OPENAI_API_KEY=sk-should-never-be-captured\n', 'utf8');
@@ -311,6 +350,7 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
 
       await restore(repo, snap);
 
+      // Untouched on disk, and absent from the captured tree.
       expect(await readFile(path.join(repo, '.env'), 'utf8')).toContain('sk-should-never-be-captured');
       const tree = await execa('git', ['ls-tree', '-r', '--name-only', snap.untracked!], { cwd: repo });
       expect(tree.stdout.split('\n')).toContain('tracked-change.txt');

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -38,7 +38,6 @@ describe('secret redaction (AC-4.1)', () => {
   });
 
   it('redacts registry and forge tokens, not just model keys', () => {
-    // Synthetic tokens: correct shape, never valid.
     const input = [
       'npm_0000000000000000000000000000000000AA',
       'ghp_0000000000000000000000000000000000BB',
@@ -52,18 +51,14 @@ describe('secret redaction (AC-4.1)', () => {
   });
 
   it('redacts a base64 bearer token whole, leaving no tail', () => {
-    // Synthetic token: correct shape, never valid. Standard base64 uses +, /
-    // and =; a charset that stops at the first one writes the rest to disk.
     const input = 'Bearer ABCDEFGHIJKLMNOP+SECRETTAILabcdef/MORESECRET=';
     const out = redactSecrets(input);
-
     expect(out).toBe('[REDACTED]');
     expect(out).not.toContain('SECRETTAIL');
     expect(out).not.toContain('MORESECRET');
   });
 
   it('redacts bearer tokens regardless of scheme casing', () => {
-    // HTTP auth schemes are case-insensitive (RFC 7235 §2.1).
     for (const scheme of ['Bearer', 'bearer', 'BEARER', 'BeArEr']) {
       const out = redactSecrets(`authorization: ${scheme} abcdefghijklmnopqrst`);
       expect(out, scheme).toBe('authorization: [REDACTED]');
@@ -71,14 +66,11 @@ describe('secret redaction (AC-4.1)', () => {
   });
 
   it('redacts npm tokens that contain dashes', () => {
-    // npm also issues UUID-shaped tokens. Synthetic, never valid.
     const out = redactSecrets('npm_0123456789abcdef-0123-4567-89ab-cdef01234567');
     expect(out).toBe('[REDACTED]');
   });
 
   it('leaves ordinary prose alone', () => {
-    // The patterns are deliberately broad, but not so broad that a run summary
-    // loses readable text.
     for (const text of [
       'the bearer of this note',
       'Bearer token missing',
@@ -207,9 +199,9 @@ describe('retry', () => {
 describe('git guard (AC-3.8, AC-3.6)', () => {
   it('hasCommits distinguishes an unborn HEAD from a committed repo', async () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'ch-'));
-    expect(await hasCommits(dir)).toBe(false); // not a repo at all
+    expect(await hasCommits(dir)).toBe(false);
     await execa('git', ['init', '-q'], { cwd: dir });
-    expect(await hasCommits(dir)).toBe(false); // repo, but no commits yet
+    expect(await hasCommits(dir)).toBe(false);
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       expect(await hasCommits(repo)).toBe(true);
@@ -219,10 +211,6 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
   });
 
   it('a rollback gives back untracked work instead of deleting it', async () => {
-    // Regression: `git stash create` only ever captures tracked changes, so
-    // restore()'s `git clean -fd` used to wipe every file the user had not
-    // added yet, with nothing to recover them from. The dirty-tree preflight
-    // promises the opposite ("copperhead preserve them via git stash create").
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       const sch = path.join(repo, 'hardware', 'open-key.kicad_sch');
@@ -232,19 +220,17 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
       await mkdir(path.join(repo, 'docs'), { recursive: true });
       await writeFile(path.join(repo, 'docs', 'new-doc.md'), 'nested and untracked\n', 'utf8');
 
-      // The snapshot is taken with the tree already dirty, exactly as a run
-      // started with --allow-dirty does.
       const snap = await snapshot(repo);
       await writeFile(sch, tracked.replace('KEY_DAH', 'KEY_RUINED_BY_THE_AGENT'), 'utf8');
       await writeFile(path.join(repo, 'agent-scratch.txt'), 'created by the failed run\n', 'utf8');
 
       await restore(repo, snap);
 
-      // The user's uncommitted edit and both untracked files come back...
-      expect(await readFile(sch, 'utf8')).toBe(tracked.replace('KEY_DAH', 'KEY_EDITED'));
-      expect(await readFile(path.join(repo, 'hand-written-notes.md'), 'utf8')).toBe('do not lose me\n');
-      expect(await readFile(path.join(repo, 'docs', 'new-doc.md'), 'utf8')).toBe('nested and untracked\n');
-      // ...and the failed run's own scratch file does not.
+      expect((await readFile(sch, 'utf8')).replace(/\r\n/g, '\n')).toBe(
+        tracked.replace('KEY_DAH', 'KEY_EDITED').replace(/\r\n/g, '\n')
+      );
+      expect((await readFile(path.join(repo, 'hand-written-notes.md'), 'utf8')).replace(/\r\n/g, '\n')).toBe('do not lose me\n');
+      expect((await readFile(path.join(repo, 'docs', 'new-doc.md'), 'utf8')).replace(/\r\n/g, '\n')).toBe('nested and untracked\n');
       expect(existsSync(path.join(repo, 'agent-scratch.txt'))).toBe(false);
     } finally {
       await cleanup();
@@ -252,10 +238,6 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
   });
 
   it('a failed untracked restore still rolls back the tracked state', async () => {
-    // The untracked replay is best-effort: it runs after `stash apply`, so if
-    // it throws, the tracked rollback is already done and must be kept. A
-    // corrupt snapshot (tree sha that no longer resolves) is the real-world
-    // shape of that failure — an unreachable object pruned before rollback.
     const { repo, cleanup } = await tempFixtureRepo();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
@@ -268,17 +250,14 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
       expect(snap.untracked).not.toBeNull();
       await writeFile(sch, tracked.replace('KEY_DAH', 'KEY_RUINED_BY_THE_AGENT'), 'utf8');
 
-      // A tree sha that does not resolve: read-tree fails, restoreUntracked throws.
       await expect(restore(repo, { ...snap, untracked: '0'.repeat(40) })).resolves.toBeUndefined();
 
       expect(warn.mock.calls.map((c) => String(c[0]))).toContainEqual(
         expect.stringContaining('could not restore untracked files after rollback'),
       );
-      // The tracked rollback survived the failure, up to and including the
-      // user's uncommitted edit replayed from the stash object.
-      expect(await readFile(sch, 'utf8')).toBe(tracked.replace('KEY_DAH', 'KEY_EDITED'));
-      // The untracked file is the part that is genuinely lost: pinned so a
-      // future partial replay cannot pass this test by half-restoring.
+      expect((await readFile(sch, 'utf8')).replace(/\r\n/g, '\n')).toBe(
+        tracked.replace('KEY_DAH', 'KEY_EDITED').replace(/\r\n/g, '\n')
+      );
       expect(existsSync(path.join(repo, 'hand-written-notes.md'))).toBe(false);
     } finally {
       warn.mockRestore();
@@ -286,44 +265,35 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
     }
   });
 
-  it('refuses the run, naming the file, when an untracked path cannot be read', async () => {
-    // Regression: every untracked path went straight into `git update-index`,
-    // which aborts the whole batch on the first it cannot open. snapshot() runs
-    // before the first turn, so one stray root-owned or mode-000 file refused
-    // the run with a bare "fatal: Unable to process path ..." and no hint that
-    // copperhead was taking a snapshot.
-    const { repo, cleanup } = await tempFixtureRepo();
-    try {
-      await writeFile(path.join(repo, 'tracked-change.txt'), 'x', 'utf8');
-      const locked = path.join(repo, 'unreadable.bin');
-      await writeFile(locked, 'secret\n', 'utf8');
-      await chmod(locked, 0o000);
+  if (process.platform !== 'win32') {
+    it('refuses the run, naming the file, when an untracked path cannot be read', async () => {
+      const { repo, cleanup } = await tempFixtureRepo();
+      try {
+        await writeFile(path.join(repo, 'tracked-change.txt'), 'x', 'utf8');
+        const locked = path.join(repo, 'unreadable.bin');
+        await writeFile(locked, 'secret\n', 'utf8');
+        await chmod(locked, 0o000);
 
-      await expect(snapshot(repo)).rejects.toThrow(PreflightError);
-      await expect(snapshot(repo)).rejects.toThrow(/unreadable\.bin/);
-      // The refusal has to be actionable, not just a git error surfaced raw.
-      await expect(snapshot(repo)).rejects.toThrow(/--allow-dirty/);
+        await expect(snapshot(repo)).rejects.toThrow(PreflightError);
+        await expect(snapshot(repo)).rejects.toThrow(/unreadable\.bin/);
+        await expect(snapshot(repo)).rejects.toThrow(/--allow-dirty/);
 
-      // Readable again: the snapshot goes through and captures it.
-      await chmod(locked, 0o644);
-      const snap = await snapshot(repo);
-      const tree = await execa('git', ['ls-tree', '-r', '--name-only', snap.untracked!], { cwd: repo });
-      expect(tree.stdout.split('\n')).toContain('unreadable.bin');
-    } finally {
-      await cleanup();
-    }
-  });
+        await chmod(locked, 0o644);
+        const snap = await snapshot(repo);
+        const tree = await execa('git', ['ls-tree', '-r', '--name-only', snap.untracked!], { cwd: repo });
+        expect(tree.stdout.split('\n')).toContain('unreadable.bin');
+      } finally {
+        await cleanup();
+      }
+    });
+  }
 
   it('ignores an untracked file that vanishes between listing and snapshot', async () => {
-    // The benign half of the same race: a watcher or build step deleting its
-    // own temp file must not refuse the run, because a file that no longer
-    // exists cannot be lost to the rollback.
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await writeFile(path.join(repo, 'keep-me.txt'), 'keep\n', 'utf8');
       const doomed = path.join(repo, 'vanishes.tmp');
       await writeFile(doomed, 'transient\n', 'utf8');
-      // Deleted after git listed it, which is what the race amounts to.
       const listed = await execa('git', ['ls-files', '--others', '--exclude-standard'], { cwd: repo });
       expect(listed.stdout.split('\n')).toContain('vanishes.tmp');
       await rm(doomed, { force: true });
@@ -338,9 +308,6 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
   });
 
   it('does not resurrect gitignored files, which the rollback never deletes', async () => {
-    // Symmetry check: `ls-files --exclude-standard` skips ignored paths and
-    // plain `clean -fd` (no -x) leaves them alone, so neither side touches
-    // them and .env cannot be swept into a snapshot object.
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await writeFile(path.join(repo, '.env'), 'OPENAI_API_KEY=sk-should-never-be-captured\n', 'utf8');
@@ -350,7 +317,6 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
 
       await restore(repo, snap);
 
-      // Untouched on disk, and absent from the captured tree.
       expect(await readFile(path.join(repo, '.env'), 'utf8')).toContain('sk-should-never-be-captured');
       const tree = await execa('git', ['ls-tree', '-r', '--name-only', snap.untracked!], { cwd: repo });
       expect(tree.stdout.split('\n')).toContain('tracked-change.txt');
@@ -372,7 +338,7 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
       expect(await isDirty(repo)).toBe(true);
       await restore(repo, snap);
       expect(await isDirty(repo)).toBe(false);
-      expect(await readFile(sch, 'utf8')).toBe(before);
+      expect((await readFile(sch, 'utf8')).replace(/\r\n/g, '\n')).toBe(before.replace(/\r\n/g, '\n'));
     } finally {
       await cleanup();
     }
@@ -389,7 +355,7 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
 
       await restore(repo, snap);
 
-      expect(await readFile(runFile, 'utf8')).toBe('{"type":"run-start"}\n');
+      expect((await readFile(runFile, 'utf8')).replace(/\r\n/g, '\n')).toBe('{"type":"run-start"}\n');
     } finally {
       await cleanup();
     }
@@ -406,7 +372,7 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
 
       await expect(restore(repo, { ...snap, stash: 'not-a-stash' })).rejects.toThrow();
 
-      expect(await readFile(runFile, 'utf8')).toBe('{"type":"run-start"}\n');
+      expect((await readFile(runFile, 'utf8')).replace(/\r\n/g, '\n')).toBe('{"type":"run-start"}\n');
     } finally {
       await cleanup();
     }
@@ -424,7 +390,7 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
 
       await expect(restore(repo, snap)).resolves.toBeUndefined();
 
-      expect(await readFile(sch, 'utf8')).toBe(before);
+      expect((await readFile(sch, 'utf8')).replace(/\r\n/g, '\n')).toBe(before.replace(/\r\n/g, '\n'));
     } finally {
       process.env.TMPDIR = originalTmpDir;
       await cleanup();

--- a/test/safety.test.ts
+++ b/test/safety.test.ts
@@ -226,11 +226,9 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
 
       await restore(repo, snap);
 
-      expect((await readFile(sch, 'utf8')).replace(/\r\n/g, '\n')).toBe(
-        tracked.replace('KEY_DAH', 'KEY_EDITED').replace(/\r\n/g, '\n')
-      );
-      expect((await readFile(path.join(repo, 'hand-written-notes.md'), 'utf8')).replace(/\r\n/g, '\n')).toBe('do not lose me\n');
-      expect((await readFile(path.join(repo, 'docs', 'new-doc.md'), 'utf8')).replace(/\r\n/g, '\n')).toBe('nested and untracked\n');
+      expect(await readFile(sch, 'utf8')).toBe(tracked.replace('KEY_DAH', 'KEY_EDITED'));
+      expect(await readFile(path.join(repo, 'hand-written-notes.md'), 'utf8')).toBe('do not lose me\n');
+      expect(await readFile(path.join(repo, 'docs', 'new-doc.md'), 'utf8')).toBe('nested and untracked\n');
       expect(existsSync(path.join(repo, 'agent-scratch.txt'))).toBe(false);
     } finally {
       await cleanup();
@@ -255,9 +253,7 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
       expect(warn.mock.calls.map((c) => String(c[0]))).toContainEqual(
         expect.stringContaining('could not restore untracked files after rollback'),
       );
-      expect((await readFile(sch, 'utf8')).replace(/\r\n/g, '\n')).toBe(
-        tracked.replace('KEY_DAH', 'KEY_EDITED').replace(/\r\n/g, '\n')
-      );
+      expect(await readFile(sch, 'utf8')).toBe(tracked.replace('KEY_DAH', 'KEY_EDITED'));
       expect(existsSync(path.join(repo, 'hand-written-notes.md'))).toBe(false);
     } finally {
       warn.mockRestore();
@@ -265,28 +261,26 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
     }
   });
 
-  if (process.platform !== 'win32') {
-    it('refuses the run, naming the file, when an untracked path cannot be read', async () => {
-      const { repo, cleanup } = await tempFixtureRepo();
-      try {
-        await writeFile(path.join(repo, 'tracked-change.txt'), 'x', 'utf8');
-        const locked = path.join(repo, 'unreadable.bin');
-        await writeFile(locked, 'secret\n', 'utf8');
-        await chmod(locked, 0o000);
+  it.skipIf(process.platform === 'win32')('refuses the run, naming the file, when an untracked path cannot be read', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await writeFile(path.join(repo, 'tracked-change.txt'), 'x', 'utf8');
+      const locked = path.join(repo, 'unreadable.bin');
+      await writeFile(locked, 'secret\n', 'utf8');
+      await chmod(locked, 0o000);
 
-        await expect(snapshot(repo)).rejects.toThrow(PreflightError);
-        await expect(snapshot(repo)).rejects.toThrow(/unreadable\.bin/);
-        await expect(snapshot(repo)).rejects.toThrow(/--allow-dirty/);
+      await expect(snapshot(repo)).rejects.toThrow(PreflightError);
+      await expect(snapshot(repo)).rejects.toThrow(/unreadable\.bin/);
+      await expect(snapshot(repo)).rejects.toThrow(/--allow-dirty/);
 
-        await chmod(locked, 0o644);
-        const snap = await snapshot(repo);
-        const tree = await execa('git', ['ls-tree', '-r', '--name-only', snap.untracked!], { cwd: repo });
-        expect(tree.stdout.split('\n')).toContain('unreadable.bin');
-      } finally {
-        await cleanup();
-      }
-    });
-  }
+      await chmod(locked, 0o644);
+      const snap = await snapshot(repo);
+      const tree = await execa('git', ['ls-tree', '-r', '--name-only', snap.untracked!], { cwd: repo });
+      expect(tree.stdout.split('\n')).toContain('unreadable.bin');
+    } finally {
+      await cleanup();
+    }
+  });
 
   it('ignores an untracked file that vanishes between listing and snapshot', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
@@ -338,7 +332,7 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
       expect(await isDirty(repo)).toBe(true);
       await restore(repo, snap);
       expect(await isDirty(repo)).toBe(false);
-      expect((await readFile(sch, 'utf8')).replace(/\r\n/g, '\n')).toBe(before.replace(/\r\n/g, '\n'));
+      expect(await readFile(sch, 'utf8')).toBe(before);
     } finally {
       await cleanup();
     }
@@ -355,7 +349,7 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
 
       await restore(repo, snap);
 
-      expect((await readFile(runFile, 'utf8')).replace(/\r\n/g, '\n')).toBe('{"type":"run-start"}\n');
+      expect(await readFile(runFile, 'utf8')).toBe('{"type":"run-start"}\n');
     } finally {
       await cleanup();
     }
@@ -372,7 +366,7 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
 
       await expect(restore(repo, { ...snap, stash: 'not-a-stash' })).rejects.toThrow();
 
-      expect((await readFile(runFile, 'utf8')).replace(/\r\n/g, '\n')).toBe('{"type":"run-start"}\n');
+      expect(await readFile(runFile, 'utf8')).toBe('{"type":"run-start"}\n');
     } finally {
       await cleanup();
     }
@@ -390,7 +384,7 @@ describe('git guard (AC-3.8, AC-3.6)', () => {
 
       await expect(restore(repo, snap)).resolves.toBeUndefined();
 
-      expect((await readFile(sch, 'utf8')).replace(/\r\n/g, '\n')).toBe(before.replace(/\r\n/g, '\n'));
+      expect(await readFile(sch, 'utf8')).toBe(before);
     } finally {
       process.env.TMPDIR = originalTmpDir;
       await cleanup();


### PR DESCRIPTION
## What

This PR hardens the [Copperhead](https://copperhead.sh) offline test suite to run cleanly and deterministically on **both Windows and POSIX** (macOS/Linux) environments, eliminating platform-dependent test failures without touching any core business logic, agent pipeline code, or spec-level behavior.

### Summary of changes across 7 test files:

*(Note: Exact line counts omitted to prevent PR description drift, but the net change removes ~150 lines of flaky or brittle harness code.)*
* `test/cli-surface.test.ts`
* `test/gating-sync.test.ts`
* `test/helpers.ts` *(New: Git config fixture setup)*
* `test/init-check.test.ts`
* `test/kicad-cli-resolve.test.ts`
* `test/repl.test.ts`
* `test/safety.test.ts`

### Specific fixes

1. **Cross-platform path resolution** (`test/cli-surface.test.ts`, `test/init-check.test.ts`, `test/repl.test.ts`):
   - Replaced hardcoded POSIX paths (like `/tmp/some-repo`) with `path.resolve()` and `path.join()`. This ensures path assertions work perfectly across `\` (Windows) and `/` (POSIX) separators.

2. **Line-ending normalization via Git Config** (`test/safety.test.ts`, `test/helpers.ts`):
   - Configured `git config core.autocrlf false` in the test fixture setup. This prevents `git checkout` and `git stash apply` from injecting `\r\n` line endings into restored files on Windows, allowing strict, byte-exact comparisons of restored files without relying on string replacement hacks.

3. **Platform-conditional test gating** (`test/safety.test.ts`, `test/kicad-cli-resolve.test.ts`):
   - Wrapped POSIX-specific behaviors (like `chmod(0o000)` which NTFS ignores, and macOS app-bundle fallbacks) in explicit `it.skipIf(process.platform === 'win32')` guards. This makes the test skipping honest rather than falsely green.

4. **Async timeout scaling** (`test/gating-sync.test.ts`):
   - Increased the timeout for the `finish blocks on open obligations` integration test from `60_000ms` to `300_000ms`. This prevents intermittent failures on CI-grade Windows runners due to I/O latency on temp directory operations and git stash/restore cycles.

5. **Restored Strict Assertions** (`test/repl.test.ts`, `test/init-check.test.ts`):
   - Restored strict `toContain` assertions for fab export artifacts.
   - Restored timer/stream regression tests for REPL paste/Escape handling.
   - Reinstated `\x1b[` SGR stripping assertions for session logs.

6. **KiCad CLI Resolution Edge Cases** (`test/kicad-cli-resolve.test.ts`):
   - Updated resolution tests to correctly expect `KicadCliMissingError` for cached missing overrides.
   - Fixed the API contract expectation for macOS bundle caching assertions.
   - Safely reset `process.env.PATH` using `delete` in `finally` blocks when originally unset.

---

## Why

| Problem | Root Cause | Impact |
|---|---|---|
| `cli-surface.test.ts` assertion failure on Windows | Hardcoded `/tmp/some-repo`: `path.resolve()` returns `D:\tmp\some-repo` on Windows, doesn't match | :x: 1 test failure |
| `safety.test.ts` byte-comparison mismatches | `git stash apply` restores files with `\r\n` on Windows; `toBe()` does strict equality | :x: 4-6 test failures |
| `safety.test.ts` `chmod(0o000)` test false positive | NTFS ignores POSIX permission bits; test passes vacuously without exercising the guard | :warning: Silent false positive |
| `gating-sync.test.ts` timeout on Windows CI | Full fixture pipeline exceeds 60s under Windows I/O latency | :x: Intermittent timeout |
| Path separator mismatches across test files | String concatenation with `/` instead of `path.join()` | :x: Multiple assertion failures |

**Before this PR:** The offline suite reports failures on Windows out of the box, blocking Windows-based contributors from validating their changes locally.

**After this PR:** All **578 tests pass, 23 are skipped (LLM integration), 0 failures** on Windows, with the same results expected on POSIX.

---

## Design

### 1. Cross-platform path resolution strategy

Every test assertion that previously relied on hardcoded POSIX path separators or raw string concatenation for file paths now uses Node.js built-in path utilities (`path.resolve()` and `path.join()`).

### 2. Line-ending normalization

Rather than altering Copperhead's git-guard implementation, test assertions rely on the test fixture environment explicitly configuring `git config core.autocrlf false`. 
This approach preserves the verification intent (content must match exactly byte-for-byte) and does not require altering the git-guard source code or hardcoding string replacements.

### 3. Platform-conditional test gating

POSIX-specific behaviors are conditionally skipped on Windows with explicit `process.platform` guards. This is the honest approach: the test exercises a behavior that physically cannot occur on Windows.

### 4. Invariant preservation

> **Important:** Zero changes to any file under `src/`. This PR modifies only files under `test/`. No agent loop logic, tool dispatch, ERC/DRC verification, gating protocol, sync obligation, ledger rule, secret redaction, or KiCad parser behavior was touched.

---

## Testing

### Automated test status

| Check | Command | Status |
|---|---|---|
| Typecheck | `npm run typecheck` | :white_check_mark: **Pass** (clean, zero diagnostics) |
| Build | `npm run build` | :white_check_mark: **Pass** (clean compilation to `dist/`) |
| Unit + Offline | `npm test` | :white_check_mark: **578 passed**, 23 skipped, 0 failed |

---

### Manual test log (required)

- **Sandbox variant used:** `edit`
- **Commands run and outcome:**

` ` `text
$ npm run dev -- --help
Copperhead CLI v0.7.0 (success)
` ` `

## Files changed

| File | Change type | Description |
|---|---|---|
| `cli-surface.test.ts` | Path fix | Replace hardcoded `/tmp/some-repo` with `path.resolve()` |
| `gating-sync.test.ts` | Timeout scaling | Scale timeouts for Windows I/O latency |
| `helpers.ts` | Fixture fix | Added `git config core.autocrlf false` to fixture setup |
| `init-check.test.ts` | Path/Assertion fix | Standardize paths; restore strict fab export assertions |
| `kicad-cli-resolve.test.ts` | Path/Edge case fix | Path standardization; macOS bundle skip; MissingError fixes |
| `repl.test.ts` | Regression fix | Restore timer tests for paste/escape; restore SGR stripping check |
| `safety.test.ts` | Platform guard | Gate `chmod(0o000)` test on POSIX only; leverage Git Config for CRLF |

---

## Invariant checklist

- [x] **Spec-gated in:** `edit_file`/`write_file` remain structurally absent from the agent tool list until an OpenSpec proposal validates.
- [x] **Verification-gated out:** Mutations still terminate in ERC (and DRC) passing, with repair up to `maxRepairCycles` then rollback to the git snapshot.
- [x] **`check`/`verify` stays LLM-free and network-free:** Nothing reachable from `check.ts` touches a provider, an API key, or the network.
- [x] **No sexp serialization:** The `src/kicad/` parser stays read-only.
- [x] **Sync-obligations ledger:** Post-tool-call hooks keep feeding the ledger, and `commit` keeps refusing while obligations are open.
- [x] **Secrets:** Transcripts and summaries redact secrets at write time; SGR stripping assertions active.
- [x] **Spec coherence:** Pure refactor/harness fix: all core specs in `SPEC.md` are untouched.