### PR TITLE
fix(create): enforce constraint registry in spec-seed completion

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -99,9 +99,13 @@ export const STAGES: Stage[] = [
       const realLines = cleanSection.split('\n').filter((l) => l.trim().length > 0);
       const registry = await loadConstraints(root);
       if (Object.keys(registry).length === 0) return false;
+      const budgetKeys = new Set(
+        [...cleanSection.matchAll(/^\s*(?:[-*]\s*)?([A-Za-z][A-Za-z0-9_-]*)\s*:/gm)]
+          .map((m) => m[1]),
+      );
       for (const key of Object.keys(registry)) {
         const shortKey = key.split('.').pop()!;
-        if (!cleanSection.includes(shortKey)) return false;
+        if (!budgetKeys.has(shortKey)) return false;
       }
       return realLines.length > 0;
     },

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { loadConstraints } from '../memory/constraints.js';
 import { existsSync } from 'node:fs';
 import { readFile, mkdir, writeFile, readdir } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
@@ -96,6 +97,12 @@ export const STAGES: Stage[] = [
       const section = nextSection >= 0 ? afterHeadingLine.slice(0, nextSection) : afterHeadingLine;
       const cleanSection = section.replace(/<!--[\s\S]*?-->/g, '');
       const realLines = cleanSection.split('\n').filter((l) => l.trim().length > 0);
+      const registry = await loadConstraints(root);
+      if (Object.keys(registry).length === 0) return false;
+      for (const key of Object.keys(registry)) {
+        const shortKey = key.split('.').pop()!;
+        if (!cleanSection.includes(shortKey)) return false;
+      }
       return realLines.length > 0;
     },
     prompt: (brief) =>

--- a/test/create-resilience.test.ts
+++ b/test/create-resilience.test.ts
@@ -54,9 +54,32 @@ function ok(): RunResult {
 async function writeStageDoc(repoRoot: string, request: string): Promise<void> {
   const docs = path.join(repoRoot, 'docs');
   await mkdir(docs, { recursive: true });
-  if (request.includes('spec-seed'))
-    await writeFile(path.join(docs, 'SPEC.md'), '# s\n\n## Budgets\n\n- sleep_current_uA: 25\n', 'utf8');
-  else if (request.includes('architecture'))
+  if (request.includes('spec-seed')) {
+    await writeFile(
+      path.join(docs, 'SPEC.md'),
+      '# s\n\n## Budgets\n\n- sleep_current_uA: 25\n',
+      'utf8',
+    );
+
+    const copperhead = path.join(repoRoot, '.copperhead');
+    await mkdir(copperhead, { recursive: true });
+
+    await writeFile(
+      path.join(copperhead, 'constraints.json'),
+      JSON.stringify(
+        {
+          sleep_current_uA: {
+            max: 25,
+            source: 'docs/SPEC.md',
+            affects: [],
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+      'utf8',
+    );
+  } else if (request.includes('architecture'))
     await writeFile(path.join(docs, 'SUBSYSTEMS.md'), '# s\n\n## Power\n\nLDO regulator.\n', 'utf8');
   else if (request.includes('part-selection'))
     await writeFile(
@@ -152,7 +175,27 @@ describe('create pipeline resilience (review F3)', () => {
       // (managed paths) — the resume-after-hard-kill situation.
       const docs = path.join(repo, 'docs');
       await mkdir(docs, { recursive: true });
-      await writeFile(path.join(docs, 'SPEC.md'), '# s\n\n## Budgets\n\n- sleep_current_uA: 25\n', 'utf8');
+      await writeFile(
+        path.join(docs, 'SPEC.md'),
+        '# s\n\n## Budgets\n\n- sleep_current_uA: 25\n',
+        'utf8',
+      );
+      await mkdir(path.join(repo, '.copperhead'), { recursive: true });
+      await writeFile(
+        path.join(repo, '.copperhead', 'constraints.json'),
+        JSON.stringify(
+          {
+            sleep_current_uA: {
+              max: 25,
+              source: 'docs/SPEC.md',
+              affects: [],
+            },
+          },
+          null,
+          2,
+        ) + '\n',
+        'utf8',
+      );
       await writeFile(path.join(docs, 'SUBSYSTEMS.md'), '# s\n\n## Power\n\nLDO regulator.\n', 'utf8');
       await writeFile(
         path.join(docs, 'BOM.md'),
@@ -182,7 +225,27 @@ describe('create pipeline resilience (review F3)', () => {
 
       const docs = path.join(repo, 'docs');
       await mkdir(docs, { recursive: true });
-      await writeFile(path.join(docs, 'SPEC.md'), '# s\n\n## Budgets\n\n- sleep_current_uA: 25\n', 'utf8');
+      await writeFile(
+        path.join(docs, 'SPEC.md'),
+        '# s\n\n## Budgets\n\n- sleep_current_uA: 25\n',
+        'utf8',
+      );
+      await mkdir(path.join(repo, '.copperhead'), { recursive: true });
+      await writeFile(
+        path.join(repo, '.copperhead', 'constraints.json'),
+        JSON.stringify(
+          {
+            sleep_current_uA: {
+              max: 25,
+              source: 'docs/SPEC.md',
+              affects: [],
+            },
+          },
+          null,
+          2,
+        ) + '\n',
+        'utf8',
+      );
       // A user's own uncommitted file, unrelated to copperhead's managed paths.
       await writeFile(path.join(repo, 'my-notes.txt'), 'do not touch\n', 'utf8');
 

--- a/test/create-stage-turns.test.ts
+++ b/test/create-stage-turns.test.ts
@@ -12,12 +12,32 @@ const mockRunAgentLoop = vi.hoisted(() =>
     const { default: pathMod } = await import('node:path');
     const docs = pathMod.join(opts.repoRoot, 'docs');
     await mkdirFs(docs, { recursive: true });
-    if (opts.request.includes('spec-seed'))
+    if (opts.request.includes('spec-seed')) {
       await writeFileFs(
         pathMod.join(docs, 'SPEC.md'),
         '# spec\n\n## Budgets\n\n- sleep_current_uA: 25\n',
         'utf8',
       );
+
+      const copperhead = pathMod.join(opts.repoRoot, '.copperhead');
+      await mkdirFs(copperhead, { recursive: true });
+
+      await writeFileFs(
+        pathMod.join(copperhead, 'constraints.json'),
+        JSON.stringify(
+          {
+            sleep_current_uA: {
+              max: 25,
+              source: 'docs/SPEC.md',
+              affects: [],
+            },
+          },
+          null,
+          2,
+        ) + '\n',
+        'utf8',
+      );
+    }
     if (opts.request.includes('architecture'))
       await writeFileFs(
         pathMod.join(docs, 'SUBSYSTEMS.md'),

--- a/test/stage-completion.test.ts
+++ b/test/stage-completion.test.ts
@@ -101,6 +101,27 @@ describe('spec-seed isComplete', () => {
         `# My Project\n\n## Budgets\n\n- sleep_current_uA: 25\n- peak_current_mA: 500\n\n## Assumptions\n\n- USB-C assumed ASSUMED\n`,
         'utf8',
       );
+      await mkdir(path.join(root, '.copperhead'), { recursive: true });
+      await writeFile(
+        path.join(root, '.copperhead', 'constraints.json'),
+        JSON.stringify(
+          {
+            'power.sleep_current_uA': {
+              max: 25,
+              source: 'docs/SPEC.md',
+              affects: [],
+            },
+            'power.peak_current_mA': {
+              max: 500,
+              source: 'docs/SPEC.md',
+              affects: [],
+            },
+          },
+          null,
+          2,
+        ) + '\n',
+        'utf8',
+      );
       expect(await stageNamed('spec-seed')(root, DOCS)).toBe(true);
     });
   });

--- a/test/stage-completion.test.ts
+++ b/test/stage-completion.test.ts
@@ -125,6 +125,44 @@ describe('spec-seed isComplete', () => {
       expect(await stageNamed('spec-seed')(root, DOCS)).toBe(true);
     });
   });
+
+  it('returns false when a registry key is only a substring of a documented budget', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, DOCS), { recursive: true });
+
+      await writeFile(
+        path.join(root, DOCS, 'SPEC.md'),
+        `# My Project
+
+## Budgets
+
+- sleep_current_uA: 25
+
+## Assumptions
+`,
+        'utf8',
+      );
+
+      await mkdir(path.join(root, '.copperhead'), { recursive: true });
+      await writeFile(
+        path.join(root, '.copperhead', 'constraints.json'),
+        JSON.stringify(
+          {
+            'power.current_uA': {
+              max: 25,
+              source: 'docs/SPEC.md',
+              affects: [],
+            },
+          },
+          null,
+          2,
+        ) + '\n',
+        'utf8',
+      );
+
+      expect(await stageNamed('spec-seed')(root, DOCS)).toBe(false);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Strengthen the `spec-seed` completion contract by enforcing the machine-readable constraint registry alongside `SPEC.md`.

## Why

The previous completion check only verified that `SPEC.md` contained a non-empty Budgets section. A stage could complete even if the constraint registry was missing or had drifted from the documented budgets, leaving the artifact that later stages actually consume unchecked.

Part of #166.

## Design

The `spec-seed` completion check now requires:

- `.copperhead/constraints.json` to exist and be non-empty.
- Every registry key to be traceable to a budget entry in `SPEC.md` (using the existing short-key convention already used elsewhere in the codebase).

The completion gate now validates both the human-readable specification and the machine-readable registry together.

## Spec / OpenSpec

N/A. This changes completion validation only and does not modify OpenSpec behavior or active change artifacts.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | Pass |
| Build | `npm run build` | Pass |
| Unit + offline | `npm test` | Pass |
| Live-LLM (opt-in) | keyed on `<ENV_VAR>` | N/A |

Updated tests:
- `test/create-stage-turns.test.ts`
- `test/create-resilience.test.ts`
- `test/stage-completion.test.ts`

### Manual test log (required)

- Sandbox variant used: n/a
- Commands run and outcome:

```text
n/a (completion contract and unit test changes only)
```

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A (does not change tool gating).
- [ ] **Verification-gated out**: N/A (does not change ERC/DRC or repair flow).
- [x] **`check`/`verify` stays LLM-free and network-free**: completion validation remains local and uses only the constraint registry.
- [x] **No sexp serialization**: unchanged.
- [x] **Sync-obligations ledger**: unchanged.
- [x] **Secrets**: unchanged.
- [ ] **Spec coherence**: N/A (does not modify OpenSpec specs or change artifacts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Spec-seed completion now verifies that every registered budget constraint is documented in the specification.
  * Completion is blocked when no constraints are registered or when a documented budget only partially matches a registered constraint name.
  * Existing specification structure and content checks remain enforced.

* **Tests**
  * Added coverage for valid constraint documentation, missing constraints, partial-name matches, and resume scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->