### PR TITLE
fix(create): harden spec-seed completion parsing

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -86,18 +86,24 @@ export const STAGES: Stage[] = [
       const p = path.join(root, docs, 'SPEC.md');
       if (!existsSync(p)) return false;
       const text = await readFile(p, 'utf8');
-      const budgetsHeading = /^#{1,6}\s+(?:\d+\.\s*)?Budgets?\s*$/im;
-      if (!budgetsHeading.test(text)) return false;
 
-      // Find the Budgets section and strip HTML comments (single or multi-line)
-      const afterBudgets = text.split(budgetsHeading)[1] ?? '';
+      // Ignore commented-out headings.
+      const searchableText = text.replace(/<!--[\s\S]*?-->/g, '');
+
+      const budgetsHeading = /^##\s+(?:\d+\.\s*)?Budgets?\s*$/im;
+
+      const match = budgetsHeading.exec(searchableText);
+      if (!match) return false;
+
+      const afterBudgets = searchableText.slice(match.index + match[0].length);
       const firstNewline = afterBudgets.indexOf('\n');
       const afterHeadingLine = firstNewline >= 0 ? afterBudgets.slice(firstNewline + 1) : '';
       const nextSection = afterHeadingLine.search(/^##\s/m);
       const section = nextSection >= 0 ? afterHeadingLine.slice(0, nextSection) : afterHeadingLine;
       const cleanSection = section.replace(/<!--[\s\S]*?-->/g, '');
-      const realLines = cleanSection.split('\n').filter((l) => l.trim().length > 0);
-      return realLines.length > 0;
+      const budgetLine =
+        /^\s*(?:[-*]\s*)?[A-Za-z][A-Za-z0-9_-]*\s*:/m;
+      return budgetLine.test(cleanSection);
     },
        prompt: (brief) =>
          `Stage 1 of the create pipeline: seed the requirements. From the product brief below, populate docs/SPEC.md (what the device is, top-level constraints and budgets). If docs/SPEC.md already exists (for example after copperhead init created the scaffold), update it with edit_file instead of write_file. Use write_file only if docs/SPEC.md does not yet exist. Every budget you state must also be recorded with record_constraint. Anything the brief does not state: propose a sensible default and flag it ASSUMED. If an openspec/ workspace exists, also seed openspec/specs/ with per-capability requirements using Given/When/Then scenarios.\n\nBrief:\n${brief}`,

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -90,7 +90,7 @@ export const STAGES: Stage[] = [
       // Ignore commented-out headings.
       const searchableText = text.replace(/<!--[\s\S]*?-->/g, '');
 
-      const budgetsHeading = /^##\s+(?:\d+\.\s*)?Budgets?\s*$/im;
+      const budgetsHeading = /^##[ \t]+(?:\d+\.[ \t]*)?Budgets?[ \t]*$/im;
 
       const match = budgetsHeading.exec(searchableText);
       if (!match) return false;
@@ -101,8 +101,7 @@ export const STAGES: Stage[] = [
       const nextSection = afterHeadingLine.search(/^##\s/m);
       const section = nextSection >= 0 ? afterHeadingLine.slice(0, nextSection) : afterHeadingLine;
       const cleanSection = section.replace(/<!--[\s\S]*?-->/g, '');
-      const budgetLine =
-        /^\s*(?:[-*]\s*)?[A-Za-z][A-Za-z0-9_-]*\s*:/m;
+      const budgetLine = /^\s*(?:[-*]\s*)?[A-Za-z][A-Za-z0-9_-]*\s*:\s*\S+/m;
       return budgetLine.test(cleanSection);
     },
        prompt: (brief) =>

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -80,9 +80,8 @@ export const STAGES: Stage[] = [
     name: 'spec-seed',
     isComplete: async (root, docs) => {
       // The init scaffold writes SPEC.md with a "## Budgets" heading and an
-      // HTML comment placeholder — that alone must not count as complete.
-      // Require the heading AND at least one non-comment, non-blank line
-      // of real budget content beneath it (a filled section vs. an empty placeholder).
+      // HTML comment placeholder. Treat the stage as complete only when the
+      // ## Budgets section contains at least one "- name: value" budget entry.
       const p = path.join(root, docs, 'SPEC.md');
       if (!existsSync(p)) return false;
       const text = await readFile(p, 'utf8');
@@ -98,14 +97,14 @@ export const STAGES: Stage[] = [
       const afterBudgets = searchableText.slice(match.index + match[0].length);
       const firstNewline = afterBudgets.indexOf('\n');
       const afterHeadingLine = firstNewline >= 0 ? afterBudgets.slice(firstNewline + 1) : '';
-      const nextSection = afterHeadingLine.search(/^##\s/m);
+      const nextSection = afterHeadingLine.search(/^#{1,2}\s/m);
       const section = nextSection >= 0 ? afterHeadingLine.slice(0, nextSection) : afterHeadingLine;
-      const cleanSection = section.replace(/<!--[\s\S]*?-->/g, '');
-      const budgetLine = /^\s*(?:[-*]\s*)?[A-Za-z][A-Za-z0-9_-]*\s*:\s*\S+/m;
+      const cleanSection = section;
+     const budgetLine = /^\s*(?:(?:[-*]|\d+\.)\s*)?[A-Za-z][A-Za-z0-9_-]*\s*:\s*\S+/m;
       return budgetLine.test(cleanSection);
     },
        prompt: (brief) =>
-         `Stage 1 of the create pipeline: seed the requirements. From the product brief below, populate docs/SPEC.md (what the device is, top-level constraints and budgets). If docs/SPEC.md already exists (for example after copperhead init created the scaffold), update it with edit_file instead of write_file. Use write_file only if docs/SPEC.md does not yet exist. Every budget you state must also be recorded with record_constraint. Anything the brief does not state: propose a sensible default and flag it ASSUMED. If an openspec/ workspace exists, also seed openspec/specs/ with per-capability requirements using Given/When/Then scenarios.\n\nBrief:\n${brief}`,
+         `Stage 1 of the create pipeline: seed the requirements. From the product brief below, populate docs/SPEC.md (what the device is, top-level constraints and budgets). List each budget under the ## Budgets heading as a plain "- name: value" line. If docs/SPEC.md already exists (for example after copperhead init created the scaffold), update it with edit_file instead of write_file. Use write_file only if docs/SPEC.md does not yet exist. Every budget you state must also be recorded with record_constraint. Anything the brief does not state: propose a sensible default and flag it ASSUMED. If an openspec/ workspace exists, also seed openspec/specs/ with per-capability requirements using Given/When/Then scenarios.\n\nBrief:\n${brief}`,
   },
   {
     name: 'architecture',

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -100,11 +100,11 @@ export const STAGES: Stage[] = [
       const nextSection = afterHeadingLine.search(/^#{1,2}\s/m);
       const section = nextSection >= 0 ? afterHeadingLine.slice(0, nextSection) : afterHeadingLine;
       const cleanSection = section;
-     const budgetLine = /^\s*(?:(?:[-*]|\d+\.)\s*)?[A-Za-z][A-Za-z0-9_-]*\s*:\s*\S+/m;
+      const budgetLine = /^\s*(?:(?:[-*]|\d+\.)\s*)?[A-Za-z][A-Za-z0-9_-]*\s*:\s*\S+/m;
       return budgetLine.test(cleanSection);
     },
        prompt: (brief) =>
-         `Stage 1 of the create pipeline: seed the requirements. From the product brief below, populate docs/SPEC.md (what the device is, top-level constraints and budgets). List each budget under the ## Budgets heading as a plain "- name: value" line. If docs/SPEC.md already exists (for example after copperhead init created the scaffold), update it with edit_file instead of write_file. Use write_file only if docs/SPEC.md does not yet exist. Every budget you state must also be recorded with record_constraint. Anything the brief does not state: propose a sensible default and flag it ASSUMED. If an openspec/ workspace exists, also seed openspec/specs/ with per-capability requirements using Given/When/Then scenarios.\n\nBrief:\n${brief}`,
+        `Stage 1 of the create pipeline: seed the requirements. From the product brief below, populate docs/SPEC.md (what the device is, top-level constraints and budgets). List each budget under the ## Budgets heading as a plain "- name: value" line. If docs/SPEC.md already exists (for example after copperhead init created the scaffold), update it with edit_file instead of write_file. Use write_file only if docs/SPEC.md does not yet exist. Every budget you state must also be recorded with record_constraint. Anything the brief does not state: propose a sensible default and flag it ASSUMED. If an openspec/ workspace exists, also seed openspec/specs/ with per-capability requirements using Given/When/Then scenarios.\n\nBrief:\n${brief}`,
   },
   {
     name: 'architecture',

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -86,20 +86,21 @@ export const STAGES: Stage[] = [
       const p = path.join(root, docs, 'SPEC.md');
       if (!existsSync(p)) return false;
       const text = await readFile(p, 'utf8');
-      const budgetsMatch = /^#{1,6}\s.*\bBudgets?\b/im.test(text);
-      if (!budgetsMatch) return false;
+      const budgetsHeading = /^#{1,6}\s+(?:\d+\.\s*)?Budgets?\s*$/im;
+      if (!budgetsHeading.test(text)) return false;
+
       // Find the Budgets section and strip HTML comments (single or multi-line)
-      const afterBudgets = text.split(/^#{1,6}\s.*\bBudgets?\b/im)[1] ?? '';
+      const afterBudgets = text.split(budgetsHeading)[1] ?? '';
       const firstNewline = afterBudgets.indexOf('\n');
       const afterHeadingLine = firstNewline >= 0 ? afterBudgets.slice(firstNewline + 1) : '';
-      const nextSection = afterHeadingLine.search(/^#{1,6}\s/m);
+      const nextSection = afterHeadingLine.search(/^##\s/m);
       const section = nextSection >= 0 ? afterHeadingLine.slice(0, nextSection) : afterHeadingLine;
       const cleanSection = section.replace(/<!--[\s\S]*?-->/g, '');
       const realLines = cleanSection.split('\n').filter((l) => l.trim().length > 0);
       return realLines.length > 0;
     },
-    prompt: (brief) =>
-      `Stage 1 of the create pipeline: seed the requirements. From the product brief below, write docs/SPEC.md (what the device is, top-level constraints and budgets). Every budget you state must also be recorded with record_constraint. Anything the brief does not state: propose a sensible default and flag it ASSUMED. If an openspec/ workspace exists, also seed openspec/specs/ with per-capability requirements using Given/When/Then scenarios.\n\nBrief:\n${brief}`,
+       prompt: (brief) =>
+         `Stage 1 of the create pipeline: seed the requirements. From the product brief below, populate docs/SPEC.md (what the device is, top-level constraints and budgets). If docs/SPEC.md already exists (for example after copperhead init created the scaffold), update it with edit_file instead of write_file. Use write_file only if docs/SPEC.md does not yet exist. Every budget you state must also be recorded with record_constraint. Anything the brief does not state: propose a sensible default and flag it ASSUMED. If an openspec/ workspace exists, also seed openspec/specs/ with per-capability requirements using Given/When/Then scenarios.\n\nBrief:\n${brief}`,
   },
   {
     name: 'architecture',

--- a/test/stage-completion.test.ts
+++ b/test/stage-completion.test.ts
@@ -110,8 +110,8 @@ describe('spec-seed isComplete', () => {
       await mkdir(path.join(root, DOCS), { recursive: true });
 
       await writeFile(
-    path.join(root, DOCS, 'SPEC.md'),
-    `# My Project
+        path.join(root, DOCS, 'SPEC.md'),
+        `# My Project
 
 ## Budgets
 

--- a/test/stage-completion.test.ts
+++ b/test/stage-completion.test.ts
@@ -156,6 +156,77 @@ describe('spec-seed isComplete', () => {
       expect(await stageNamed('spec-seed')(root, DOCS)).toBe(false);
     });
   });
+
+  it('returns false when SPEC.md Budgets section contains prose but no budget entries', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, DOCS), { recursive: true });
+
+      await writeFile(
+        path.join(root, DOCS, 'SPEC.md'),
+        `# My Project
+
+## Budgets
+
+TBD
+
+## Assumptions
+
+- USB-C assumed ASSUMED
+`,
+        'utf8',
+      );
+
+      expect(await stageNamed('spec-seed')(root, DOCS)).toBe(false);
+    });
+  });
+
+  it('returns false when Budgets heading exists only inside an HTML comment', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, DOCS), { recursive: true });
+
+      await writeFile(
+        path.join(root, DOCS, 'SPEC.md'),
+        `# My Project
+
+<!--
+## Budgets
+
+- sleep_current_uA: 25
+-->
+
+## Assumptions
+
+- USB-C assumed ASSUMED
+`,
+        'utf8',
+      );
+
+      expect(await stageNamed('spec-seed')(root, DOCS)).toBe(false);
+    });
+  });
+
+  it('returns true when a nested heading is named Budget', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, DOCS), { recursive: true });
+
+      await writeFile(
+        path.join(root, DOCS, 'SPEC.md'),
+        `# My Project
+
+## Budgets
+
+### Budget
+
+- sleep_current_uA: 25
+
+## Assumptions
+`,
+        'utf8',
+      );
+
+      expect(await stageNamed('spec-seed')(root, DOCS)).toBe(true);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/stage-completion.test.ts
+++ b/test/stage-completion.test.ts
@@ -227,6 +227,47 @@ TBD
       expect(await stageNamed('spec-seed')(root, DOCS)).toBe(true);
     });
   });
+
+  it('returns false when the Budgets heading is split across lines', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, DOCS), { recursive: true });
+
+      await writeFile(
+        path.join(root, DOCS, 'SPEC.md'),
+        `# My Project
+
+##
+Budgets
+
+- sleep_current_uA: 25
+`,
+        'utf8',
+      );
+
+      expect(await stageNamed('spec-seed')(root, DOCS)).toBe(false);
+    });
+  });
+
+  it('returns false when a budget entry has no value', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, DOCS), { recursive: true });
+
+      await writeFile(
+        path.join(root, DOCS, 'SPEC.md'),
+        `# My Project
+
+## Budgets
+
+- current_mA:
+
+## Assumptions
+`,
+        'utf8',
+      );
+
+      expect(await stageNamed('spec-seed')(root, DOCS)).toBe(false);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/stage-completion.test.ts
+++ b/test/stage-completion.test.ts
@@ -104,6 +104,58 @@ describe('spec-seed isComplete', () => {
       expect(await stageNamed('spec-seed')(root, DOCS)).toBe(true);
     });
   });
+
+  it('returns true when SPEC.md Budgets section contains nested headings', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, DOCS), { recursive: true });
+
+      await writeFile(
+    path.join(root, DOCS, 'SPEC.md'),
+    `# My Project
+
+## Budgets
+
+### Sleep
+
+- sleep_current_uA: 25
+
+### Peak current
+
+- peak_current_mA: 500
+
+## Assumptions
+
+- USB-C assumed ASSUMED
+  `,
+    'utf8',
+  );
+
+      expect(await stageNamed('spec-seed')(root, DOCS)).toBe(true);
+    });
+  });
+
+  it('returns false when a non-Budgets heading contains the word budget', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, DOCS), { recursive: true });
+
+      await writeFile(
+        path.join(root, DOCS, 'SPEC.md'),
+        `# My Project
+
+## Cost budget notes
+
+- This is explanatory text only.
+
+## Assumptions
+
+- USB-C assumed ASSUMED
+  `,
+        'utf8',
+      );
+
+      expect(await stageNamed('spec-seed')(root, DOCS)).toBe(false);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/stage-completion.test.ts
+++ b/test/stage-completion.test.ts
@@ -268,6 +268,50 @@ Budgets
       expect(await stageNamed('spec-seed')(root, DOCS)).toBe(false);
     });
   });
+
+  it('returns false when an H1 section follows a placeholder Budgets section', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, DOCS), { recursive: true });
+
+      await writeFile(
+        path.join(root, DOCS, 'SPEC.md'),
+        `# My Project
+
+## Budgets
+
+<!-- placeholder -->
+
+# Appendix
+
+Note: draft only.
+`,
+        'utf8',
+      );
+
+      expect(await stageNamed('spec-seed')(root, DOCS)).toBe(false);
+    });
+  });
+
+  it('returns true when Budgets contains a plain key-value budget entry', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, DOCS), { recursive: true });
+
+      await writeFile(
+        path.join(root, DOCS, 'SPEC.md'),
+        `# My Project
+
+## Budgets
+
+sleep_current_uA: 25
+
+## Assumptions
+`,
+        'utf8',
+      );
+
+      expect(await stageNamed('spec-seed')(root, DOCS)).toBe(true);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Harden the `spec-seed` stage by making completion detection more accurate and clarifying how the agent should update `docs/SPEC.md` when the init scaffold already exists.

## Why

The completion check could incorrectly accept headings that merely contained the word "budget" and could reject valid Budgets sections that used nested headings. The stage prompt also instructed the agent to write `docs/SPEC.md`, even though `copperhead init` already creates the file and `write_file` refuses to overwrite it.

Part of #166.

## Design

The `spec-seed` completion parser now:

- Matches only the actual `Budgets` heading (including numbered forms such as `## 3. Budgets`).
- Allows nested headings within the Budgets section while continuing to stop at the next top-level section.
- Preserves the existing requirement that the section contain real (non-comment) content.

The stage prompt now tells the agent to update an existing scaffolded `docs/SPEC.md` with `edit_file` and to use `write_file` only when the file does not yet exist.

## Spec / OpenSpec

N/A. This change hardens stage completion parsing and prompt guidance only. It does not modify SPEC.md or any OpenSpec change artifacts.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | Pass |
| Build | `npm run build` | Pass |
| Unit + offline | `npx vitest run test/stage-completion.test.ts` | Pass |
| Live-LLM (opt-in) | keyed on `<ENV_VAR>` | N/A |

Added regression tests:

- Nested headings inside the `Budgets` section are accepted.
- Headings that merely contain the word "budget" do not satisfy the completion contract.

### Manual test log (required)

- Sandbox variant used: n/a
- Commands run and outcome:

```text
n/a (parser and prompt changes only)
```

## Docs

Updated the stage prompt in `src/commands/create.ts` to document the correct edit path for scaffolded repositories.

---

## Invariant checklist

- [x] **Spec-gated in**: unchanged.
- [x] **Verification-gated out**: unchanged.
- [x] **`check`/`verify` stays LLM-free and network-free**: unchanged.
- [x] **No sexp serialization**: unchanged.
- [x] **Sync-obligations ledger**: unchanged.
- [x] **Secrets**: unchanged.
- [ ] **Spec coherence**: N/A (does not modify OpenSpec behavior or change artifacts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion checks for the Budgets section in `SPEC.md` files.
  * Budget sections now require an exact level-2 heading and a valid key/value entry.
  * Commented content, unrelated headings, split headings, and entries without values are no longer accepted.
  * Updated guidance to edit existing specification files and create new ones only when needed.

* **Tests**
  * Added coverage for valid and invalid budget section formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->