### PR TITLE
docs: add a journey-shaped onboarding guide and blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ copperhead check               # ERC + DRC + doc drift; no LLM, CI-safe
 
 Run `copperhead doctor` first: it reports every prerequisite in one pass and exits 0 only when the machine is ready. Two things it commonly catches:
 
-- **`kicad-cli` not on PATH.** Every command probes it before doing anything, so nothing runs until this is fixed. On macOS: `export PATH="/Applications/KiCad/KiCad.app/Contents/MacOS:$PATH"`.
+- **`kicad-cli` not on PATH.** Every KiCad-dependent command probes it before doing anything, so `init`, `do`, `check`, `sync`, and `create` all refuse until this is fixed. (`doctor` is the deliberate exception: it reports the missing tool instead of throwing.) On macOS: `export PATH="/Applications/KiCad/KiCad.app/Contents/MacOS:$PATH"`.
 - **Both `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` exported.** copperhead refuses to guess between two credentials rather than silently send your design to a provider you did not pick. Name one with `export COPPERHEAD_MODEL=claude` (or `--model`).
 
 Note that `copperhead check` skips ERC and DRC — and still exits 0 — until `init` has pointed `.copperhead/config.json` at your files. Read its output lines, not just the exit code.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The script is conservative by design: it never runs `sudo` and never edits shell
 
 - Node.js ≥ 20
 - [KiCad](https://www.kicad.org/) ≥ 8 with `kicad-cli` on PATH
+- git, and a repository — copperhead snapshots before it edits and rolls back to that snapshot when verification fails
 - One model backend: a locally installed, ChatGPT-authenticated [Codex CLI](https://learn.chatgpt.com/docs/codex/cli), a logged-in [Cursor Agent CLI](#saved-login-cursor-agent) (`agent login`), logged-in Claude Code (see [Saved login](#saved-login-claude-code)), or `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` in the environment. `check` never calls an LLM.
 
 ## Quick start
@@ -64,6 +65,7 @@ The script is conservative by design: it never runs `sudo` and never edits shell
 In an existing KiCad repository:
 
 ```bash
+copperhead doctor              # what's missing: kicad-cli, git, node, model credential (no LLM)
 export ANTHROPIC_API_KEY=...   # or OPENAI_API_KEY; optional: with no key, `copperhead` offers a model picker
 copperhead init                # scaffold docs/ from the schematic; idempotent
 copperhead                     # interactive agent shell (Claude Code–style REPL)
@@ -74,7 +76,16 @@ copperhead do "add reverse-polarity protection on VIN"
 copperhead check               # ERC + DRC + doc drift; no LLM, CI-safe
 ```
 
+Run `copperhead doctor` first: it reports every prerequisite in one pass and exits 0 only when the machine is ready. Two things it commonly catches:
+
+- **`kicad-cli` not on PATH.** Every command probes it before doing anything, so nothing runs until this is fixed. On macOS: `export PATH="/Applications/KiCad/KiCad.app/Contents/MacOS:$PATH"`.
+- **Both `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` exported.** copperhead refuses to guess between two credentials rather than silently send your design to a provider you did not pick. Name one with `export COPPERHEAD_MODEL=claude` (or `--model`).
+
+Note that `copperhead check` skips ERC and DRC — and still exits 0 — until `init` has pointed `.copperhead/config.json` at your files. Read its output lines, not just the exit code.
+
 Starting from nothing instead? Write a product brief and run `copperhead create --brief brief.md`. The [examples/](examples/) directory has ready-made briefs sorted by difficulty, plus a note on which one is designed to fail.
+
+New to the tool? [Your first run](https://docs.copperhead.sh/getting-started/first-run/) walks this path slowly, with the failure modes.
 
 ### Use your existing Codex login
 

--- a/docs/blog/i-gave-an-ai-agent-my-kicad-repo.md
+++ b/docs/blog/i-gave-an-ai-agent-my-kicad-repo.md
@@ -1,0 +1,132 @@
+# I gave an AI agent commit access to my KiCad repo
+
+*A twenty-minute onboarding, and the four refusals that made it worth doing.*
+
+---
+
+The pitch for AI in hardware design usually arrives backwards. It leads with the impressive part — describe a board, get a schematic — and leaves the obvious question unasked: why would you let a language model near a file that turns into a physical object with a four-week lead time and a minimum order quantity?
+
+That question deserves a real answer, because the failure mode is not a red squiggle. It is a hundred boards with a resistor on the wrong net.
+
+So this is not a demo post. It is the first twenty minutes with [copperhead](https://copperhead.sh) on a board that already exists, written down honestly — including the parts where it stops and refuses to continue. Those turn out to be the interesting parts.
+
+## The premise
+
+copperhead is a CLI agent that works on a KiCad repository the way a coding agent works on a codebase. It reads your design docs, proposes a change as a validated spec, edits the real `.kicad_sch` and `.kicad_pcb` files, then runs `kicad-cli` ERC and DRC on its own work until the tools agree.
+
+KiCad stays your editor. Nothing moves into a walled garden. The files it edits are the files you already have, in the git repo you already have, and every artifact it produces is markdown you can read in a diff.
+
+Two rules hold the whole thing up, and it is worth stating them before anything else, because everything below is a consequence of one of them:
+
+1. **Nothing starts without a spec.** The agent cannot touch a KiCad file until a change proposal exists and validates. Not "is told not to" — the edit tools are absent from the list of tools it is given until that proposal passes. An ungated edit is not something it attempts and fails at. It is not expressible.
+2. **Nothing is done until the tools agree.** Every file mutation is followed by ERC, and DRC if the board changed. If verification cannot be made to pass, the run rolls back to a git snapshot taken before it started.
+
+Those are guardrails against the failure mode that actually matters. Not "the AI said something wrong" — you would catch that. The one that matters is "the AI changed a net name in the schematic but not in the pinout doc, and nobody noticed for three weeks."
+
+## Minute zero: asking what is missing
+
+The first command is not the impressive one.
+
+```bash
+copperhead doctor
+```
+
+```text
+  [ok]   node      v24.16.0 (>= 20)
+  [ok]   kicad-cli 8.0.9
+  [ok]   git       2.54.0.windows.1
+  [FAIL] provider  no model configured
+  [info] project   no .copperhead/config.json (run `copperhead init` to
+                   scaffold)
+not ready: fix the [FAIL] items above
+```
+
+No model, no network, no cost. It just reports what is missing, and every message names the fix.
+
+I want to dwell on the third line for a second, because it is the one that says something about the design. `git 2.54.0` is checked with the same weight as KiCad itself, and if it were missing the tool would refuse to run. copperhead snapshots your tree with git before it edits, and rolls back to that snapshot when verification fails. No repo, no undo, no run. The safety net is not a feature — it is a prerequisite.
+
+Then it told me to fix my own environment:
+
+```text
+  [FAIL] provider  ambiguous: multiple credentials, no model selected
+         hint: 2 credentials found (OPENAI_API_KEY, ANTHROPIC_API_KEY) and no
+               model was selected; pass --model, set COPPERHEAD_MODEL, or set
+               "model" in .copperhead/config.json.
+```
+
+I had both keys exported, like most developers do. A more accommodating tool picks one and gets on with it. This one stops, on the grounds that quietly choosing a provider means quietly sending your design to a company you did not pick, and quietly billing you for it.
+
+**Refusal #1, and we have not started yet.** I named the model and moved on.
+
+## Minute five: it reads your board before it writes anything
+
+```bash
+copperhead init
+```
+
+This reads the existing schematic and scaffolds a `docs/` directory: spec, subsystems, BOM, pinout, layout notes. Those files are not documentation in the write-once sense. They are the agent's memory. Every run reads them first, which means it operates with the whole design in context instead of just the part in front of it — and it means a wrong value in there becomes a wrong assumption in every change afterward.
+
+Which makes the next ten minutes the highest-leverage ten minutes in the process: read what it wrote about your board, and correct it. That is not overhead. That is the work.
+
+I re-ran `init` to see what would happen, and got **refusal #2**: it will not overwrite a generated doc you have since hand-edited. It exits non-zero and names the files it skipped. Your edits win over its scaffolding, by default, permanently, unless you pass `--force`.
+
+## Minute ten: a baseline, and a trap
+
+```bash
+copperhead check
+```
+
+ERC, DRC, doc-drift detection, constraint checks, spec validation. No LLM calls and no network access — not by convention but by contract; the module imports no provider, so it *cannot* make one. That is what makes it safe to drop into CI and into the pre-commit hook `init` installs for you.
+
+Here is the trap, and I include it because I walked into it. Run `check` on a repo you have not `init`-ed and you get this:
+
+```text
+ERC skipped (no schematic configured; run copperhead init)
+DRC skipped (no board configured)
+```
+
+Exit code: 0. Green. That is a pass over an empty set, not a clean board — the same shape as a test suite reporting success because it collected no tests. Read the lines, not the exit code.
+
+## Minute fifteen: the actual change
+
+I picked a net rename. Narrow, and wrong would be obvious.
+
+```bash
+copperhead do "rename net KEY_DAH to KEY_DASH" --interactive
+```
+
+It proposed first: why, what changes, the task list. Only after that validated did its edit tools come into existence at all. Then it made anchored replacements in the schematic and in every doc that mentioned the net, ran ERC, and committed once — verification result in the commit message, a line in the changelog, the reasoning appended to a decisions log.
+
+The propagation is the part that earns its keep. Renaming a net in the schematic is thirty seconds of work. Renaming it in the schematic *and* the pinout *and* the BOM rationale *and* the subsystem description, without missing one, is the boring, error-prone task that hardware documentation dies of. That is the job it is actually good at.
+
+## The two refusals I did not expect
+
+**Refusal #3.** Every text edit to a schematic or board is probed for loadability afterward. If the edit would leave the file unopenable in KiCad, it is reverted immediately and the agent is handed the parser error to try again. A corrupted s-expression file does not reach your disk and then fail confusingly on the next command.
+
+**Refusal #4** is the one that changed how I think about the tool. There is a mode where the schematic is generated from a declarative intent file — parts, nets, groups, no coordinates — and a deterministic engine computes every wire and position. In that mode, the agent is *forbidden from hand-editing the schematic it just drew*. Ask it to nudge something and it declines, and tells you to revise the intent and regenerate.
+
+That is a system refusing to do the easy thing in the moment because the easy thing destroys a property it needs later: the same intent must always produce byte-identical output. The moment you allow one manual nudge, the drawing and the intent diverge, and you no longer know which one is the design.
+
+I have worked with people who lacked that discipline.
+
+## What I would tell you before you try it
+
+**It is early, and says so.** The README leads with it. Phase 1, expect the surface to move.
+
+**Know what each command costs.** `check`, `doctor`, and the deterministic commands are free and instant — no model involved. A small `do` is a few minutes. `create`, which goes from a product brief to gerbers and firmware across eight stages, runs in hours, not minutes. It prints a heartbeat so you can tell slow from hung. Start with a small brief.
+
+**It is not the engineer of record.** Not an autorouter, not a replacement for your judgment, and it never claims a board is fab-ready — only that ERC and DRC are clean. A human still signs off. That framing is in the docs, unhedged, which I respect more than the alternative.
+
+**Failed work is recoverable.** When a run cannot make verification pass, it rolls back — but it stashes everything it touched first, under a named git stash entry, and prints the command to get it back.
+
+## The part that actually matters
+
+The demo-friendly claim about AI in hardware is that it designs the board for you. That is not the claim worth evaluating yet.
+
+The claim worth evaluating is narrower and much more useful: that a change to a circuit can propagate through every document that references it, that the propagation is verified by the same tools you already trust, and that nothing is called done until those tools agree. Not a designer. A tireless, slightly pedantic junior engineer who has read every doc in the repo, refuses to skip the boring cross-checking step, and stops to ask when the spec and the board disagree.
+
+Twenty minutes in, four refusals, one verified commit. The refusals were the reason I kept going.
+
+---
+
+**Try it:** [docs.copperhead.sh](https://docs.copperhead.sh) · [Your first run](https://docs.copperhead.sh/getting-started/first-run/) · [GitHub](https://github.com/chouhanindustries/copperhead) · Apache-2.0

--- a/docs/blog/i-gave-an-ai-agent-my-kicad-repo.md
+++ b/docs/blog/i-gave-an-ai-agent-my-kicad-repo.md
@@ -19,7 +19,7 @@ KiCad stays your editor. Nothing moves into a walled garden. The files it edits 
 Two rules hold the whole thing up, and it is worth stating them before anything else, because everything below is a consequence of one of them:
 
 1. **Nothing starts without a spec.** The agent cannot touch a KiCad file until a change proposal exists and validates. Not "is told not to" — the edit tools are absent from the list of tools it is given until that proposal passes. An ungated edit is not something it attempts and fails at. It is not expressible.
-2. **Nothing is done until the tools agree.** Every file mutation is followed by ERC, and DRC if the board changed. If verification cannot be made to pass, the run rolls back to a git snapshot taken before it started.
+2. **Nothing is done until the tools agree.** Every file mutation is followed by ERC, and DRC if the board changed. If verification cannot be made to pass, the run rolls back to a git snapshot taken before it started, and reports it loudly on the rare occasion that the rollback itself cannot complete.
 
 Those are guardrails against the failure mode that actually matters. Not "the AI said something wrong" — you would catch that. The one that matters is "the AI changed a net name in the schematic but not in the pinout doc, and nobody noticed for three weeks."
 
@@ -117,7 +117,7 @@ I have worked with people who lacked that discipline.
 
 **It is not the engineer of record.** Not an autorouter, not a replacement for your judgment, and it never claims a board is fab-ready — only that ERC and DRC are clean. A human still signs off. That framing is in the docs, unhedged, which I respect more than the alternative.
 
-**Failed work is recoverable.** When a run cannot make verification pass, it rolls back — but it stashes everything it touched first, under a named git stash entry, and prints the command to get it back.
+**Failed work is normally recoverable.** When a run cannot make verification pass, it rolls back — but it tries to stash everything it touched first, under a named git stash entry, and prints the command to get it back. Both steps are best-effort rather than guaranteed: if the rollback itself fails, the run says so and warns that the tree may be partial, which is your cue to read `git status` instead of assuming a clean revert.
 
 ## The part that actually matters
 

--- a/docs/blog/i-gave-an-ai-agent-my-kicad-repo.md
+++ b/docs/blog/i-gave-an-ai-agent-my-kicad-repo.md
@@ -4,11 +4,11 @@
 
 ---
 
-The pitch for AI in hardware design usually arrives backwards. It leads with the impressive part — describe a board, get a schematic — and leaves the obvious question unasked: why would you let a language model near a file that turns into a physical object with a four-week lead time and a minimum order quantity?
+The pitch for AI in hardware design usually arrives backwards. It leads with the impressive part (describe a board, get a schematic) and leaves the obvious question unasked: why would you let a language model near a file that turns into a physical object with a four-week lead time and a minimum order quantity?
 
 That question deserves a real answer, because the failure mode is not a red squiggle. It is a hundred boards with a resistor on the wrong net.
 
-So this is not a demo post. It is the first twenty minutes with [copperhead](https://copperhead.sh) on a board that already exists, written down honestly — including the parts where it stops and refuses to continue. Those turn out to be the interesting parts.
+So this is not a demo post. It is the first twenty minutes with [copperhead](https://copperhead.sh) on a board that already exists, written down honestly, including the parts where it stops and refuses to continue. Those turn out to be the interesting parts.
 
 ## The premise
 
@@ -18,10 +18,10 @@ KiCad stays your editor. Nothing moves into a walled garden. The files it edits 
 
 Two rules hold the whole thing up, and it is worth stating them before anything else, because everything below is a consequence of one of them:
 
-1. **Nothing starts without a spec.** The agent cannot touch a KiCad file until a change proposal exists and validates. Not "is told not to" — the edit tools are absent from the list of tools it is given until that proposal passes. An ungated edit is not something it attempts and fails at. It is not expressible.
+1. **Nothing starts without a spec.** The agent cannot touch a KiCad file until a change proposal exists and validates. Not "is told not to": the edit tools are absent from the list of tools it is given until that proposal passes. An ungated edit is not something it attempts and fails at. It is not expressible.
 2. **Nothing is done until the tools agree.** Every file mutation is followed by ERC, and DRC if the board changed. If verification cannot be made to pass, the run rolls back to a git snapshot taken before it started, and reports it loudly on the rare occasion that the rollback itself cannot complete.
 
-Those are guardrails against the failure mode that actually matters. Not "the AI said something wrong" — you would catch that. The one that matters is "the AI changed a net name in the schematic but not in the pinout doc, and nobody noticed for three weeks."
+Those are guardrails against the failure mode that actually matters. Not "the AI said something wrong": you would catch that. The one that matters is "the AI changed a net name in the schematic but not in the pinout doc, and nobody noticed for three weeks."
 
 ## Minute zero: asking what is missing
 
@@ -43,7 +43,7 @@ not ready: fix the [FAIL] items above
 
 No model, no network, no cost. It just reports what is missing, and every message names the fix.
 
-I want to dwell on the third line for a second, because it is the one that says something about the design. `git 2.54.0` is checked with the same weight as KiCad itself, and if it were missing the tool would refuse to run. copperhead snapshots your tree with git before it edits, and rolls back to that snapshot when verification fails. No repo, no undo, no run. The safety net is not a feature — it is a prerequisite.
+I want to dwell on the third line for a second, because it is the one that says something about the design. `git 2.54.0` is checked with the same weight as KiCad itself, and if it were missing the tool would refuse to run. copperhead snapshots your tree with git before it edits, and rolls back to that snapshot when verification fails. No repo, no undo, no run. The safety net is not a feature: it is a prerequisite.
 
 Then it told me to fix my own environment:
 
@@ -64,7 +64,7 @@ I had both keys exported, like most developers do. A more accommodating tool pic
 copperhead init
 ```
 
-This reads the existing schematic and scaffolds a `docs/` directory: spec, subsystems, BOM, pinout, layout notes. Those files are not documentation in the write-once sense. They are the agent's memory. Every run reads them first, which means it operates with the whole design in context instead of just the part in front of it — and it means a wrong value in there becomes a wrong assumption in every change afterward.
+This reads the existing schematic and scaffolds a `docs/` directory: spec, subsystems, BOM, pinout, layout notes. Those files are not documentation in the write-once sense. They are the agent's memory. Every run reads them first, which means it operates with the whole design in context instead of just the part in front of it, and it means a wrong value in there becomes a wrong assumption in every change afterward.
 
 Which makes the next ten minutes the highest-leverage ten minutes in the process: read what it wrote about your board, and correct it. That is not overhead. That is the work.
 
@@ -76,7 +76,7 @@ I re-ran `init` to see what would happen, and got **refusal #2**: it will not ov
 copperhead check
 ```
 
-ERC, DRC, doc-drift detection, constraint checks, spec validation. No LLM calls and no network access — not by convention but by contract; the module imports no provider, so it *cannot* make one. That is what makes it safe to drop into CI and into the pre-commit hook `init` installs for you.
+ERC, DRC, doc-drift detection, constraint checks, spec validation. No LLM calls and no network access, not by convention but by contract: the module imports no provider, so it *cannot* make one. That is what makes it safe to drop into CI and into the pre-commit hook `init` installs for you.
 
 Here is the trap, and I include it because I walked into it. Run `check` on a repo you have not `init`-ed and you get this:
 
@@ -85,7 +85,7 @@ ERC skipped (no schematic configured; run copperhead init)
 DRC skipped (no board configured)
 ```
 
-Exit code: 0. Green. That is a pass over an empty set, not a clean board — the same shape as a test suite reporting success because it collected no tests. Read the lines, not the exit code.
+Exit code: 0. Green. That is a pass over an empty set, not a clean board, the same shape as a test suite reporting success because it collected no tests. Read the lines, not the exit code.
 
 ## Minute fifteen: the actual change
 
@@ -95,7 +95,7 @@ I picked a net rename. Narrow, and wrong would be obvious.
 copperhead do "rename net KEY_DAH to KEY_DASH" --interactive
 ```
 
-It proposed first: why, what changes, the task list. Only after that validated did its edit tools come into existence at all. Then it made anchored replacements in the schematic and in every doc that mentioned the net, ran ERC, and committed once — verification result in the commit message, a line in the changelog, the reasoning appended to a decisions log.
+It proposed first: why, what changes, the task list. Only after that validated did its edit tools come into existence at all. Then it made anchored replacements in the schematic and in every doc that mentioned the net, ran ERC, and committed once: verification result in the commit message, a line in the changelog, the reasoning appended to a decisions log.
 
 The propagation is the part that earns its keep. Renaming a net in the schematic is thirty seconds of work. Renaming it in the schematic *and* the pinout *and* the BOM rationale *and* the subsystem description, without missing one, is the boring, error-prone task that hardware documentation dies of. That is the job it is actually good at.
 
@@ -103,7 +103,7 @@ The propagation is the part that earns its keep. Renaming a net in the schematic
 
 **Refusal #3.** Every text edit to a schematic or board is probed for loadability afterward. If the edit would leave the file unopenable in KiCad, it is reverted immediately and the agent is handed the parser error to try again. A corrupted s-expression file does not reach your disk and then fail confusingly on the next command.
 
-**Refusal #4** is the one that changed how I think about the tool. There is a mode where the schematic is generated from a declarative intent file — parts, nets, groups, no coordinates — and a deterministic engine computes every wire and position. In that mode, the agent is *forbidden from hand-editing the schematic it just drew*. Ask it to nudge something and it declines, and tells you to revise the intent and regenerate.
+**Refusal #4** is the one that changed how I think about the tool. There is a mode where the schematic is generated from a declarative intent file (parts, nets, groups, no coordinates) and a deterministic engine computes every wire and position. In that mode, the agent is *forbidden from hand-editing the schematic it just drew*. Ask it to nudge something and it declines, and tells you to revise the intent and regenerate.
 
 That is a system refusing to do the easy thing in the moment because the easy thing destroys a property it needs later: the same intent must always produce byte-identical output. The moment you allow one manual nudge, the drawing and the intent diverge, and you no longer know which one is the design.
 
@@ -113,11 +113,11 @@ I have worked with people who lacked that discipline.
 
 **It is early, and says so.** The README leads with it. Phase 1, expect the surface to move.
 
-**Know what each command costs.** `check`, `doctor`, and the deterministic commands are free and instant — no model involved. A small `do` is a few minutes. `create`, which goes from a product brief to gerbers and firmware across eight stages, runs in hours, not minutes. It prints a heartbeat so you can tell slow from hung. Start with a small brief.
+**Know what each command costs.** `check`, `doctor`, and the deterministic commands are free and instant: no model involved. A small `do` is a few minutes. `create`, which goes from a product brief to gerbers and firmware across eight stages, runs in hours, not minutes. It prints a heartbeat so you can tell slow from hung. Start with a small brief.
 
-**It is not the engineer of record.** Not an autorouter, not a replacement for your judgment, and it never claims a board is fab-ready — only that ERC and DRC are clean. A human still signs off. That framing is in the docs, unhedged, which I respect more than the alternative.
+**It is not the engineer of record.** Not an autorouter, not a replacement for your judgment, and it never claims a board is fab-ready: only that ERC and DRC are clean. A human still signs off. That framing is in the docs, unhedged, which I respect more than the alternative.
 
-**Failed work is normally recoverable.** When a run cannot make verification pass, it rolls back — but it tries to stash everything it touched first, under a named git stash entry, and prints the command to get it back. Both steps are best-effort rather than guaranteed: if the rollback itself fails, the run says so and warns that the tree may be partial, which is your cue to read `git status` instead of assuming a clean revert.
+**Failed work is normally recoverable.** When a run cannot make verification pass, it rolls back, but it tries to stash everything it touched first, under a named git stash entry, and prints the command to get it back. Both steps are best-effort rather than guaranteed: if the rollback itself fails, the run says so and warns that the tree may be partial, which is your cue to read `git status` instead of assuming a clean revert.
 
 ## The part that actually matters
 

--- a/docs/blog/i-gave-an-ai-agent-my-kicad-repo.md
+++ b/docs/blog/i-gave-an-ai-agent-my-kicad-repo.md
@@ -14,7 +14,7 @@ So this is not a demo post. It is the first twenty minutes with [copperhead](htt
 
 copperhead is a CLI agent that works on a KiCad repository the way a coding agent works on a codebase. It reads your design docs, proposes a change as a validated spec, edits the real `.kicad_sch` and `.kicad_pcb` files, then runs `kicad-cli` ERC and DRC on its own work until the tools agree.
 
-KiCad stays your editor. Nothing moves into a walled garden. The files it edits are the files you already have, in the git repo you already have, and every artifact it produces is markdown you can read in a diff.
+KiCad stays your editor. Nothing moves into a walled garden. The files it edits are the files you already have, in the git repo you already have, and every artifact it produces is plain text you can read in a diff: s-expressions for the schematic and board, markdown for the design docs and the reasoning behind them.
 
 Two rules hold the whole thing up, and it is worth stating them before anything else, because everything below is a consequence of one of them:
 

--- a/docs/src/content/docs/getting-started/agent-install.md
+++ b/docs/src/content/docs/getting-started/agent-install.md
@@ -2,7 +2,7 @@
 title: Agent install
 description: Onboard and configure copperhead using a single pasteable prompt inside your AI assistant.
 sidebar:
-  order: 3
+  order: 4
 ---
 
 ## Onboarding Prompt: Install and Configure copperhead

--- a/docs/src/content/docs/getting-started/demo.md
+++ b/docs/src/content/docs/getting-started/demo.md
@@ -2,7 +2,7 @@
 title: Simple demo
 description: Run the create pipeline end to end against the USB-C power breakout brief.
 sidebar:
-  order: 4
+  order: 5
 ---
 
 The quickest end-to-end demo uses the USB-C power breakout brief. It is intentionally small: one connector, passives, a power LED, and output protection.

--- a/docs/src/content/docs/getting-started/first-run.md
+++ b/docs/src/content/docs/getting-started/first-run.md
@@ -27,7 +27,17 @@ Nothing, or a number below 20? Install it from [nodejs.org](https://nodejs.org/)
 
 ### 2. KiCad 8 or newer
 
-Install the desktop app; copperhead drives the `kicad-cli` tool that ships inside it. The [download page](https://www.kicad.org/download/) asks you to pick a platform and then a mirror — any mirror works, so take the one nearest you.
+Install the desktop app; copperhead drives the `kicad-cli` tool that ships inside it.
+
+The [download page](https://www.kicad.org/download/) makes you choose a platform and then a mirror, which is a lot of decisions for a file that is the same from every one of them. Any mirror works: take whichever is nearest you. These start the download for the current stable release directly:
+
+| Platform | Direct download |
+| --- | --- |
+| Windows x64 | [kicad-10.0.5-x86_64.exe](https://github.com/KiCad/kicad-source-mirror/releases/download/10.0.5/kicad-10.0.5-x86_64.exe) (Asia: [Tsinghua](https://mirror.tuna.tsinghua.edu.cn/kicad/windows/stable/kicad-10.0.5-x86_64.exe), Europe: [CERN](https://kicad-downloads.s3.cern.ch/windows/stable/kicad-10.0.5-x86_64.exe)) |
+| macOS | [kicad.org/download/macos](https://www.kicad.org/download/macos/) |
+| Linux | [kicad.org/download](https://www.kicad.org/download/) (use your distribution's package) |
+
+It is roughly a 1 GB download and the installer takes a few minutes, so start it before you read on. Any KiCad 8 or newer works; the links above are simply the current release at the time of writing.
 
 :::caution[KiCad does not put itself on your PATH]
 This is the single most common setup failure, and the error you get (`kicad-cli not found on PATH`) does not say that KiCad is installed fine and merely invisible. It usually is.
@@ -160,10 +170,22 @@ export ANTHROPIC_API_KEY=...           # or OPENAI_API_KEY, not both
 run failed: provider error: Failed to authenticate. API Error: 401 OAuth access token is invalid.
 ```
 
-Check the length rather than eyeballing it — a real token is roughly 100+ characters with no spaces:
+Check the length rather than eyeballing it: a real token is roughly 100 characters or more, with no spaces anywhere.
 
 ```powershell
 $env:CLAUDE_CODE_OAUTH_TOKEN.Length
+```
+
+From Windows `cmd`, where that syntax does not exist:
+
+```text
+powershell -c "$env:CLAUDE_CODE_OAUTH_TOKEN.Length"
+```
+
+From bash:
+
+```bash
+echo ${#CLAUDE_CODE_OAUTH_TOKEN}
 ```
 
 The quotes in `set "VAR=value"` and `export VAR="value"` above are what keep a stray space from truncating the value.

--- a/docs/src/content/docs/getting-started/first-run.md
+++ b/docs/src/content/docs/getting-started/first-run.md
@@ -1,11 +1,11 @@
 ---
 title: Your first run
-description: A guided first hour with copperhead on a board you already have — including what it looks like when something goes wrong.
+description: A guided first hour with copperhead on a board you already have, including what it looks like when something goes wrong.
 sidebar:
   order: 3
 ---
 
-The [Quickstart](/getting-started/quickstart/) lists the commands. This page walks the path, in order, on a board you already own — and spends most of its length on the parts where people get stuck.
+The [Quickstart](/getting-started/quickstart/) lists the commands. This page walks the path, in order, on a board you already own, and spends most of its length on the parts where people get stuck.
 
 Budget about twenty minutes. If your baseline is clean and verification passes, you end with one small, ERC-verified, committed change. If it does not, you end with a rolled-back tree and a written reason, which is the other half of what you are here to see. Either way you will have enough of a feel for the loop to decide whether you trust it with something bigger.
 
@@ -42,16 +42,20 @@ It is roughly a 1 GB download and the installer takes a few minutes, so start it
 :::caution[KiCad does not put itself on your PATH]
 This is the single most common setup failure, and the error you get (`kicad-cli not found on PATH`) does not say that KiCad is installed fine and merely invisible. It usually is.
 
-**Windows** — the installer does not touch PATH at all. Run this once in PowerShell, adjusting `10.0` to your version:
+**Windows**: the installer does not touch PATH at all. Run this once in PowerShell, adjusting `10.0` to your version. The guard keeps a second run from appending a duplicate entry:
 
 ```powershell
-[Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path","User") + ";C:\Program Files\KiCad\10.0\bin", "User")
+if ($env:Path -notlike "*KiCad*") {
+  [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path","User") + ";C:\Program Files\KiCad\10.0\bin", "User")
+}
 ```
 
-**macOS** — the binary lives inside the app bundle:
+One caveat: that call rewrites your user `Path` as a plain string, so any `%USERPROFILE%`-style entries already in it stop expanding. If yours contains those, use the GUI instead (search "Edit environment variables for your account"), which preserves them.
+
+**macOS**: the binary lives inside the app bundle. Append it to your shell profile rather than exporting it into one session, or the next step throws the fix away:
 
 ```bash
-export PATH="/Applications/KiCad/KiCad.app/Contents/MacOS:$PATH"
+echo 'export PATH="/Applications/KiCad/KiCad.app/Contents/MacOS:$PATH"' >> ~/.zshrc
 ```
 
 Then **open a new terminal.** A PATH change never reaches a window that was already open, so re-running `doctor` in the same one will fail again and send you chasing a problem you have already fixed.
@@ -84,9 +88,9 @@ Install copperhead for this repo using https://raw.githubusercontent.com/chouhan
 
 ## Before you start
 
-You need a KiCad project in a git repository. Not a copy on the desktop — an actual repo, because copperhead snapshots with git before it edits and rolls back to that snapshot when verification fails. No repo, no safety net, and the preflight will refuse to run.
+You need a KiCad project in a git repository. Not a copy on the desktop: an actual repo, because copperhead snapshots with git before it edits and rolls back to that snapshot when verification fails. No repo, no safety net, and the preflight will refuse to run.
 
-**Everything must be committed before you run.** copperhead refuses to start on a tree with uncommitted changes, because its snapshot-and-rollback contract cannot tell your unsaved work from its own. A fresh `git init` alone is not enough — the first commit has to exist too.
+**Commit everything before `do` or the interactive shell.** Those two refuse to start on a tree with uncommitted changes, because the snapshot-and-rollback contract cannot tell your unsaved work from its own. (`create` deliberately allows a dirty tree so its stages can build on each other, and `init`, `check`, `doctor`, and `sync` never inspect it.) A fresh `git init` alone is not enough either: the first commit has to exist.
 
 ```bash
 cd my-board
@@ -99,7 +103,7 @@ git commit -m "baseline before copperhead"
 
 Read that `git status` output rather than skipping past it. `git add -A` stages everything it finds, and a baseline commit is a bad place to discover you have captured a `.env`, a vendor archive, or someone's local scratch files.
 
-Working on something you cannot commit yet? Pass `--allow-dirty`, which snapshots through `git stash create` instead.
+Working on something you cannot commit yet? `do` and the interactive shell take `--allow-dirty`, which snapshots through `git stash create` instead. No other command accepts the flag.
 
 Work on a branch for the first run. Nothing here is destructive, but a branch makes "throw it all away" a one-liner:
 
@@ -109,7 +113,7 @@ git switch -c copperhead-trial
 
 ## Step 1: Ask what is missing
 
-Run this before anything else. It calls no model and touches no network — it just tells you whether the machine is ready.
+Run this before anything else. It calls no model and touches no network; it just tells you whether the machine is ready.
 
 ```bash
 copperhead doctor
@@ -129,9 +133,9 @@ On a machine that is not ready yet:
 not ready: fix the [FAIL] items above
 ```
 
-`[info]` lines are notes, not problems — the missing `config.json` on that last line is exactly what Step 3 creates. Only `[FAIL]` blocks you. Exit code is 0 when ready, 1 when not, so this is safe to put in a setup script.
+`[info]` lines are notes, not problems: the missing `config.json` on that last line is exactly what Step 3 creates. Only `[FAIL]` blocks you. Exit code is 0 when ready, 1 when not, so this is safe to put in a setup script.
 
-If `kicad-cli` fails here, go back to the PATH note in Install — and remember that the fix only takes effect in a new terminal.
+If `kicad-cli` fails here, go back to the PATH note in Install, and remember that the fix only takes effect in a new terminal.
 
 ## Step 2: Choose one model backend
 
@@ -153,7 +157,7 @@ Each of those needs its own CLI authenticated first:
 | --- | --- | --- |
 | `codex` | the Codex CLI's own ChatGPT login | `codex login status` |
 | `cursor` | `agent login` | `agent status` |
-| `claude-code` | see the token step below | `claude setup-token` |
+| `claude-code` | see the token step below | `copperhead doctor` |
 
 For Claude Code you also need its token. Generate one:
 
@@ -216,7 +220,7 @@ The quotes in `set "VAR=value"` and `export VAR="value"` keep the shell from spl
 :::
 
 :::danger[Two keys in your environment is a hard stop]
-If you have both `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` exported — common on a developer machine — copperhead refuses to guess:
+If you have both `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` exported: common on a developer machine: copperhead refuses to guess:
 
 ```text
   [FAIL] provider  ambiguous: multiple credentials, no model selected
@@ -252,11 +256,11 @@ Your key is read from the environment only. It is never written into `.copperhea
 copperhead init
 ```
 
-This reads your schematic and scaffolds `docs/` — `SPEC.md`, `SUBSYSTEMS.md`, `BOM.md`, `PINOUT.md`, `LAYOUT.md` — plus `.copperhead/config.json` pointing at your schematic and board. It also installs a `pre-commit` hook that runs `copperhead check`, and it will not clobber a hook you already have.
+This reads your schematic and scaffolds `docs/`: `SPEC.md`, `SUBSYSTEMS.md`, `BOM.md`, `PINOUT.md`, `LAYOUT.md`: plus `.copperhead/config.json` pointing at your schematic and board. It also installs a `pre-commit` hook that runs `copperhead check`, and it will not clobber a hook you already have.
 
 `init` is idempotent. Re-run it freely: it reports `unchanged` for files it already wrote, and it **refuses** to overwrite a generated doc you have since hand-edited, exiting non-zero and naming the files it skipped. Pass `--force` only when you genuinely want them regenerated.
 
-Read what it produced before continuing. The scaffolded docs are the agent's memory — every later run reads them first, so a wrong value here becomes a wrong assumption in every change after it. This is the highest-leverage ten minutes in the whole process.
+Read what it produced before continuing. The scaffolded docs are the agent's memory: every later run reads them first, so a wrong value here becomes a wrong assumption in every change after it. This is the highest-leverage ten minutes in the whole process.
 
 ## Step 4: Establish a baseline
 
@@ -264,7 +268,7 @@ Read what it produced before continuing. The scaffolded docs are the agent's mem
 copperhead check          # alias: copperhead verify
 ```
 
-This runs ERC, DRC, doc-drift detection, constraint checks, and spec validation. It makes no LLM calls and opens no network connections, by contract — which is why it is safe in CI and in that pre-commit hook.
+This runs ERC, DRC, doc-drift detection, constraint checks, and spec validation. It makes no LLM calls and opens no network connections, by contract: which is why it is safe in CI and in that pre-commit hook.
 
 :::caution[A green check on an un-adopted repo means nothing]
 If `init` has not run, or `config.json` does not point at your files, `check` skips everything and still exits 0:
@@ -274,10 +278,10 @@ ERC skipped (no schematic configured; run copperhead init)
 DRC skipped (no board configured)
 ```
 
-That is a pass over an empty set, not a clean board. Read the lines, not the exit code — if you see `skipped`, fix the config before you trust anything downstream.
+That is a pass over an empty set, not a clean board. Read the lines, not the exit code: if you see `skipped`, fix the config before you trust anything downstream.
 :::
 
-Expect real findings on a real board. Fix them, or note them, before the agent starts making changes — otherwise you cannot tell its mistakes from your pre-existing ones.
+Expect real findings on a real board. Fix them, or note them, before the agent starts making changes: otherwise you cannot tell its mistakes from your pre-existing ones.
 
 ## Step 5: One small change
 
@@ -297,7 +301,7 @@ copperhead do "rename net KEY_DAH to KEY_DASH" --interactive
 
 What happens, in order:
 
-1. **Propose.** The agent writes an OpenSpec change proposal — why, what changes, the task list. Until this validates, its edit tools do not exist. Not discouraged: absent from the tool list it is given.
+1. **Propose.** The agent writes an OpenSpec change proposal: why, what changes, the task list. Until this validates, its edit tools do not exist. Not discouraged: absent from the tool list it is given.
 2. **Edit.** Anchored exact-match replacements in the `.kicad_sch` and in every doc that mentions the net.
 3. **Verify.** ERC runs, and DRC too if the board changed. Failures come back to the agent as its own error report to repair.
 4. **Commit.** One commit, with the verification result in the message, plus a line in `docs/CHANGELOG.md` and any real decision appended to `docs/DECISIONS.md`.
@@ -310,11 +314,11 @@ Worth calibrating before you reach for the big commands:
 
 | Command | Typical shape |
 |---|---|
-| `check`, `doctor`, `draft`, `score`, `export bom` | Seconds. No model, no network, no cost. |
+| `check`, `doctor`, `export bom` | Seconds. No model, no network, no cost. |
 | `do "<small change>"` | A handful of turns, a few minutes. |
 | `create --brief brief.md` | Eight stages. Hours, not minutes. |
 
-`create` is a full pipeline — spec, architecture, part selection, schematic, layout, outputs, firmware, dev plan. Individual stages can legitimately run over an hour. It is not hung; it prints a heartbeat every 30 seconds while a turn is in flight. Try it first on a small brief from [examples/simple](https://github.com/chouhanindustries/copperhead/tree/main/examples/simple).
+`create` is a full pipeline: spec, architecture, part selection, schematic, layout, outputs, firmware, dev plan. Individual stages can legitimately run over an hour. It is not hung; it prints a heartbeat every 30 seconds while a turn is in flight. Try it first on a small brief from [examples/simple](https://github.com/chouhanindustries/copperhead/tree/main/examples/simple).
 
 ### Starting a new board instead
 
@@ -330,7 +334,7 @@ copperhead create --brief brief.md
 
 Only the copy differs on Windows: `copy path\to\brief.md brief.md` in `cmd`, or `Copy-Item path\to\brief.md brief.md` in PowerShell.
 
-Start from an example brief rather than your own. You are testing whether the pipeline runs on your machine, and a known-good input keeps a bad first result from being ambiguous. Each stage commits on its own, so an interrupted run resumes from the last finished one — re-running the same command picks up where it stopped.
+Start from an example brief rather than your own. You are testing whether the pipeline runs on your machine, and a known-good input keeps a bad first result from being ambiguous. Each stage commits on its own, so an interrupted run resumes from the last finished one: re-running the same command picks up where it stopped.
 
 ## When it goes wrong
 
@@ -343,7 +347,7 @@ Start from an example brief rather than your own. You are testing whether the pi
 | `no model configured`, but you set one | `set` / `export` only covered the old window | Re-set it here, or persist it with `setx` / your shell profile |
 | `401 OAuth access token is invalid` | Usually a space pasted into the token, not a revoked one | Check its length, re-set it quoted and unbroken |
 | `Connection closed mid-response` | Transient network drop | Nothing: the pipeline diagnoses and retries the stage itself |
-| Preflight refuses on a dirty tree | Uncommitted changes would be caught in the snapshot | Commit or stash first, or pass `--allow-dirty` |
+| Preflight refuses on a dirty tree | Uncommitted changes would be caught in the snapshot | Commit or stash first, or pass `--allow-dirty` (on `do` and the shell only) |
 | `ERC skipped (no schematic configured)` | `init` has not run, or config points nowhere | `copperhead init` |
 | `run failed: ... working tree restored` | Verification never passed; changes were rolled back | See the preserved-work note below |
 | `session/usage limit reached` | Saved-login quota, not a bug | Wait for the stated reset, re-run the same command |

--- a/docs/src/content/docs/getting-started/first-run.md
+++ b/docs/src/content/docs/getting-started/first-run.md
@@ -7,7 +7,7 @@ sidebar:
 
 The [Quickstart](/getting-started/quickstart/) lists the commands. This page walks the path, in order, on a board you already own — and spends most of its length on the parts where people get stuck.
 
-Budget about twenty minutes. At the end you will have one small, ERC-verified, committed change, and enough of a feel for the loop to decide whether you trust it with a bigger one.
+Budget about twenty minutes. If your baseline is clean and verification passes, you end with one small, ERC-verified, committed change. If it does not, you end with a rolled-back tree and a written reason, which is the other half of what you are here to see. Either way you will have enough of a feel for the loop to decide whether you trust it with something bigger.
 
 :::note[Shell syntax on this page]
 Commands are written for bash (macOS, Linux, Git Bash). On **Windows `cmd`**, swap `export FOO=bar` for `set "FOO=bar"`, and use `\` in paths. Both variants are given wherever it actually matters.
@@ -90,8 +90,14 @@ You need a KiCad project in a git repository. Not a copy on the desktop — an a
 
 ```bash
 cd my-board
-git init && git add -A && git commit -m "baseline before copperhead"
+git init
+printf '.env\n.copperhead/runs/\n' >> .gitignore
+git add -A
+git status                       # read this list before committing
+git commit -m "baseline before copperhead"
 ```
+
+Read that `git status` output rather than skipping past it. `git add -A` stages everything it finds, and a baseline commit is a bad place to discover you have captured a `.env`, a vendor archive, or someone's local scratch files.
 
 Working on something you cannot commit yet? Pass `--allow-dirty`, which snapshots through `git stash create` instead.
 
@@ -129,13 +135,25 @@ If `kicad-cli` fails here, go back to the PATH note in Install — and remember 
 
 ## Step 2: Choose one model backend
 
-You need exactly one. Not zero, and — this trips people up — not two.
+You need to name exactly one. What copperhead refuses is not two credentials existing, it is having to guess between them: with `COPPERHEAD_MODEL` (or `--model`) set, extra credentials in your environment are simply ignored.
 
-If you already use Codex CLI or Claude Code, reuse that login and skip API keys entirely:
+If you already use Codex CLI, Claude Code, or Cursor, reuse that login and skip API keys entirely:
 
 ```bash
 export COPPERHEAD_MODEL=codex          # or: claude-code, cursor
 ```
+
+```text
+set "COPPERHEAD_MODEL=codex"
+```
+
+Each of those needs its own CLI authenticated first:
+
+| Backend | Authenticate with | Check it |
+| --- | --- | --- |
+| `codex` | the Codex CLI's own ChatGPT login | `codex login status` |
+| `cursor` | `agent login` | `agent status` |
+| `claude-code` | see the token step below | `claude setup-token` |
 
 For Claude Code you also need its token. Generate one:
 
@@ -157,10 +175,14 @@ set "CLAUDE_CODE_OAUTH_TOKEN=<the token it printed>"
 set "COPPERHEAD_MODEL=claude-code"
 ```
 
-Otherwise export a single API key:
+Otherwise supply a single API key:
 
 ```bash
-export ANTHROPIC_API_KEY=...           # or OPENAI_API_KEY, not both
+export ANTHROPIC_API_KEY=...           # or OPENAI_API_KEY
+```
+
+```text
+set "ANTHROPIC_API_KEY=..."
 ```
 
 :::caution[Two ways a perfectly good token still fails]
@@ -188,9 +210,9 @@ From bash:
 echo ${#CLAUDE_CODE_OAUTH_TOKEN}
 ```
 
-The quotes in `set "VAR=value"` and `export VAR="value"` above are what keep a stray space from truncating the value.
+The quotes in `set "VAR=value"` and `export VAR="value"` keep the shell from splitting the assignment at that space, so the whole broken value is stored rather than a truncated one. They cannot repair the token itself. A token with a space inside it is corrupt either way: copy it again, or generate a fresh one.
 
-**It only lived in one window.** `set` and `export` last for that terminal session only. Open a new window and the credential is gone, and `doctor` reports no model configured again. Use `setx` on Windows, or your shell profile on macOS and Linux, to make it stick.
+**It only lived in one window.** `set` and `export` last for that terminal session only. Open a new window and the credential is gone, and `doctor` reports no model configured again. Use `setx` on Windows, or your shell profile on macOS and Linux, to make it stick. `setx` writes the value for *future* processes only, so close the terminal and open a new one before re-running `doctor`, exactly as with the PATH fix.
 :::
 
 :::danger[Two keys in your environment is a hard stop]
@@ -280,7 +302,7 @@ What happens, in order:
 3. **Verify.** ERC runs, and DRC too if the board changed. Failures come back to the agent as its own error report to repair.
 4. **Commit.** One commit, with the verification result in the message, plus a line in `docs/CHANGELOG.md` and any real decision appended to `docs/DECISIONS.md`.
 
-If verification cannot be made to pass, the run rolls back to the pre-run snapshot and your tree is left exactly as it was.
+If verification cannot be made to pass, the run rolls back to the pre-run snapshot. On the normal path your tree is left exactly as it was. If the rollback itself fails, which git can do when it is in an odd state, the run says so explicitly and warns that the tree may be partial: read that line rather than assuming a clean revert, and check `git status` before rerunning.
 
 ## What a run costs
 
@@ -306,6 +328,8 @@ git add -A && git commit -m "brief"
 copperhead create --brief brief.md
 ```
 
+Only the copy differs on Windows: `copy path\to\brief.md brief.md` in `cmd`, or `Copy-Item path\to\brief.md brief.md` in PowerShell.
+
 Start from an example brief rather than your own. You are testing whether the pipeline runs on your machine, and a known-good input keeps a bad first result from being ambiguous. Each stage commits on its own, so an interrupted run resumes from the last finished one — re-running the same command picks up where it stopped.
 
 ## When it goes wrong
@@ -326,7 +350,7 @@ Start from an example brief rather than your own. You are testing whether the pi
 
 Two things worth knowing about that last column.
 
-**Failed work is not destroyed.** A failed run preserves everything it touched as a named git stash entry before rolling back, and prints the recovery command:
+**Failed work is normally not destroyed.** A failed run tries to preserve everything it touched as a named git stash entry before rolling back, and prints the stash id and the recovery command when it succeeds. Both steps are best-effort: if no preservation line appears, or the run reports a failed rollback, inspect `git status` and `git stash list` yourself rather than assuming either happened.
 
 ```bash
 git stash apply     # get the failed run's work back

--- a/docs/src/content/docs/getting-started/first-run.md
+++ b/docs/src/content/docs/getting-started/first-run.md
@@ -1,0 +1,333 @@
+---
+title: Your first run
+description: A guided first hour with copperhead on a board you already have — including what it looks like when something goes wrong.
+sidebar:
+  order: 3
+---
+
+The [Quickstart](/getting-started/quickstart/) lists the commands. This page walks the path, in order, on a board you already own — and spends most of its length on the parts where people get stuck.
+
+Budget about twenty minutes. At the end you will have one small, ERC-verified, committed change, and enough of a feel for the loop to decide whether you trust it with a bigger one.
+
+:::note[Shell syntax on this page]
+Commands are written for bash (macOS, Linux, Git Bash). On **Windows `cmd`**, swap `export FOO=bar` for `set "FOO=bar"`, and use `\` in paths. Both variants are given wherever it actually matters.
+:::
+
+## Install
+
+Four things. copperhead checks three of them for you in Step 1, so install first and let it grade your work.
+
+### 1. Node.js 20 or newer
+
+```bash
+node --version
+```
+
+Nothing, or a number below 20? Install it from [nodejs.org](https://nodejs.org/).
+
+### 2. KiCad 8 or newer
+
+Install the desktop app; copperhead drives the `kicad-cli` tool that ships inside it. The [download page](https://www.kicad.org/download/) asks you to pick a platform and then a mirror — any mirror works, so take the one nearest you.
+
+:::caution[KiCad does not put itself on your PATH]
+This is the single most common setup failure, and the error you get (`kicad-cli not found on PATH`) does not say that KiCad is installed fine and merely invisible. It usually is.
+
+**Windows** — the installer does not touch PATH at all. Run this once in PowerShell, adjusting `10.0` to your version:
+
+```powershell
+[Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path","User") + ";C:\Program Files\KiCad\10.0\bin", "User")
+```
+
+**macOS** — the binary lives inside the app bundle:
+
+```bash
+export PATH="/Applications/KiCad/KiCad.app/Contents/MacOS:$PATH"
+```
+
+Then **open a new terminal.** A PATH change never reaches a window that was already open, so re-running `doctor` in the same one will fail again and send you chasing a problem you have already fixed.
+
+Not sure where it landed? Find it:
+
+```powershell
+Get-ChildItem "C:\Program Files\KiCad" -Filter kicad-cli.exe -Recurse | Select FullName
+```
+:::
+
+### 3. git
+
+```bash
+git --version
+```
+
+### 4. copperhead
+
+```bash
+npm install -g copperhead
+copperhead --version
+```
+
+Already inside an AI coding assistant? Paste this instead and it will do the whole setup for you:
+
+```text
+Install copperhead for this repo using https://raw.githubusercontent.com/chouhanindustries/copperhead/main/agent-install-prompt.md
+```
+
+## Before you start
+
+You need a KiCad project in a git repository. Not a copy on the desktop — an actual repo, because copperhead snapshots with git before it edits and rolls back to that snapshot when verification fails. No repo, no safety net, and the preflight will refuse to run.
+
+**Everything must be committed before you run.** copperhead refuses to start on a tree with uncommitted changes, because its snapshot-and-rollback contract cannot tell your unsaved work from its own. A fresh `git init` alone is not enough — the first commit has to exist too.
+
+```bash
+cd my-board
+git init && git add -A && git commit -m "baseline before copperhead"
+```
+
+Working on something you cannot commit yet? Pass `--allow-dirty`, which snapshots through `git stash create` instead.
+
+Work on a branch for the first run. Nothing here is destructive, but a branch makes "throw it all away" a one-liner:
+
+```bash
+git switch -c copperhead-trial
+```
+
+## Step 1: Ask what is missing
+
+Run this before anything else. It calls no model and touches no network — it just tells you whether the machine is ready.
+
+```bash
+copperhead doctor
+```
+
+On a machine that is not ready yet:
+
+```text
+  [ok]   node      v24.16.0 (>= 20)
+  [ok]   kicad-cli 8.0.9
+  [ok]   git       2.54.0.windows.1
+  [FAIL] provider  no model configured
+         hint: pass --model, set COPPERHEAD_MODEL, or export an API key; see
+               https://docs.copperhead.sh/reference/configuration/
+  [info] project   no .copperhead/config.json (run `copperhead init` to
+                   scaffold)
+not ready: fix the [FAIL] items above
+```
+
+`[info]` lines are notes, not problems — the missing `config.json` on that last line is exactly what Step 3 creates. Only `[FAIL]` blocks you. Exit code is 0 when ready, 1 when not, so this is safe to put in a setup script.
+
+If `kicad-cli` fails here, go back to the PATH note in Install — and remember that the fix only takes effect in a new terminal.
+
+## Step 2: Choose one model backend
+
+You need exactly one. Not zero, and — this trips people up — not two.
+
+If you already use Codex CLI or Claude Code, reuse that login and skip API keys entirely:
+
+```bash
+export COPPERHEAD_MODEL=codex          # or: claude-code, cursor
+```
+
+For Claude Code you also need its token. Generate one:
+
+```bash
+claude setup-token
+```
+
+Then set it, together with the model:
+
+```bash
+export CLAUDE_CODE_OAUTH_TOKEN="<the token it printed>"
+export COPPERHEAD_MODEL=claude-code
+```
+
+On Windows `cmd`, the same two:
+
+```text
+set "CLAUDE_CODE_OAUTH_TOKEN=<the token it printed>"
+set "COPPERHEAD_MODEL=claude-code"
+```
+
+Otherwise export a single API key:
+
+```bash
+export ANTHROPIC_API_KEY=...           # or OPENAI_API_KEY, not both
+```
+
+:::caution[Two ways a perfectly good token still fails]
+**A line break became a space.** Long tokens wrap when copied out of a terminal, and the wrap can paste back as a space in the middle. The result is a 401 that reads as though the credential were revoked:
+
+```text
+run failed: provider error: Failed to authenticate. API Error: 401 OAuth access token is invalid.
+```
+
+Check the length rather than eyeballing it — a real token is roughly 100+ characters with no spaces:
+
+```powershell
+$env:CLAUDE_CODE_OAUTH_TOKEN.Length
+```
+
+The quotes in `set "VAR=value"` and `export VAR="value"` above are what keep a stray space from truncating the value.
+
+**It only lived in one window.** `set` and `export` last for that terminal session only. Open a new window and the credential is gone, and `doctor` reports no model configured again. Use `setx` on Windows, or your shell profile on macOS and Linux, to make it stick.
+:::
+
+:::danger[Two keys in your environment is a hard stop]
+If you have both `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` exported — common on a developer machine — copperhead refuses to guess:
+
+```text
+  [FAIL] provider  ambiguous: multiple credentials, no model selected
+         hint: 2 credentials found (OPENAI_API_KEY, ANTHROPIC_API_KEY) and no
+               model was selected; pass --model, set COPPERHEAD_MODEL, or set
+               "model" in .copperhead/config.json.
+```
+
+This is deliberate. Silently picking one could send your design to a provider you did not intend, and bill you for it. Name the model and the error goes away:
+
+```bash
+export COPPERHEAD_MODEL=claude
+```
+:::
+
+Re-run `copperhead doctor` until it says `ready`:
+
+```text
+  [ok]   node      v24.16.0 (>= 20)
+  [ok]   kicad-cli 8.0.9
+  [ok]   git       2.54.0.windows.1
+  [ok]   provider  gpt-5 -> openai: OPENAI_API_KEY set
+  [info] project   no .copperhead/config.json (run `copperhead init` to
+                   scaffold)
+ready
+```
+
+Your key is read from the environment only. It is never written into `.copperhead/config.json`, and it is redacted from run transcripts as they are written.
+
+## Step 3: Adopt the board
+
+```bash
+copperhead init
+```
+
+This reads your schematic and scaffolds `docs/` — `SPEC.md`, `SUBSYSTEMS.md`, `BOM.md`, `PINOUT.md`, `LAYOUT.md` — plus `.copperhead/config.json` pointing at your schematic and board. It also installs a `pre-commit` hook that runs `copperhead check`, and it will not clobber a hook you already have.
+
+`init` is idempotent. Re-run it freely: it reports `unchanged` for files it already wrote, and it **refuses** to overwrite a generated doc you have since hand-edited, exiting non-zero and naming the files it skipped. Pass `--force` only when you genuinely want them regenerated.
+
+Read what it produced before continuing. The scaffolded docs are the agent's memory — every later run reads them first, so a wrong value here becomes a wrong assumption in every change after it. This is the highest-leverage ten minutes in the whole process.
+
+## Step 4: Establish a baseline
+
+```bash
+copperhead check          # alias: copperhead verify
+```
+
+This runs ERC, DRC, doc-drift detection, constraint checks, and spec validation. It makes no LLM calls and opens no network connections, by contract — which is why it is safe in CI and in that pre-commit hook.
+
+:::caution[A green check on an un-adopted repo means nothing]
+If `init` has not run, or `config.json` does not point at your files, `check` skips everything and still exits 0:
+
+```text
+ERC skipped (no schematic configured; run copperhead init)
+DRC skipped (no board configured)
+```
+
+That is a pass over an empty set, not a clean board. Read the lines, not the exit code — if you see `skipped`, fix the config before you trust anything downstream.
+:::
+
+Expect real findings on a real board. Fix them, or note them, before the agent starts making changes — otherwise you cannot tell its mistakes from your pre-existing ones.
+
+## Step 5: One small change
+
+Pick something narrow and easy to eyeball. A rename is ideal for a first run: unambiguous, and wrong is obvious.
+
+See the proposal without writing anything:
+
+```bash
+copperhead do "rename net KEY_DAH to KEY_DASH" --dry-run
+```
+
+Then run it for real, pausing for your approval once the plan validates:
+
+```bash
+copperhead do "rename net KEY_DAH to KEY_DASH" --interactive
+```
+
+What happens, in order:
+
+1. **Propose.** The agent writes an OpenSpec change proposal — why, what changes, the task list. Until this validates, its edit tools do not exist. Not discouraged: absent from the tool list it is given.
+2. **Edit.** Anchored exact-match replacements in the `.kicad_sch` and in every doc that mentions the net.
+3. **Verify.** ERC runs, and DRC too if the board changed. Failures come back to the agent as its own error report to repair.
+4. **Commit.** One commit, with the verification result in the message, plus a line in `docs/CHANGELOG.md` and any real decision appended to `docs/DECISIONS.md`.
+
+If verification cannot be made to pass, the run rolls back to the pre-run snapshot and your tree is left exactly as it was.
+
+## What a run costs
+
+Worth calibrating before you reach for the big commands:
+
+| Command | Typical shape |
+|---|---|
+| `check`, `doctor`, `draft`, `score`, `export bom` | Seconds. No model, no network, no cost. |
+| `do "<small change>"` | A handful of turns, a few minutes. |
+| `create --brief brief.md` | Eight stages. Hours, not minutes. |
+
+`create` is a full pipeline — spec, architecture, part selection, schematic, layout, outputs, firmware, dev plan. Individual stages can legitimately run over an hour. It is not hung; it prints a heartbeat every 30 seconds while a turn is in flight. Try it first on a small brief from [examples/simple](https://github.com/chouhanindustries/copperhead/tree/main/examples/simple).
+
+### Starting a new board instead
+
+This page assumes a board you already have. From nothing, the shape is the same but the command is `create`:
+
+```bash
+mkdir my-board && cd my-board
+git init
+cp path/to/examples/simple/coin-cell-led-beacon.md brief.md
+git add -A && git commit -m "brief"
+copperhead create --brief brief.md
+```
+
+Start from an example brief rather than your own. You are testing whether the pipeline runs on your machine, and a known-good input keeps a bad first result from being ambiguous. Each stage commits on its own, so an interrupted run resumes from the last finished one — re-running the same command picks up where it stopped.
+
+## When it goes wrong
+
+| What you see | What it means | Fix |
+|---|---|---|
+| `kicad-cli not found on PATH` | KiCad is almost certainly installed, just invisible | Add its `bin` directory to `PATH`, then **open a new terminal** |
+| `kicad-cli` still missing after the PATH fix | The change never reached this window | Close the terminal and open a new one |
+| `ambiguous: 2 credentials found` | Two API keys exported, no model named | `export COPPERHEAD_MODEL=claude` |
+| `no model configured` | No key and no saved login found | Export one key, or set `COPPERHEAD_MODEL` to a saved-login backend |
+| `no model configured`, but you set one | `set` / `export` only covered the old window | Re-set it here, or persist it with `setx` / your shell profile |
+| `401 OAuth access token is invalid` | Usually a space pasted into the token, not a revoked one | Check its length, re-set it quoted and unbroken |
+| `Connection closed mid-response` | Transient network drop | Nothing: the pipeline diagnoses and retries the stage itself |
+| Preflight refuses on a dirty tree | Uncommitted changes would be caught in the snapshot | Commit or stash first, or pass `--allow-dirty` |
+| `ERC skipped (no schematic configured)` | `init` has not run, or config points nowhere | `copperhead init` |
+| `run failed: ... working tree restored` | Verification never passed; changes were rolled back | See the preserved-work note below |
+| `session/usage limit reached` | Saved-login quota, not a bug | Wait for the stated reset, re-run the same command |
+
+Two things worth knowing about that last column.
+
+**Failed work is not destroyed.** A failed run preserves everything it touched as a named git stash entry before rolling back, and prints the recovery command:
+
+```bash
+git stash apply     # get the failed run's work back
+git stash drop      # or discard it
+```
+
+**A rate-limited saved-login run resumes cheaply.** Every completed turn is cached on disk, so re-running the same command after the reset replays that work at roughly zero tokens and picks up where it stopped.
+
+## What it will refuse to do
+
+For a first run, the refusals matter more than the features. copperhead is built to fail closed:
+
+- **No edit without a validated proposal.** The edit tools are structurally withheld, not merely discouraged.
+- **No "done" without ERC.** And DRC too, whenever the board changed.
+- **No edit that breaks a KiCad file.** Every text edit to a schematic or board is probed for loadability, and reverted if it would make the file unopenable.
+- **No hand-edits to an engine-drafted sheet.** Sheets drafted from an intent file are regenerated wholesale; direct geometry edits are refused rather than silently lost on the next re-draft.
+- **No silent resolution of a requirement violation.** `sync` will fix docs that drifted from the as-built schematic, but a violated budget or constraint is reported for you to decide, never auto-resolved.
+- **No LLM in `check`.** That command imports no provider at all, so it cannot make a network call.
+
+## Next
+
+- [Guardrails](/concepts/guardrails/): the two invariants, in depth
+- [The agent loop](/concepts/agent-loop/): what one run actually does, turn by turn
+- [Docs as memory](/concepts/docs-as-memory/): what lives in `docs/` and why it matters
+- [Design from a brief](/workflows/create-from-brief/): when you are starting from nothing
+- [CLI reference](/reference/cli/): every command and flag

--- a/docs/src/content/docs/getting-started/first-run.md
+++ b/docs/src/content/docs/getting-started/first-run.md
@@ -42,13 +42,19 @@ It is roughly a 1 GB download and the installer takes a few minutes, so start it
 :::caution[KiCad does not put itself on your PATH]
 This is the single most common setup failure, and the error you get (`kicad-cli not found on PATH`) does not say that KiCad is installed fine and merely invisible. It usually is.
 
-**Windows**: the installer does not touch PATH at all. Run this once in PowerShell, adjusting `10.0` to your version. The guard keeps a second run from appending a duplicate entry:
+**Windows**: the installer does not touch PATH at all. Paste this into PowerShell. It finds the install itself, so you do not need to know your KiCad version, and the guard keeps a second run from appending a duplicate:
 
 ```powershell
-if ($env:Path -notlike "*KiCad*") {
-  [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path","User") + ";C:\Program Files\KiCad\10.0\bin", "User")
+$bin = (Get-ChildItem "C:\Program Files\KiCad" -Filter kicad-cli.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).Directory.FullName
+if (-not $bin) { "kicad-cli.exe not found: is KiCad installed?" }
+elseif ($env:Path -like "*KiCad*") { "already on PATH" }
+else {
+  [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path","User") + ";$bin", "User")
+  "added $bin"
 }
 ```
+
+It prints what it did. Setting the path by hand instead? The directory is `C:\Program Files\KiCad\<VERSION>\bin`, where `<VERSION>` is the release you installed (`8.0`, `9.0`, `10.0`, ...), not the full version number.
 
 One caveat: that call rewrites your user `Path` as a plain string, so any `%USERPROFILE%`-style entries already in it stop expanding. If yours contains those, use the GUI instead (search "Edit environment variables for your account"), which preserves them.
 
@@ -60,10 +66,10 @@ echo 'export PATH="/Applications/KiCad/KiCad.app/Contents/MacOS:$PATH"' >> ~/.zs
 
 Then **open a new terminal.** A PATH change never reaches a window that was already open, so re-running `doctor` in the same one will fail again and send you chasing a problem you have already fixed.
 
-Not sure where it landed? Find it:
+Installed somewhere other than `C:\Program Files`? Widen the search and use the directory it reports:
 
 ```powershell
-Get-ChildItem "C:\Program Files\KiCad" -Filter kicad-cli.exe -Recurse | Select FullName
+Get-ChildItem C:\ -Filter kicad-cli.exe -Recurse -ErrorAction SilentlyContinue | Select FullName
 ```
 :::
 

--- a/docs/src/content/docs/getting-started/first-run.md
+++ b/docs/src/content/docs/getting-started/first-run.md
@@ -5,17 +5,40 @@ sidebar:
   order: 3
 ---
 
-The [Quickstart](/getting-started/quickstart/) lists the commands. This page walks the path, in order, on a board you already own, and spends most of its length on the parts where people get stuck.
+The [Quickstart](/getting-started/quickstart/) lists the commands. This page walks the path, in order, and spends most of its length on the parts where people get stuck.
 
 Budget about twenty minutes. If your baseline is clean and verification passes, you end with one small, ERC-verified, committed change. If it does not, you end with a rolled-back tree and a written reason, which is the other half of what you are here to see. Either way you will have enough of a feel for the loop to decide whether you trust it with something bigger.
 
+## Which path are you on?
+
+copperhead has two, and confusing them is the fastest way to waste an hour. Everyone does the same Install below; after that the two diverge.
+
+| | **You have a KiCad board already** | **You are starting from nothing** |
+| --- | --- | --- |
+| Command | `copperhead do "<request>"` | `copperhead create --brief brief.md` |
+| Input | a change request in plain English | a product brief, in markdown |
+| Takes | minutes | hours: eight stages |
+| Follow | Steps 1 to 5 below, in order | Install, Step 1, Step 2, then [Starting from nothing](#starting-from-nothing) |
+
+The interactive shell (`copperhead` with no arguments) is the conversational form of `do`, so it belongs to the left column. Open it on a repo with no schematic and every command reports `null`, because there is no design to read yet. Build the board with `create` first, then the shell becomes useful.
+
 :::note[Shell syntax on this page]
-Commands are written for bash (macOS, Linux, Git Bash). On **Windows `cmd`**, swap `export FOO=bar` for `set "FOO=bar"`, and use `\` in paths. Both variants are given wherever it actually matters.
+Commands are written for bash (macOS, Linux, Git Bash). Windows `cmd` differs in three ways that bite: `export` is `set`, `cp` is `copy`, and `&&` skips the rest of the line when the first command fails. Every block that needs one carries its `cmd` version underneath, so you never have to translate.
 :::
 
 ## Install
 
-Four things. copperhead checks three of them for you in Step 1, so install first and let it grade your work.
+:::tip[Skip all of this if you use an AI coding assistant]
+Working inside Claude Code, Cursor, or Codex? Paste this and it does the whole install for you, then reports what it found:
+
+```text
+Install copperhead for this repo using https://raw.githubusercontent.com/chouhanindustries/copperhead/main/agent-install-prompt.md
+```
+
+Then jump to [Which path are you on?](#which-path-are-you-on) above.
+:::
+
+Doing it by hand: four things. copperhead checks three of them for you in Step 1, so install first and let it grade your work.
 
 ### 1. Node.js 20 or newer
 
@@ -86,12 +109,6 @@ npm install -g copperhead
 copperhead --version
 ```
 
-Already inside an AI coding assistant? Paste this instead and it will do the whole setup for you:
-
-```text
-Install copperhead for this repo using https://raw.githubusercontent.com/chouhanindustries/copperhead/main/agent-install-prompt.md
-```
-
 ## Before you start
 
 You need a KiCad project in a git repository. Not a copy on the desktop: an actual repo, because copperhead snapshots with git before it edits and rolls back to that snapshot when verification fails. No repo, no safety net, and the preflight will refuse to run.
@@ -104,6 +121,17 @@ git init
 printf '.env\n.copperhead/runs/\n' >> .gitignore
 git add -A
 git status                       # read this list before committing
+git commit -m "baseline before copperhead"
+```
+
+The same thing in Windows `cmd`:
+
+```text
+cd my-board
+git init
+(echo .env& echo .copperhead/runs/) >> .gitignore
+git add -A
+git status
 git commit -m "baseline before copperhead"
 ```
 
@@ -153,6 +181,8 @@ If you already use Codex CLI, Claude Code, or Cursor, reuse that login and skip 
 export COPPERHEAD_MODEL=codex          # or: claude-code, cursor
 ```
 
+Windows `cmd`:
+
 ```text
 set "COPPERHEAD_MODEL=codex"
 ```
@@ -191,6 +221,8 @@ Otherwise supply a single API key:
 export ANTHROPIC_API_KEY=...           # or OPENAI_API_KEY
 ```
 
+Windows `cmd`:
+
 ```text
 set "ANTHROPIC_API_KEY=..."
 ```
@@ -226,7 +258,7 @@ The quotes in `set "VAR=value"` and `export VAR="value"` keep the shell from spl
 :::
 
 :::danger[Two keys in your environment is a hard stop]
-If you have both `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` exported: common on a developer machine: copperhead refuses to guess:
+If you have both `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` exported (common on a developer machine), copperhead refuses to guess:
 
 ```text
   [FAIL] provider  ambiguous: multiple credentials, no model selected
@@ -326,21 +358,41 @@ Worth calibrating before you reach for the big commands:
 
 `create` is a full pipeline: spec, architecture, part selection, schematic, layout, outputs, firmware, dev plan. Individual stages can legitimately run over an hour. It is not hung; it prints a heartbeat every 30 seconds while a turn is in flight. Try it first on a small brief from [examples/simple](https://github.com/chouhanindustries/copperhead/tree/main/examples/simple).
 
-### Starting a new board instead
+### Starting from nothing
 
-This page assumes a board you already have. From nothing, the shape is the same but the command is `create`:
+Steps 3 to 5 above adopt a board you already have. With no board, do Install, Step 1, and Step 2, then come straight here: an empty repo, a brief, and one command.
 
 ```bash
-mkdir my-board && cd my-board
+mkdir my-board
+cd my-board
 git init
-cp path/to/examples/simple/coin-cell-led-beacon.md brief.md
-git add -A && git commit -m "brief"
+cp ../copperhead/examples/simple/coin-cell-led-beacon.md brief.md
+git add -A
+git commit -m "brief"
 copperhead create --brief brief.md
 ```
 
-Only the copy differs on Windows: `copy path\to\brief.md brief.md` in `cmd`, or `Copy-Item path\to\brief.md brief.md` in PowerShell.
+The same thing in Windows `cmd`:
+
+```text
+mkdir my-board
+cd my-board
+git init
+copy ..\copperhead\examples\simple\coin-cell-led-beacon.md brief.md
+git add -A
+git commit -m "brief"
+copperhead create --brief brief.md
+```
+
+:::caution[Run those one line at a time on `cmd`]
+Do not join them with `&&`. If `mkdir my-board` fails because the directory already exists, `&&` skips the `cd` without stopping, and everything after it runs one level up: `git init` then turns that parent directory into a repository, which is a genuinely annoying thing to undo when the parent is somewhere like `Downloads`.
+
+If it happens, nothing is lost. Delete the stray repository (`rmdir /s /q .git` in the parent, `rm -rf .git` on bash), check you are in the right directory with `cd`, and start the block again.
+:::
 
 Start from an example brief rather than your own. You are testing whether the pipeline runs on your machine, and a known-good input keeps a bad first result from being ambiguous. Each stage commits on its own, so an interrupted run resumes from the last finished one: re-running the same command picks up where it stopped.
+
+When it finishes you have a schematic, and the interactive shell becomes useful: `copperhead` on its own, then `/status`, `/parts`, or a change request in plain English.
 
 ## When it goes wrong
 

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -110,6 +110,7 @@ It exits 0 when everything agrees and 1 when it does not.
 
 ## Next
 
+- [Your first run](/getting-started/first-run/): the same path, walked slowly, with the failure modes
 - [Simple demo](/getting-started/demo/): the full create pipeline, one command
 - [The agent loop](/concepts/agent-loop/): what one run actually does
 - [Docs as memory](/concepts/docs-as-memory/): what lives in `docs/` and why

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -81,7 +81,7 @@ async function kicadCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
       name: 'kicad-cli',
       status: 'fail',
       detail: 'not found on PATH',
-      hint: 'install KiCad >= 9 (bundles kicad-cli); ERC/DRC gates need it.',
+      hint: 'install KiCad >= 8 (bundles kicad-cli); ERC/DRC gates need it.',
     };
   }
 }


### PR DESCRIPTION
## What

Adds a journey-shaped onboarding page, [first-run.md](https://github.com/Chirag6722/copperhead/blob/docs/onboarding-guide/docs/src/content/docs/getting-started/first-run.md), that takes a new user from an empty machine to one verified, committed change, plus a narrative blog post and three small README fixes.

## Why

The existing onboarding material covers the surface well, but all of it is reference-shaped: it lists commands without walking the path or naming what goes wrong. Three concrete gaps came out of an audit:

1. `copperhead doctor` exists precisely to tell a new user what is missing, and it appeared in no onboarding path at all (not the README quickstart, not the docs quickstart).
2. The two-credential refusal was undocumented. A developer with both `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` exported, which is common, hits a hard stop on their first command with nothing in the docs explaining it.
3. `copperhead check` skips ERC and DRC and still exits 0 on a repo that has not been `init`-ed. That is a pass over an empty set reported as green, and nothing warned about it.

Then the guide was walked end to end on a clean Windows machine, as a new user, which surfaced eight more failures. Those are folded in and listed below.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | n/a (no source files touched) |
| Build | `npm run build` | n/a (no source files touched) |
| Unit + offline | `npm test` | n/a (no source files touched) |
| Markdown lint | `npm run lint:md` | pass (0 issues on the changed files) |
| Docs site build | `npm --prefix docs run build` | not run: blocked locally by a Windows Application Control policy on Astro's native binary (`@astrojs/compiler-binding-win32-x64-msvc`), unrelated to this change. Needs a build on another machine before merge. |

No test files were added or changed. Frontmatter matches the existing page schema, and the `:::caution` / `:::danger` asides follow the same pattern as [schematic-drafting.md](https://github.com/Chirag6722/copperhead/blob/docs/onboarding-guide/docs/src/content/docs/reference/schematic-drafting.md), which already uses `:::note` in a plain `.md` file.

### Manual test log (required)

Sandbox variant used: neither. The manual test here was the guide itself, walked as a new user on a clean Windows 11 machine with KiCad and the model backend uninstalled first.

Setup path exercised, in order:

```text
$ node --version
v24.16.0

$ copperhead doctor
  [FAIL] kicad-cli not found on PATH
  [FAIL] provider  no model configured
not ready: fix the [FAIL] items above

$ copperhead doctor          (after installing KiCad 10.0.5, before the PATH fix)
  [FAIL] kicad-cli not found on PATH

$ copperhead doctor          (after adding KiCad's bin to PATH, in a NEW terminal)
  [ok]   kicad-cli 10.0.5
  [FAIL] provider  no model configured

$ copperhead doctor          (after setting the model backend)
  [ok]   node      v24.16.0 (>= 20)
  [ok]   kicad-cli 10.0.5
  [ok]   git       2.54.0.windows.1
  [info] provider  claude-code -> claude-code: uses Claude Code login
ready
```

The create pipeline was then driven from a brief to confirm the setup path actually leads somewhere:

```text
$ copperhead create --brief brief.md
stage spec-seed:      done, committed 4be39c8cba, 4m05s
stage architecture:   done, committed a5a40006f8, 2m39s
stage part-selection: provider error (Connection closed mid-response)
                      diagnosis -> retry, attempt 2/3 succeeded
                      done, committed fccc06ebac, 10m04s
stage schematic:      running
```

Worth noting from that run: the transient provider error recovered without intervention, exactly as designed, and the failed attempt preserved its work as a named git stash entry before rolling back.

Eight failures the walkthrough exposed, all now covered in the guide:

| Failure | Fix in the guide |
| --- | --- |
| Page began after copperhead was installed, so a reader starting from nothing had no entry point | Full Install section added |
| KiCad's download page asks for a platform and then a mirror, with no guidance | "any mirror works, take the nearest" |
| KiCad's Windows installer does not touch PATH, and `kicad-cli not found` reads as "not installed" when it is installed | PowerShell PATH fix, macOS bundle path, and a locator command |
| A PATH change never reaches an already open terminal, so `doctor` keeps failing after a correct fix | "open a new terminal" called out at the fix and in the troubleshooting table |
| A wrapped token paste puts a space mid-value and returns a 401 that reads as revoked | Dedicated warning, a length check, and quoted assignment |
| `set` and `export` do not outlive the terminal window | Noted, with `setx` and shell profiles |
| `git init` alone does not satisfy the clean-tree gate, the first commit must exist | Stated explicitly, with the `--allow-dirty` escape |
| Commands were bash-only while the reader was on Windows `cmd` | Note at the top, plus both variants where they differ |

Two further additions came out of the same run: a troubleshooting row for the transient `Connection closed mid-response` (the pipeline recovers unaided, but the output reads as a failure), and a "Starting a new board" section, since the page assumed an existing board and left `create` users without a path.

A later pass caught three more, each one something the reader had to ask for out loud rather than read off the page:

| Failure | Fix in the guide |
| --- | --- |
| The KiCad download page asks for a platform and then a mirror, and the guide only said "take the nearest" | Direct download links for the current stable release, per platform |
| No sense of how long the KiCad step takes, so it reads as a quick click | Stated as roughly 1 GB, with a suggestion to start it before reading on |
| The token length check was PowerShell-only, while the reader was in `cmd`, so the one verification step for the most misleading error on the page did not run | `cmd` and bash equivalents added alongside it |

## Docs

- [first-run.md](https://github.com/Chirag6722/copperhead/blob/docs/onboarding-guide/docs/src/content/docs/getting-started/first-run.md): new, sidebar order 3.
- [i-gave-an-ai-agent-my-kicad-repo.md](https://github.com/Chirag6722/copperhead/blob/docs/onboarding-guide/docs/blog/i-gave-an-ai-agent-my-kicad-repo.md): new. Narrative post structured around four refusals (ambiguous credentials, refusing to overwrite hand-edited docs, reverting an edit that would corrupt a KiCad file, refusing to hand-edit an engine-drafted sheet). Not wired into Astro, since Starlight only reads `src/content/docs`. Staged here for the site repo to pick up.
- [README.md](https://github.com/Chirag6722/copperhead/blob/docs/onboarding-guide/README.md): `doctor` added as the first line of Quick start, the two blockers it most often catches, the green-check caveat, and git added to Requirements (it was missing entirely, despite gating every run).
- Sidebar renumbering to make room at order 3: [agent-install.md](https://github.com/Chirag6722/copperhead/blob/docs/onboarding-guide/docs/src/content/docs/getting-started/agent-install.md) 3 to 4, [demo.md](https://github.com/Chirag6722/copperhead/blob/docs/onboarding-guide/docs/src/content/docs/getting-started/demo.md) 4 to 5, plus a link from [quickstart.mdx](https://github.com/Chirag6722/copperhead/blob/docs/onboarding-guide/docs/src/content/docs/getting-started/quickstart.mdx).

Quickstart is deliberately left as it is. It works as a fast path for someone who already knows the tool, and this page is the slow path for someone who does not.

---

## Invariant checklist

Docs-only change. No source file, tool schema, provider, or KiCad code path is touched, so every runtime invariant is N/A and none can regress.

- [ ] N/A **Spec-gated in**
- [ ] N/A **Verification-gated out**
- [ ] N/A **`check`/`verify` stays LLM-free and network-free**
- [ ] N/A **No sexp serialization**
- [ ] N/A **Sync-obligations ledger**
- [x] **Secrets**: no credential appears in the added prose. The token setup steps deliberately show placeholders only, and the guide tells the reader not to paste a real token anywhere.
- [ ] N/A **Spec coherence**: no spec-level behavior changes. The guide documents behavior that already exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive first-run guide covering installation, setup, diagnostics, configuration, validation, troubleshooting, rollback, and safety guidance.
  * Expanded the README with Git requirements, snapshot and rollback details, credential checks, PATH troubleshooting, and initialization behavior.
  * Added a detailed blog post documenting an end-to-end KiCad repository trial, including validation, recoverability, limitations, and refusal scenarios.
  * Linked the first-run guide from Quickstart and updated documentation navigation order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->