### PR TITLE
fix(agent): remove unreachable constraint-dual-write obligation

### DIFF
--- a/src/agent/ledger.ts
+++ b/src/agent/ledger.ts
@@ -9,7 +9,6 @@ export type ObligationKind =
   | 'drift'
   | 'changelog'
   | 'decision-log'
-  | 'constraint-dual-write'
   | 'affects-revisit';
 
 export interface Obligation {
@@ -54,7 +53,6 @@ export class ObligationsLedger {
   }
 
   onConstraintChange(constraintKey: string, affects: string[]): void {
-    this.add('constraint-dual-write', constraintKey, constraintKey);
     for (const item of affects) {
       this.add('affects-revisit', `${constraintKey} affects ${item}`, constraintKey);
     }

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -476,7 +476,6 @@ export const TOOLS: ToolDef[] = [
         ...(deferred.length ? { deferred } : {}),
       });
       ctx.ledger.onConstraintChange(key, openNow);
-      ctx.ledger.clear('constraint-dual-write', key);
       const parts = [`constraint ${key} recorded`];
       parts.push(`revisit obligations opened for: ${openNow.join(', ') || '(none)'}`);
       if (deferred.length) {


### PR DESCRIPTION
## What

Remove the unreachable `constraint-dual-write` obligation from the sync-obligations ledger.

This preserves the existing `affects-revisit` behavior while removing an obligation that was never observable by the commit gate.

## Why

Fixes #177.

`constraint-dual-write` was opened and immediately cleared within the same `record_constraint` call, making it impossible for the commit gate to observe or enforce. Since the obligation had no remaining consumers, removing it eliminates dead behavior without changing runtime semantics.

## Design

The change removes the dead `constraint-dual-write` obligation from the ledger.

- Removes the unused `constraint-dual-write` obligation kind.
- Removes the corresponding `add()` call from `onConstraintChange()`.
- Removes the immediate `clear()` call from `record_constraint()`.
- Preserves the existing `affects-revisit` behavior unchanged.

This PR intentionally does not redesign the dual-write invariant. Any future reconciliation between documentation and `.copperhead/constraints.json` can be implemented independently.

## Spec / OpenSpec

N/A.

This is an internal refactor and does not modify spec-level behavior or OpenSpec artifacts.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | Pass |
| Build | `npm run build` | Pass |
| Unit + offline | `npm test` | Pre-existing unrelated failures |
| Live-LLM (opt-in) | keyed on `<ENV_VAR>` | N/A |

No new tests were required because this change removes unreachable code and does not change observable runtime behavior.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a
- Commands run and outcome:

```text
n/a

This change removes an unreachable internal ledger obligation and does not change CLI behavior.
```

## Docs

No user-facing documentation changes.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A (no changes to proposal validation or tool gating)
- [ ] **Verification-gated out**: N/A (no changes to ERC/DRC, repair, or rollback behavior)
- [x] **`check`/`verify` stays LLM-free and network-free**: unchanged
- [x] **No sexp serialization**: unchanged
- [x] **Sync-obligations ledger**: removes an unreachable obligation while preserving existing `affects-revisit` behavior
- [x] **Secrets**: unchanged
- [ ] **Spec coherence**: N/A (no spec-level behavior changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Constraint changes now create revisit reminders for all affected items.
  * Removed outdated dual-write obligation handling when recording constraints.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->