### PR TITLE
fix(kicad): find symbols across libraries, not just the guessed file

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -354,6 +354,8 @@ export const TOOLS: ToolDef[] = [
         return 'no schematic configured; verify_symbols does not apply yet';
       const { findings, checked, skipped } = await verifySchematicSymbols(
         path.join(ctx.repoRoot, ctx.config.schematic),
+        process.env,
+        ctx.repoRoot,
       );
       if (!findings.length) {
         return `verify_symbols: ${checked} symbol(s) match the installed KiCad library. No divergences.`;

--- a/src/kicad/draft/symsource.ts
+++ b/src/kicad/draft/symsource.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { parseSexp, children, child, isList, type SexpNode, type Bounds } from '../sexp.js';
-import { symbolSearchDirs, findLibraryFile } from '../symlib.js';
+import { symbolSearchDirs, findLibraryFile, findSymbolAcrossLibraries } from '../symlib.js';
 import { EMIT_VERSION, renameSymbolBlock } from '../emit.js';
 
 /**
@@ -186,7 +186,7 @@ function appendToVendorLib(libText: string, block: string): string {
 export class SymbolResolutionError extends Error {
   constructor(
     public readonly libId: string,
-    public readonly reason: 'no-library' | 'no-symbol' | 'derived-unsupported',
+    public readonly reason: 'no-library' | 'no-symbol' | 'derived-unsupported' | 'found-elsewhere',
     public readonly candidates: string[] = [],
   ) {
     super(
@@ -194,9 +194,26 @@ export class SymbolResolutionError extends Error {
         ? `library for "${libId}" is not installed and not vendored`
         : reason === 'derived-unsupported'
           ? `"${libId}" extends a symbol that cannot be followed (missing base name, or a cycle deeper than ${MAX_EXTENDS_DEPTH} hops); use the base symbol directly`
-          : `"${libId}" does not exist in the library${candidates.length ? ` — closest: ${candidates.join(', ')}` : ''}`,
+          : reason === 'found-elsewhere'
+            ? `"${libId}" is wrong about the library, not the part: use ${candidates.join(' or ')} instead`
+            : `"${libId}" does not exist in the library${candidates.length ? ` — closest: ${candidates.join(', ')}` : ''}`,
     );
   }
+}
+
+/**
+ * A part's library file is guessed wrong more often than the part itself is
+ * misspelled (a chip's stock library nickname is not derivable from its part
+ * number). Before failing outright, check every other stock/vendored library
+ * for this exact part name; an exact hit elsewhere is a stronger signal than
+ * a same-file substring guess, so it takes priority over `candidates`.
+ * Returns corrected `lib_id`s (exact matches first) or an empty array.
+ */
+async function crossLibrarySuggestions(name: string, lib: string, dirs: string[]): Promise<string[]> {
+  const matches = await findSymbolAcrossLibraries(name, dirs, lib);
+  const exact = matches.filter((m) => m.exact).map((m) => `${m.lib}:${name}`);
+  if (exact.length) return exact;
+  return matches.map((m) => `${m.lib}:${name}`);
 }
 
 export class SymbolSource {
@@ -296,13 +313,26 @@ export class SymbolSource {
     if (!block) {
       const dirs = this.searchDirs ?? (await symbolSearchDirs());
       const file = await findLibraryFile(lib, dirs);
-      if (!file) throw new SymbolResolutionError(libId, 'no-library');
+      if (!file) {
+        const elsewhere = await crossLibrarySuggestions(name, lib, dirs);
+        if (elsewhere.length) throw new SymbolResolutionError(libId, 'found-elsewhere', elsewhere);
+        throw new SymbolResolutionError(libId, 'no-library');
+      }
       const libText = await readFile(file, 'utf8');
       block = extractSymbolBlock(libText, name);
       if (!block) {
+        // The guessed library exists and simply lacks this name, so its own
+        // near-matches are the most useful answer and come first: the caller
+        // named the right file and mistyped the part. Only when that file
+        // offers nothing is a different library worth suggesting — and only
+        // an exact hit there, since a cross-library *fuzzy* guess is weaker
+        // evidence than "you were close, in the right file".
         const names = [...libText.matchAll(/^\s*\(symbol\s+"([^"]+)"/gm)].map((m) => m[1]!);
         const q = name.toLowerCase();
         const candidates = names.filter((k) => k.toLowerCase().includes(q) || q.includes(k.toLowerCase())).slice(0, 8);
+        if (candidates.length) throw new SymbolResolutionError(libId, 'no-symbol', candidates);
+        const elsewhere = await crossLibrarySuggestions(name, lib, dirs);
+        if (elsewhere.length) throw new SymbolResolutionError(libId, 'found-elsewhere', elsewhere);
         throw new SymbolResolutionError(libId, 'no-symbol', candidates);
       }
       fromInstalled = true;

--- a/src/kicad/draft/symsource.ts
+++ b/src/kicad/draft/symsource.ts
@@ -211,9 +211,9 @@ export class SymbolResolutionError extends Error {
  */
 async function crossLibrarySuggestions(name: string, lib: string, dirs: string[]): Promise<string[]> {
   const matches = await findSymbolAcrossLibraries(name, dirs, lib);
-  const exact = matches.filter((m) => m.exact).map((m) => `${m.lib}:${name}`);
+  const exact = matches.filter((m) => m.exact).map((m) => `${m.lib}:${m.name}`);
   if (exact.length) return exact;
-  return matches.map((m) => `${m.lib}:${name}`);
+  return matches.map((m) => `${m.lib}:${m.name}`);
 }
 
 export class SymbolSource {

--- a/src/kicad/draft/symsource.ts
+++ b/src/kicad/draft/symsource.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { parseSexp, children, child, isList, type SexpNode, type Bounds } from '../sexp.js';
-import { symbolSearchDirs, findLibraryFile, findSymbolAcrossLibraries } from '../symlib.js';
+import { symbolSearchDirs, findLibraryFile, findSymbolAcrossLibraries, crossLibraryIds } from '../symlib.js';
 import { EMIT_VERSION, renameSymbolBlock } from '../emit.js';
 
 /**
@@ -201,21 +201,6 @@ export class SymbolResolutionError extends Error {
   }
 }
 
-/**
- * A part's library file is guessed wrong more often than the part itself is
- * misspelled (a chip's stock library nickname is not derivable from its part
- * number). Before failing outright, check every other stock/vendored library
- * for this exact part name; an exact hit elsewhere is a stronger signal than
- * a same-file substring guess, so it takes priority over `candidates`.
- * Returns corrected `lib_id`s (exact matches first) or an empty array.
- */
-async function crossLibrarySuggestions(name: string, lib: string, dirs: string[]): Promise<string[]> {
-  const matches = await findSymbolAcrossLibraries(name, dirs, lib);
-  const exact = matches.filter((m) => m.exact).map((m) => `${m.lib}:${m.name}`);
-  if (exact.length) return exact;
-  return matches.map((m) => `${m.lib}:${m.name}`);
-}
-
 export class SymbolSource {
   private cache = new Map<string, ResolvedSymbol>();
 
@@ -314,25 +299,30 @@ export class SymbolSource {
       const dirs = this.searchDirs ?? (await symbolSearchDirs());
       const file = await findLibraryFile(lib, dirs);
       if (!file) {
-        const elsewhere = await crossLibrarySuggestions(name, lib, dirs);
-        if (elsewhere.length) throw new SymbolResolutionError(libId, 'found-elsewhere', elsewhere);
+        const elsewhere = await findSymbolAcrossLibraries(name, dirs, lib);
+        const exactElsewhere = elsewhere.filter((m) => m.exact);
+        if (exactElsewhere.length) throw new SymbolResolutionError(libId, 'found-elsewhere', crossLibraryIds(exactElsewhere));
+        if (elsewhere.length) throw new SymbolResolutionError(libId, 'found-elsewhere', crossLibraryIds(elsewhere));
         throw new SymbolResolutionError(libId, 'no-library');
       }
       const libText = await readFile(file, 'utf8');
       block = extractSymbolBlock(libText, name);
       if (!block) {
-        // The guessed library exists and simply lacks this name, so its own
-        // near-matches are the most useful answer and come first: the caller
-        // named the right file and mistyped the part. Only when that file
-        // offers nothing is a different library worth suggesting — and only
-        // an exact hit there, since a cross-library *fuzzy* guess is weaker
-        // evidence than "you were close, in the right file".
+        // Evidence, strongest first: an exact match in a different library is
+        // unambiguous, so it outranks even a same-file substring guess — the
+        // guessed library is often full of single-letter generics ("R", "C",
+        // "L") that trivially substring-match almost any query, and would
+        // otherwise silently outrank a real cross-library answer. Same-file
+        // candidates come next (the caller named the right file and mistyped
+        // the part); a cross-library fuzzy hit is last resort.
+        const elsewhere = await findSymbolAcrossLibraries(name, dirs, lib);
+        const exactElsewhere = elsewhere.filter((m) => m.exact);
+        if (exactElsewhere.length) throw new SymbolResolutionError(libId, 'found-elsewhere', crossLibraryIds(exactElsewhere));
         const names = [...libText.matchAll(/^\s*\(symbol\s+"([^"]+)"/gm)].map((m) => m[1]!);
         const q = name.toLowerCase();
         const candidates = names.filter((k) => k.toLowerCase().includes(q) || q.includes(k.toLowerCase())).slice(0, 8);
         if (candidates.length) throw new SymbolResolutionError(libId, 'no-symbol', candidates);
-        const elsewhere = await crossLibrarySuggestions(name, lib, dirs);
-        if (elsewhere.length) throw new SymbolResolutionError(libId, 'found-elsewhere', elsewhere);
+        if (elsewhere.length) throw new SymbolResolutionError(libId, 'found-elsewhere', crossLibraryIds(elsewhere));
         throw new SymbolResolutionError(libId, 'no-symbol', candidates);
       }
       fromInstalled = true;

--- a/src/kicad/symlib.ts
+++ b/src/kicad/symlib.ts
@@ -56,7 +56,9 @@ export async function symbolSearchDirs(env = process.env): Promise<string[]> {
     '/usr/share/kicad/symbols',
     '/usr/local/share/kicad/symbols',
     '/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols',
-    'C:/Program Files/KiCad/share/kicad/symbols',
+    // Windows installs under a version-numbered directory
+    // (C:\Program Files\KiCad\10.0\...), unlike Linux/macOS, so there is no
+    // single fixed path here. Discovered below instead.
   ];
   const out: string[] = [];
   for (const dir of [...fromEnv, ...defaults]) {
@@ -66,6 +68,34 @@ export async function symbolSearchDirs(env = process.env): Promise<string[]> {
     } catch {
       // not present on this machine; skip
     }
+  }
+  // Windows: KiCad's own installer picks the version directory
+  // (`10.0`, `9.0`, `8.0`, ...), so no fixed path is ever correct. List
+  // `C:\Program Files\KiCad` and check each version folder instead. Sorted
+  // descending so a machine with more than one version prefers the newest.
+  // Skipped entirely when an env override is set: "env overrides win" means
+  // exactly that, not "env overrides win, plus whatever else this discovers"
+  // — a caller pointing KICAD_SYMBOL_DIR at an isolated directory (tests, a
+  // pinned library set) must get only that directory back.
+  const kicadRoot = 'C:/Program Files/KiCad';
+  try {
+    if (fromEnv.length > 0) throw new Error('env override present; skip Windows auto-discovery');
+    const entries = await readdir(kicadRoot, { withFileTypes: true });
+    const versions = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+    for (const version of versions) {
+      const dir = `${kicadRoot}/${version}/share/kicad/symbols`;
+      try {
+        await access(dir);
+        if (!out.includes(dir)) out.push(dir);
+      } catch {
+        // this version folder has no symbols dir; skip
+      }
+    }
+  } catch {
+    // C:\Program Files\KiCad doesn't exist on this machine (not Windows, or KiCad not installed here); skip
   }
   return out;
 }
@@ -82,6 +112,127 @@ export async function findLibraryFile(lib: string, dirs: string[]): Promise<stri
     }
   }
   return null;
+}
+
+/** Every `<name>.kicad_sym` file across the search dirs, first occurrence wins per name. */
+async function allLibraryFiles(dirs: string[]): Promise<{ lib: string; file: string }[]> {
+  const seen = new Set<string>();
+  const out: { lib: string; file: string }[] = [];
+  for (const dir of dirs) {
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.endsWith('.kicad_sym')) continue;
+      const lib = entry.slice(0, -'.kicad_sym'.length);
+      if (seen.has(lib)) continue;
+      seen.add(lib);
+      out.push({ lib, file: path.join(dir, entry) });
+    }
+  }
+  return out;
+}
+
+export interface CrossLibraryMatch {
+  lib: string;
+  /** true when the part name matched exactly; false for a fuzzy hit. */
+  exact: boolean;
+}
+
+/** Levenshtein edit distance, capped: returns `cap + 1` once the true distance
+ * would exceed `cap`, so a caller doing a cheap "is this close enough" check
+ * never pays for the full O(n·m) table on two names that are obviously
+ * unrelated. */
+function editDistanceWithin(a: string, b: string, cap: number): number {
+  if (Math.abs(a.length - b.length) > cap) return cap + 1;
+  let prev = Array.from({ length: b.length + 1 }, (_, j) => j);
+  for (let i = 1; i <= a.length; i++) {
+    const cur = [i];
+    let rowMin = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      const v = Math.min(prev[j]! + 1, cur[j - 1]! + 1, prev[j - 1]! + cost);
+      cur.push(v);
+      if (v < rowMin) rowMin = v;
+    }
+    if (rowMin > cap) return cap + 1; // whole row exceeded cap: no cell can recover
+    prev = cur;
+  }
+  return prev[b.length]!;
+}
+
+/**
+ * A part is unresolvable at its guessed `lib_id`, but the guess itself is often
+ * right about the *part*, just wrong about which stock file it lives in (a
+ * chip's library nickname is not derivable from its part number). Rather than
+ * fail outright, check every other discovered `.kicad_sym` for a symbol with
+ * this exact name; when none matches exactly, fall back to the same
+ * closest-candidate substring heuristic `resolveLibrarySymbol` already uses
+ * within one file, just applied across all of them.
+ *
+ * Returns matches sorted exact-first; the caller decides what "found" means
+ * (one exact hit resolves unambiguously, several means the agent must pick).
+ */
+export async function findSymbolAcrossLibraries(
+  name: string,
+  dirs: string[],
+  excludeLib?: string,
+): Promise<CrossLibraryMatch[]> {
+  const files = await allLibraryFiles(dirs);
+  const q = name.toLowerCase();
+  const exact: CrossLibraryMatch[] = [];
+  const fuzzy: CrossLibraryMatch[] = [];
+  for (const { lib, file } of files) {
+    // `excludeLib` is only known not to hold this *exact* name; it can still
+    // hold the near-miss the caller actually wants (SHT40 guessed in
+    // Sensor_Humidity, where the real symbol is SHT4x). Skip its exact check,
+    // never its fuzzy one.
+    const skipExact = lib === excludeLib;
+    let text: string;
+    try {
+      text = await readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+    const names = [...text.matchAll(/^\s*\(symbol\s+"([^"]+)"/gm)].map((m) => m[1]!);
+    if (!skipExact && names.includes(name)) {
+      exact.push({ lib, exact: true });
+      continue;
+    }
+    // The "does the query contain the library name" direction is only
+    // meaningful for a reasonably specific name (>= 3 chars): a stock library
+    // is full of single-letter generics ("R", "C", "L", "D", "U", "Q"), and
+    // "does <any part number> contain the letter R" is true for nearly
+    // everything, which would fuzzy-match almost any query against them.
+    const MIN_SHORT_NAME_LEN = 3;
+    // Substring alone misses the most common real near-miss: a datasheet part
+    // number against a library's family name, differing mid-string rather than
+    // at either end (SHT40 vs SHT4x, where `x` stands for "any variant").
+    // Neither contains the other, so only edit distance catches it. Kept tight
+    // (1 edit, and only for names long enough that one edit is still
+    // distinctive) so TPS22860 does not silently match TPS22810 — a different
+    // real part, which is exactly the wrong-part failure this tool must not
+    // introduce.
+    const MIN_EDIT_MATCH_LEN = 5;
+    if (
+      names.some((n) => {
+        const lower = n.toLowerCase();
+        if (lower.includes(q)) return true;
+        if (lower.length >= MIN_SHORT_NAME_LEN && q.includes(lower)) return true;
+        return (
+          q.length >= MIN_EDIT_MATCH_LEN &&
+          lower.length >= MIN_EDIT_MATCH_LEN &&
+          editDistanceWithin(q, lower, 1) <= 1
+        );
+      })
+    ) {
+      fuzzy.push({ lib, exact: false });
+    }
+  }
+  return [...exact, ...fuzzy];
 }
 
 /** Collect pins (number, name, electrical type) from a `(symbol …)` node,
@@ -130,10 +281,15 @@ export async function resolveLibrarySymbol(
   | { status: 'ok'; pins: LibPin[] }
   | { status: 'no-symbol'; candidates: string[] }
   | { status: 'no-library' }
+  | { status: 'found-elsewhere'; libIds: string[] }
 > {
   const [lib, name] = libId.includes(':') ? [libId.slice(0, libId.indexOf(':')), libId.slice(libId.indexOf(':') + 1)] : ['', libId];
   const file = await findLibraryFile(lib, dirs);
-  if (!file) return { status: 'no-library' };
+  if (!file) {
+    const elsewhere = await findSymbolAcrossLibraries(name, dirs, lib);
+    if (elsewhere.length) return { status: 'found-elsewhere', libIds: elsewhere.map((m) => `${m.lib}:${name}`) };
+    return { status: 'no-library' };
+  }
   const root = parseSexp(await readFile(file, 'utf8'))[0];
   if (root === undefined || !isList(root)) return { status: 'no-library' };
   const symbols = librarySymbols(root);
@@ -152,7 +308,14 @@ export async function resolveLibrarySymbol(
     current = base;
   }
 
-  // exact name not found: offer near matches (case-insensitive substring both ways)
+  // Not in the guessed file: a genuine exact match elsewhere is a stronger
+  // signal than a same-file substring guess (the file name, not the part
+  // name, was the mistake), so it takes priority.
+  const elsewhere = await findSymbolAcrossLibraries(name, dirs, lib);
+  if (elsewhere.length) return { status: 'found-elsewhere', libIds: elsewhere.map((m) => `${m.lib}:${name}`) };
+
+  // exact name not found anywhere: offer near matches within the guessed file
+  // (case-insensitive substring both ways)
   const q = name.toLowerCase();
   const candidates = [...symbols.keys()]
     .filter((k) => {
@@ -216,6 +379,14 @@ export async function verifySchematicSymbols(
         detail: resolved.candidates.length
           ? `"${entry.libId}" does not exist in the installed library — closest real symbols: ${resolved.candidates.join(', ')}. Use one of these lib_ids (KiCad renames symbols across versions).`
           : `"${entry.libId}" does not exist in the installed library and no close match was found; confirm the lib_id.`,
+      });
+      continue;
+    }
+    if (resolved.status === 'found-elsewhere') {
+      findings.push({
+        libId: entry.libId,
+        kind: 'no-library',
+        detail: `"${entry.libId}" names the wrong library, not the wrong part: use ${resolved.libIds.join(' or ')} instead.`,
       });
       continue;
     }

--- a/src/kicad/symlib.ts
+++ b/src/kicad/symlib.ts
@@ -44,8 +44,13 @@ export interface LibPin {
  * Candidate directories holding KiCad's stock `.kicad_sym` libraries, most
  * specific first. Env overrides win (KiCad exports these), then the standard
  * install locations for Linux/macOS/Windows. Only existing dirs are returned.
+ *
+ * @param winRoot test seam for the Windows `C:\Program Files\KiCad` root;
+ *   defaults to the real path. Without this, the Windows version-directory
+ *   discovery below can only be exercised on an actual Windows machine with
+ *   KiCad installed at the default location.
  */
-export async function symbolSearchDirs(env = process.env): Promise<string[]> {
+export async function symbolSearchDirs(env = process.env, winRoot = 'C:/Program Files/KiCad'): Promise<string[]> {
   const fromEnv = [
     env.KICAD_SYMBOL_DIR,
     env.KICAD10_SYMBOL_DIR,
@@ -77,7 +82,7 @@ export async function symbolSearchDirs(env = process.env): Promise<string[]> {
   // exactly that, not "env overrides win, plus whatever else this discovers"
   // — a caller pointing KICAD_SYMBOL_DIR at an isolated directory (tests, a
   // pinned library set) must get only that directory back.
-  const kicadRoot = 'C:/Program Files/KiCad';
+  const kicadRoot = winRoot;
   try {
     if (fromEnv.length > 0) throw new Error('env override present; skip Windows auto-discovery');
     const entries = await readdir(kicadRoot, { withFileTypes: true });
@@ -138,7 +143,12 @@ async function allLibraryFiles(dirs: string[]): Promise<{ lib: string; file: str
 
 export interface CrossLibraryMatch {
   lib: string;
-  /** true when the part name matched exactly; false for a fuzzy hit. */
+  /** The symbol name actually found (may differ from the query on a fuzzy hit,
+   * e.g. `SHT4x` for a query of `SHT40`) — the suggested lib_id must be built
+   * from this, never from the caller's original query, or a fuzzy suggestion
+   * points at a lib_id that does not exist. */
+  name: string;
+  /** true when `name` matched exactly; false for a fuzzy hit. */
   exact: boolean;
 }
 
@@ -199,7 +209,7 @@ export async function findSymbolAcrossLibraries(
     }
     const names = [...text.matchAll(/^\s*\(symbol\s+"([^"]+)"/gm)].map((m) => m[1]!);
     if (!skipExact && names.includes(name)) {
-      exact.push({ lib, exact: true });
+      exact.push({ lib, name, exact: true });
       continue;
     }
     // The "does the query contain the library name" direction is only
@@ -217,19 +227,23 @@ export async function findSymbolAcrossLibraries(
     // real part, which is exactly the wrong-part failure this tool must not
     // introduce.
     const MIN_EDIT_MATCH_LEN = 5;
-    if (
-      names.some((n) => {
-        const lower = n.toLowerCase();
-        if (lower.includes(q)) return true;
-        if (lower.length >= MIN_SHORT_NAME_LEN && q.includes(lower)) return true;
-        return (
-          q.length >= MIN_EDIT_MATCH_LEN &&
-          lower.length >= MIN_EDIT_MATCH_LEN &&
-          editDistanceWithin(q, lower, 1) <= 1
-        );
-      })
-    ) {
-      fuzzy.push({ lib, exact: false });
+    // The matched candidate string, not just whether one exists: a fuzzy hit
+    // must report the real symbol name (`n`) so the caller can build a lib_id
+    // that actually resolves. Suggesting `${lib}:${query}` back would name a
+    // part that was never found in that library — the exact regression this
+    // fuzzy path exists to avoid repeating.
+    const fuzzyHit = names.find((n) => {
+      const lower = n.toLowerCase();
+      if (lower.includes(q)) return true;
+      if (lower.length >= MIN_SHORT_NAME_LEN && q.includes(lower)) return true;
+      return (
+        q.length >= MIN_EDIT_MATCH_LEN &&
+        lower.length >= MIN_EDIT_MATCH_LEN &&
+        editDistanceWithin(q, lower, 1) <= 1
+      );
+    });
+    if (fuzzyHit) {
+      fuzzy.push({ lib, name: fuzzyHit, exact: false });
     }
   }
   return [...exact, ...fuzzy];
@@ -287,7 +301,7 @@ export async function resolveLibrarySymbol(
   const file = await findLibraryFile(lib, dirs);
   if (!file) {
     const elsewhere = await findSymbolAcrossLibraries(name, dirs, lib);
-    if (elsewhere.length) return { status: 'found-elsewhere', libIds: elsewhere.map((m) => `${m.lib}:${name}`) };
+    if (elsewhere.length) return { status: 'found-elsewhere', libIds: elsewhere.map((m) => `${m.lib}:${m.name}`) };
     return { status: 'no-library' };
   }
   const root = parseSexp(await readFile(file, 'utf8'))[0];
@@ -308,14 +322,10 @@ export async function resolveLibrarySymbol(
     current = base;
   }
 
-  // Not in the guessed file: a genuine exact match elsewhere is a stronger
-  // signal than a same-file substring guess (the file name, not the part
-  // name, was the mistake), so it takes priority.
-  const elsewhere = await findSymbolAcrossLibraries(name, dirs, lib);
-  if (elsewhere.length) return { status: 'found-elsewhere', libIds: elsewhere.map((m) => `${m.lib}:${name}`) };
-
-  // exact name not found anywhere: offer near matches within the guessed file
-  // (case-insensitive substring both ways)
+  // The guessed library exists and simply lacks this name, so its own
+  // near-matches are the most useful answer and come first: the caller named
+  // the right file and mistyped the part. Only when that file offers nothing
+  // is a different library worth suggesting (mirrors SymbolSource.resolve).
   const q = name.toLowerCase();
   const candidates = [...symbols.keys()]
     .filter((k) => {
@@ -323,6 +333,11 @@ export async function resolveLibrarySymbol(
       return lk.includes(q) || q.includes(lk);
     })
     .slice(0, 8);
+  if (candidates.length) return { status: 'no-symbol', candidates };
+
+  const elsewhere = await findSymbolAcrossLibraries(name, dirs, lib);
+  if (elsewhere.length) return { status: 'found-elsewhere', libIds: elsewhere.map((m) => `${m.lib}:${m.name}`) };
+
   return { status: 'no-symbol', candidates };
 }
 

--- a/src/kicad/symlib.ts
+++ b/src/kicad/symlib.ts
@@ -152,6 +152,24 @@ export interface CrossLibraryMatch {
   exact: boolean;
 }
 
+/** Cross-library matches, most-caller-useful first. */
+const CROSS_LIBRARY_CAP = 8;
+
+/**
+ * Reduce raw cross-library matches to the lib_ids worth suggesting: any exact
+ * hit is unambiguous evidence and crowds out fuzzy noise entirely (a query
+ * with one exact match and several fuzzy near-misses must report only the
+ * exact one, never a mix); with no exact hit, fuzzy candidates are offered but
+ * capped, matching the cap the same-file candidate list already uses, so a
+ * short or generic query (a single letter, a common prefix) cannot return
+ * dozens of unrelated libraries in one finding.
+ */
+export function crossLibraryIds(matches: CrossLibraryMatch[]): string[] {
+  const exact = matches.filter((m) => m.exact);
+  const chosen = exact.length ? exact : matches;
+  return chosen.slice(0, CROSS_LIBRARY_CAP).map((m) => `${m.lib}:${m.name}`);
+}
+
 /** Levenshtein edit distance, capped: returns `cap + 1` once the true distance
  * would exceed `cap`, so a caller doing a cheap "is this close enough" check
  * never pays for the full O(n·m) table on two names that are obviously
@@ -301,7 +319,7 @@ export async function resolveLibrarySymbol(
   const file = await findLibraryFile(lib, dirs);
   if (!file) {
     const elsewhere = await findSymbolAcrossLibraries(name, dirs, lib);
-    if (elsewhere.length) return { status: 'found-elsewhere', libIds: elsewhere.map((m) => `${m.lib}:${m.name}`) };
+    if (elsewhere.length) return { status: 'found-elsewhere', libIds: crossLibraryIds(elsewhere) };
     return { status: 'no-library' };
   }
   const root = parseSexp(await readFile(file, 'utf8'))[0];
@@ -322,10 +340,18 @@ export async function resolveLibrarySymbol(
     current = base;
   }
 
-  // The guessed library exists and simply lacks this name, so its own
-  // near-matches are the most useful answer and come first: the caller named
-  // the right file and mistyped the part. Only when that file offers nothing
-  // is a different library worth suggesting (mirrors SymbolSource.resolve).
+  // Evidence, strongest first: an exact match in a different library is
+  // unambiguous (the file name was the mistake, not the part), so it outranks
+  // even a same-file substring guess — the guessed library is often full of
+  // single-letter generics ("R", "C", "L") that trivially substring-match
+  // almost any query, and would otherwise silently outrank a real answer.
+  // Same-file candidates come next: the caller named the right file and
+  // mistyped the part, which is stronger evidence than a fuzzy guess in a
+  // library the caller never named. A cross-library fuzzy hit is last resort.
+  const elsewhere = await findSymbolAcrossLibraries(name, dirs, lib);
+  const exactElsewhere = elsewhere.filter((m) => m.exact);
+  if (exactElsewhere.length) return { status: 'found-elsewhere', libIds: crossLibraryIds(exactElsewhere) };
+
   const q = name.toLowerCase();
   const candidates = [...symbols.keys()]
     .filter((k) => {
@@ -335,15 +361,17 @@ export async function resolveLibrarySymbol(
     .slice(0, 8);
   if (candidates.length) return { status: 'no-symbol', candidates };
 
-  const elsewhere = await findSymbolAcrossLibraries(name, dirs, lib);
-  if (elsewhere.length) return { status: 'found-elsewhere', libIds: elsewhere.map((m) => `${m.lib}:${m.name}`) };
+  if (elsewhere.length) return { status: 'found-elsewhere', libIds: crossLibraryIds(elsewhere) };
 
   return { status: 'no-symbol', candidates };
 }
 
 export interface SymbolFinding {
   libId: string;
-  kind: 'no-library' | 'no-symbol' | 'pin-count' | 'pin-mismatch';
+  /** 'wrong-library' is a real issue to reconcile (an actionable correction),
+   * unlike 'no-library' (nothing could be checked) — keeping it distinct means
+   * a caller's issue count does not silently drop it into neither bucket. */
+  kind: 'no-library' | 'no-symbol' | 'wrong-library' | 'pin-count' | 'pin-mismatch';
   detail: string;
 }
 
@@ -357,18 +385,55 @@ function schematicLibSymbols(root: SexpNode[]): { libId: string; pins: LibPin[] 
   }));
 }
 
+// Must match SYM_CACHE_DIR in ../kicad/draft/symsource.ts. Not imported from
+// there: symsource.ts already imports from this module, and the constant is
+// stable enough (it is part of the on-disk project layout, D4) that a literal
+// here is safer than risking a cycle.
+const VENDOR_CACHE_DIR = 'sym-lib-cache';
+
+/**
+ * Library nicknames the project has vendored into `sym-lib-cache/` (the
+ * drafting engine's own generated power symbols, or a stock symbol it copied
+ * in on first use). A nickname absent from every installed search dir is not
+ * necessarily a *wrong* library: it may be deliberately absent, because the
+ * project vendors it instead. Returns an empty set (never throws) when the
+ * directory does not exist or is unreadable, so a caller that cannot check
+ * simply treats nothing as vendored rather than failing the whole check.
+ */
+async function vendoredLibNames(repoRoot: string): Promise<Set<string>> {
+  try {
+    const entries = await readdir(path.join(repoRoot, VENDOR_CACHE_DIR));
+    return new Set(entries.filter((e) => e.endsWith('.kicad_sym')).map((e) => e.slice(0, -'.kicad_sym'.length)));
+  } catch {
+    return new Set();
+  }
+}
+
 /**
  * Compare every lib_symbols entry in a schematic against the installed library.
  * Returns one finding per divergence; an empty array means every resolvable
  * symbol matched. A part whose library is not installed is reported once (so
  * the model knows the check could not run for it) but never treated as a
  * mismatch — absence of the library is not evidence of wrong pins.
+ *
+ * @param repoRoot project root, so a nickname the project deliberately vendors
+ *   (the drafting engine's generated power symbols, `copperhead_power`) is
+ *   never reported as "wrong library, use X instead": that library is absent
+ *   from the search dirs on purpose, and telling the agent to switch away from
+ *   its own vendored symbols would either churn for nothing or break the
+ *   deterministic-vendoring guarantee (design D4). Optional for callers that
+ *   cannot supply it (older call sites, ad hoc checks): those simply cannot
+ *   distinguish "deliberately vendored" from "genuinely wrong", so they get
+ *   the plain `no-library` treatment for every unresolvable nickname, which
+ *   is always safe, just less specific for the genuinely-wrong case.
  */
 export async function verifySchematicSymbols(
   schPath: string,
   env = process.env,
+  repoRoot?: string,
 ): Promise<{ findings: SymbolFinding[]; checked: number; skipped: number }> {
   const dirs = await symbolSearchDirs(env);
+  const vendored = repoRoot ? await vendoredLibNames(repoRoot) : new Set<string>();
   const root = parseSexp(await readFile(schPath, 'utf8'))[0];
   const findings: SymbolFinding[] = [];
   if (root === undefined || !isList(root)) return { findings, checked: 0, skipped: 0 };
@@ -377,7 +442,8 @@ export async function verifySchematicSymbols(
   let skipped = 0;
   for (const entry of schematicLibSymbols(root)) {
     if (!entry.libId) continue;
-    const resolved = await resolveLibrarySymbol(entry.libId, dirs);
+    const guessedLib = entry.libId.includes(':') ? entry.libId.slice(0, entry.libId.indexOf(':')) : '';
+    const resolved = vendored.has(guessedLib) ? ({ status: 'no-library' } as const) : await resolveLibrarySymbol(entry.libId, dirs);
     if (resolved.status === 'no-library') {
       skipped++;
       findings.push({
@@ -400,7 +466,7 @@ export async function verifySchematicSymbols(
     if (resolved.status === 'found-elsewhere') {
       findings.push({
         libId: entry.libId,
-        kind: 'no-library',
+        kind: 'wrong-library',
         detail: `"${entry.libId}" names the wrong library, not the wrong part: use ${resolved.libIds.join(' or ')} instead.`,
       });
       continue;

--- a/test/draft-hardening.test.ts
+++ b/test/draft-hardening.test.ts
@@ -637,4 +637,53 @@ describe('draft orchestration error paths', () => {
       await rm(repo, { recursive: true, force: true });
     }
   });
+
+  // Regression for a review finding on #186: a fuzzy cross-library suggestion
+  // was built from the caller's original (wrong) query name, not the symbol
+  // that actually matched, so re-resolving the "fix" it offered failed again
+  // with the identical error (SHT40 guessed in the wrong library; the real
+  // symbol two directories over is spelled SHT4x, not SHT40).
+  it('a fuzzy cross-library suggestion names the real symbol, and resolves', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'copperhead-fuzzy-elsewhere-'));
+    const libDir = await mkdtemp(path.join(tmpdir(), 'copperhead-fuzzy-libs-'));
+    try {
+      await writeFile(
+        path.join(libDir, 'Sensor_Wrong.kicad_sym'),
+        `(kicad_symbol_lib (version 20251024) (generator test)\n  (symbol "Unrelated" (pin_numbers hide) (pin_names (offset 0))))`,
+        'utf8',
+      );
+      await writeFile(
+        path.join(libDir, 'Sensor_Humidity.kicad_sym'),
+        `(kicad_symbol_lib (version 20251024) (generator test)
+  (symbol "SHT4x" (pin_numbers hide) (pin_names (offset 0))
+    (symbol "SHT4x_1_1"
+      (pin passive line (at 0 3.81 270) (length 1.27) (name "~") (number "1"))
+      (pin passive line (at 0 -3.81 90) (length 1.27) (name "~") (number "2"))
+    )
+  )
+)`,
+        'utf8',
+      );
+      const src = new SymbolSource(repo, [libDir]);
+      let suggested: string | null = null;
+      try {
+        await src.resolve('Sensor_Wrong:SHT40');
+        expect.unreachable('expected resolve to throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(SymbolResolutionError);
+        const err = e as SymbolResolutionError;
+        expect(err.reason).toBe('found-elsewhere');
+        suggested = err.candidates[0]!;
+        // The bug this guards: reconstructing from the query would produce
+        // "Sensor_Humidity:SHT40", which does not exist anywhere.
+        expect(suggested).toBe('Sensor_Humidity:SHT4x');
+      }
+      const resolved = await src.resolve(suggested!);
+      expect(resolved.libId).toBe('Sensor_Humidity:SHT4x');
+      expect(resolved.pins).toHaveLength(2);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      await rm(libDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/symlib.test.ts
+++ b/test/symlib.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { resolveLibrarySymbol, verifySchematicSymbols } from '../src/kicad/symlib.js';
+import { resolveLibrarySymbol, verifySchematicSymbols, symbolSearchDirs, findSymbolAcrossLibraries } from '../src/kicad/symlib.js';
 
 // A minimal stand-in for /usr/share/kicad/symbols/Device.kicad_sym: R (2 pins)
 // and R_Small which `extends` R (inherits R's pins, has none of its own).
@@ -103,5 +103,126 @@ describe('symlib (I9: verify symbols against the installed KiCad library)', () =
     expect(skipped).toBe(1);
     // The faithful Device:R must NOT produce a pin-mismatch.
     expect(findings.find((f) => f.libId === 'Device:R')).toBeUndefined();
+  });
+});
+
+describe('cross-library resolution (review findings on #186)', () => {
+  let libDir: string;
+
+  beforeAll(async () => {
+    libDir = await mkdtemp(path.join(tmpdir(), 'copperhead-crosslib-test-'));
+    // Device.kicad_sym: guessed-but-wrong library for these tests, plus a
+    // same-file typo target (R_Small) that must still win over any
+    // cross-library fuzzy noise.
+    await writeFile(path.join(libDir, 'Device.kicad_sym'), DEVICE_LIB, 'utf8');
+    // The real symbol lives elsewhere, and is spelled differently than the
+    // query (SHT4x, not SHT40) — the shape that broke substring-only matching.
+    await writeFile(
+      path.join(libDir, 'Sensor_Humidity.kicad_sym'),
+      `(kicad_symbol_lib (version 20251024) (generator test)
+  (symbol "SHT4x" (pin_numbers hide) (pin_names (offset 0))
+    (symbol "SHT4x_1_1"
+      (pin passive line (at 0 3.81 270) (length 1.27) (name "~") (number "1"))
+      (pin passive line (at 0 -3.81 90) (length 1.27) (name "~") (number "2"))
+    )
+  )
+)`,
+      'utf8',
+    );
+  });
+
+  afterAll(async () => {
+    await rm(libDir, { recursive: true, force: true });
+  });
+
+  it('finds an exact match under a different library name', async () => {
+    const matches = await findSymbolAcrossLibraries('SHT4x', [libDir], 'Sensor_Wrong');
+    expect(matches).toContainEqual({ lib: 'Sensor_Humidity', name: 'SHT4x', exact: true });
+  });
+
+  it('a fuzzy cross-library match reports the real symbol name, not the query', async () => {
+    const matches = await findSymbolAcrossLibraries('SHT40', [libDir], 'Sensor_Wrong');
+    const hit = matches.find((m) => m.lib === 'Sensor_Humidity');
+    expect(hit).toBeDefined();
+    expect(hit!.exact).toBe(false);
+    // The bug this guards: recording only `{ lib, exact }` and reconstructing
+    // the suggestion from the caller's original query built "Sensor_Humidity:SHT40",
+    // a lib_id that does not exist anywhere.
+    expect(hit!.name).toBe('SHT4x');
+  });
+
+  it('does not match a genuinely different part number one edit away', async () => {
+    // TPS22860 vs TPS22810: same length, one character differs. Real parts,
+    // not the same chip. The 1-edit cap must not blur them together.
+    const matches = await findSymbolAcrossLibraries('TPS22860', [libDir], 'Power_Switch');
+    expect(matches.some((m) => m.name === 'TPS22810')).toBe(false);
+  });
+
+  it('a same-file typo wins over a cross-library fuzzy match, and never suggests itself', async () => {
+    // Device:R_Sma is a typo of Device:R_Small, which lives in the same file.
+    // The fix on #186 ordered same-file candidates before cross-library
+    // lookup; before that fix this returned 'found-elsewhere' pointing at
+    // "Device:R_Sma" itself, the identical failing lib_id.
+    const r = await resolveLibrarySymbol('Device:R_Sma', [libDir]);
+    expect(r.status).toBe('no-symbol');
+    if (r.status === 'no-symbol') {
+      expect(r.candidates).toContain('R_Small');
+    }
+  });
+
+  it('resolveLibrarySymbol resolves a fuzzy cross-library suggestion end to end', async () => {
+    const first = await resolveLibrarySymbol('Sensor_Wrong:SHT40', [libDir]);
+    expect(first.status).toBe('found-elsewhere');
+    if (first.status !== 'found-elsewhere') return;
+    const suggested = first.libIds[0]!;
+    expect(suggested).toBe('Sensor_Humidity:SHT4x');
+    const second = await resolveLibrarySymbol(suggested, [libDir]);
+    expect(second.status).toBe('ok');
+  });
+});
+
+describe('symbolSearchDirs: Windows version-directory discovery', () => {
+  let root: string;
+  let versionDir: string;
+
+  beforeAll(async () => {
+    // Stand-in for "C:\Program Files\KiCad": a version-numbered child holding
+    // the real symbols directory, the layout every real Windows install uses.
+    // symbolSearchDirs builds the version path by string concatenation with
+    // forward slashes (matching a Windows-accepted `C:/...` root), not
+    // path.join, so the expected values here must be built the same way.
+    root = (await mkdtemp(path.join(tmpdir(), 'copperhead-kicadroot-'))).split(path.sep).join('/');
+    versionDir = `${root}/10.0/share/kicad/symbols`;
+    await mkdir(versionDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('discovers a version-numbered directory when no env override is set', async () => {
+    const dirs = await symbolSearchDirs({}, root);
+    expect(dirs).toEqual([versionDir]);
+  });
+
+  it('prefers the newest version when more than one is installed', async () => {
+    const older = `${root}/8.0/share/kicad/symbols`;
+    await mkdir(older, { recursive: true });
+    try {
+      const dirs = await symbolSearchDirs({}, root);
+      expect(dirs[0]).toBe(versionDir); // 10.0 sorts before 8.0
+      expect(dirs).toContain(older);
+    } finally {
+      await rm(`${root}/8.0`, { recursive: true, force: true });
+    }
+  });
+
+  it('an env override skips Windows auto-discovery entirely, even when set', async () => {
+    // Regression: symbolSearchDirs used to run the Windows version-directory
+    // scan unconditionally, so a caller pinning KICAD_SYMBOL_DIR at an
+    // isolated directory (this repo's own tests, or a pinned library set)
+    // could silently get the real machine's KiCad install appended too.
+    const dirs = await symbolSearchDirs({ KICAD_SYMBOL_DIR: versionDir }, root);
+    expect(dirs).toEqual([versionDir]);
   });
 });

--- a/test/symlib.test.ts
+++ b/test/symlib.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { resolveLibrarySymbol, verifySchematicSymbols, symbolSearchDirs, findSymbolAcrossLibraries } from '../src/kicad/symlib.js';
+import {
+  resolveLibrarySymbol,
+  verifySchematicSymbols,
+  symbolSearchDirs,
+  findSymbolAcrossLibraries,
+  crossLibraryIds,
+} from '../src/kicad/symlib.js';
+import { SymbolSource } from '../src/kicad/draft/symsource.js';
 
 // A minimal stand-in for /usr/share/kicad/symbols/Device.kicad_sym: R (2 pins)
 // and R_Small which `extends` R (inherits R's pins, has none of its own).
@@ -179,6 +186,128 @@ describe('cross-library resolution (review findings on #186)', () => {
     const second = await resolveLibrarySymbol(suggested, [libDir]);
     expect(second.status).toBe('ok');
   });
+
+  // Finding 6 (review round 2): the wrong-nickname-but-library-exists path
+  // through resolveLibrarySymbol, exercised via verify_symbols's shape
+  // (Sensor_Humidity:SHT40 guessed correctly by file, wrong by part name),
+  // as opposed to the drafting engine's SymbolSource, which the round-1 tests
+  // already cover.
+  it('a guessed library that exists, but lacks the name, still finds the real symbol elsewhere', async () => {
+    const r = await resolveLibrarySymbol('Sensor_Humidity:SHT40', [libDir]);
+    expect(r.status).toBe('found-elsewhere');
+    if (r.status === 'found-elsewhere') expect(r.libIds).toEqual(['Sensor_Humidity:SHT4x']);
+  });
+
+  // Finding 2 (review round 2): the reorder that fixed the self-suggestion
+  // regression introduced its own regression, an exact cross-library hit
+  // pre-empted by a junk same-file candidate. Real stock Device.kicad_sym
+  // has a symbol literally named "L" (inductor), and any query containing
+  // the letter L (e.g. "LM358") trivially substring-matches it — this is
+  // exactly the reviewer's live repro (Device:LM358), reproduced here with a
+  // synthetic fixture so the test does not depend on the real KiCad library.
+  it('an exact cross-library hit outranks a junk short same-file candidate', async () => {
+    const junkDir = await mkdtemp(path.join(tmpdir(), 'copperhead-junk-'));
+    try {
+      await writeFile(
+        path.join(junkDir, 'Device.kicad_sym'),
+        `(kicad_symbol_lib (version 20251024) (generator test)\n  (symbol "L" (pin_numbers hide) (pin_names (offset 0))))`,
+        'utf8',
+      );
+      await writeFile(
+        path.join(junkDir, 'Amplifier_Operational.kicad_sym'),
+        `(kicad_symbol_lib (version 20251024) (generator test)\n  (symbol "LM358" (pin_numbers hide) (pin_names (offset 0))))`,
+        'utf8',
+      );
+      const r = await resolveLibrarySymbol('Device:LM358', [junkDir]);
+      expect(r.status).toBe('found-elsewhere');
+      if (r.status === 'found-elsewhere') expect(r.libIds).toEqual(['Amplifier_Operational:LM358']);
+    } finally {
+      await rm(junkDir, { recursive: true, force: true });
+    }
+  });
+
+  // Finding 4 (review round 2): an exact hit and a fuzzy hit for the same
+  // query must not be reported together — only the exact one, so the agent
+  // is never invited to consider a wrong-but-plausible-looking alternative
+  // alongside the right answer.
+  it('an exact hit suppresses a coexisting fuzzy hit, not just a same-lib fuzzy one', async () => {
+    const mixedDir = await mkdtemp(path.join(tmpdir(), 'copperhead-mixed-'));
+    try {
+      await writeFile(
+        path.join(mixedDir, 'Exact.kicad_sym'),
+        `(kicad_symbol_lib (version 20251024) (generator test)\n  (symbol "Widget123" (pin_numbers hide) (pin_names (offset 0))))`,
+        'utf8',
+      );
+      await writeFile(
+        path.join(mixedDir, 'Fuzzy.kicad_sym'),
+        `(kicad_symbol_lib (version 20251024) (generator test)\n  (symbol "Widget12x" (pin_numbers hide) (pin_names (offset 0))))`,
+        'utf8',
+      );
+      const matches = await findSymbolAcrossLibraries('Widget123', [mixedDir], 'Nowhere');
+      // both a real exact hit and a real fuzzy hit exist in the raw scan
+      expect(matches.some((m) => m.exact)).toBe(true);
+      expect(matches.some((m) => !m.exact)).toBe(true);
+      const ids = crossLibraryIds(matches);
+      expect(ids).toEqual(['Exact:Widget123']);
+    } finally {
+      await rm(mixedDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a short/generic query is capped rather than returning every generic library', async () => {
+    // "R" is a real canonical symbol name (Device:R), so an exact hit exists
+    // and must collapse the result to that one hit, not every library whose
+    // name happens to contain the letter R.
+    const r = await resolveLibrarySymbol('Nowhere:R', [libDir]);
+    expect(r.status).toBe('found-elsewhere');
+    if (r.status === 'found-elsewhere') expect(r.libIds).toEqual(['Device:R']);
+  });
+});
+
+// Finding 1 (review round 2): a nickname the project deliberately vendors
+// (the drafting engine's own generated power symbols) must never be reported
+// as a "wrong library, use X instead" correction just because it is absent
+// from the installed search dirs — it is absent on purpose.
+describe('verifySchematicSymbols: vendored libraries are not "wrong", just absent', () => {
+  it('a vendored nickname reports no-library, not found-elsewhere, when repoRoot is given', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'copperhead-vendored-'));
+    const libDir = await mkdtemp(path.join(tmpdir(), 'copperhead-vendored-libs-'));
+    try {
+      // A stock library that happens to also define a symbol named "GND" —
+      // standing in for the real stock `power` library, which the project's
+      // own vendored `copperhead_power` nickname must not be confused with.
+      await writeFile(
+        path.join(libDir, 'power.kicad_sym'),
+        `(kicad_symbol_lib (version 20251024) (generator test)\n  (symbol "GND" (power)\n    (pin power_in line (at 0 0 90) (length 0) (name "GND") (number "1"))\n  ))`,
+        'utf8',
+      );
+      const src = new SymbolSource(repo, [libDir]);
+      await src.vendorGenerated(
+        'copperhead_power:GND',
+        '\n\t(symbol "GND" (power)\n\t\t(pin power_in line (at 0 0 90) (length 0) (name "GND") (number "1"))\n\t)',
+      );
+      const sch = `(kicad_sch (version 20251024) (generator test)
+  (lib_symbols
+    (symbol "copperhead_power:GND" (power)
+      (pin power_in line (at 0 0 90) (length 0) (name "GND") (number "1"))
+    )
+  )
+)`;
+      const schPath = path.join(repo, 'x.kicad_sch');
+      await writeFile(schPath, sch, 'utf8');
+
+      const withoutRoot = await verifySchematicSymbols(schPath, { KICAD_SYMBOL_DIR: libDir });
+      // Old (and still default-for-unaware-callers) behavior: bad advice.
+      expect(withoutRoot.findings[0]!.kind).toBe('wrong-library');
+
+      const withRoot = await verifySchematicSymbols(schPath, { KICAD_SYMBOL_DIR: libDir }, repo);
+      expect(withRoot.findings[0]!.kind).toBe('no-library');
+      expect(withRoot.skipped).toBe(1);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      await rm(libDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('symbolSearchDirs: Windows version-directory discovery', () => {
@@ -200,16 +329,25 @@ describe('symbolSearchDirs: Windows version-directory discovery', () => {
     await rm(root, { recursive: true, force: true });
   });
 
+  // `symbolSearchDirs` also checks the hardcoded Linux/macOS default paths
+  // unconditionally, regardless of the `winRoot` test seam: on a machine that
+  // actually has KiCad installed at one of those (any real developer or CI
+  // box capable of running this tool at all), asserting the whole return
+  // value fails not because discovery is wrong, but because something else
+  // real is also present. Assert on the discovered subset instead, so the
+  // test states the actual contract independently of what else is installed.
+  const discovered = (dirs: string[]): string[] => dirs.filter((d) => d.startsWith(root));
+
   it('discovers a version-numbered directory when no env override is set', async () => {
     const dirs = await symbolSearchDirs({}, root);
-    expect(dirs).toEqual([versionDir]);
+    expect(discovered(dirs)).toEqual([versionDir]);
   });
 
   it('prefers the newest version when more than one is installed', async () => {
     const older = `${root}/8.0/share/kicad/symbols`;
     await mkdir(older, { recursive: true });
     try {
-      const dirs = await symbolSearchDirs({}, root);
+      const dirs = discovered(await symbolSearchDirs({}, root));
       expect(dirs[0]).toBe(versionDir); // 10.0 sorts before 8.0
       expect(dirs).toContain(older);
     } finally {
@@ -222,7 +360,17 @@ describe('symbolSearchDirs: Windows version-directory discovery', () => {
     // scan unconditionally, so a caller pinning KICAD_SYMBOL_DIR at an
     // isolated directory (this repo's own tests, or a pinned library set)
     // could silently get the real machine's KiCad install appended too.
-    const dirs = await symbolSearchDirs({ KICAD_SYMBOL_DIR: versionDir }, root);
-    expect(dirs).toEqual([versionDir]);
+    // Points the override at an unrelated directory (not `versionDir`, which
+    // sits under `root`) so the assertion states the real contract: discovery
+    // under `root` did not run, independent of whether the override directory
+    // itself happens to overlap with anything else.
+    const envDir = await mkdtemp(path.join(tmpdir(), 'copperhead-envdir-'));
+    try {
+      const dirs = await symbolSearchDirs({ KICAD_SYMBOL_DIR: envDir }, root);
+      expect(dirs).toContain(envDir);
+      expect(dirs.some((d) => d.startsWith(root))).toBe(false);
+    } finally {
+      await rm(envDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Closes #185. Targets `feat/deterministic-schematic-drafting` rather than `main`, since `src/kicad/draft/symsource.ts` only exists on that branch: the diff here is the single commit on top of #160.

## What

Symbol resolution now searches across libraries before giving up, instead of only opening the one file named in the `lib_id`.

## Why

Driving `create` end to end on `examples/medium/esp32-soil-sensor.md`, stage 4 reported four real parts as "library not installed and not vendored" and burned two full turn budgets on them. Three of the four were in the stock KiCad library the whole time, filed under a library nickname the caller could not have derived from the part number:

| Part | lib_id used | Actually in |
| --- | --- | --- |
| TPS63900 | `Regulator_DCDC:` | `Regulator_Switching` |
| SHT40 | `Sensor_Humidity:SHT40` | `Sensor_Humidity`, as `SHT4x` |
| FDC1004 | `Sensor:` | `Sensor_Proximity` |
| TPS22860 | `Power_Switch:` | genuinely absent from the stock set |

`resolveLibrarySymbol` and `SymbolSource.resolve` both split the lib_id at the colon and opened only that file, so a wrong library nickname was indistinguishable from a missing part. The agent could not tell "you named the wrong file" from "this part does not exist", and correctly refused rather than guess a pinout, twice.

## Design

Fallback order is by strength of evidence, so a weaker signal never displaces a stronger one:

1. exact name in the guessed file (unchanged)
2. near-matches within the guessed file: the caller named the right file and mistyped the part, so its own candidates outrank any other library's
3. exact name in a different library: the file was the mistake, not the part
4. fuzzy match in a different library, surfaced as a suggestion

Matching has to stay tight enough never to propose a *different real chip*. Two guards, both added in response to a case this actually hit:

- substring matching ignores library names under 3 characters. A stock library is full of single-letter generics (`R`, `C`, `D`), and "does &lt;any part number&gt; contain R" is true for nearly everything.
- edit distance (≤1 edit, names ≥5 chars) catches the datasheet-vs-library near-miss substring cannot: `SHT40` vs `SHT4x` differ mid-string, so neither contains the other. Capped at one edit specifically so `TPS22860` does not match `TPS22810`, a different real part.

`TPS22860` still resolving to nothing is the correct outcome, and is the case the config-level extra-library option in #185 is for.

Two defects found while building this are fixed in the same commit:

- `symbolSearchDirs` ran Windows version-directory discovery even when `KICAD_SYMBOL_DIR` was set, contradicting its own "env overrides win" contract and leaking the machine's real KiCad install into tests that had pinned an isolated fixture directory.
- the Windows fallback path hardcoded `C:/Program Files/KiCad/share/kicad/symbols`, omitting the version segment KiCad's installer always creates (`.../KiCad/10.0/share/...`), so symbol resolution failed outright on a stock Windows install. Now discovered by listing the install root, newest version first.

## Testing

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Unit + offline | `npx vitest run` | 16 failing before and after (see below) |
| Targeted | `npx vitest run test/symlib.test.ts test/draft-hardening.test.ts test/draft-tools.test.ts` | 47/47 pass |

The 16 failures are pre-existing on this machine and unrelated to symbol resolution: Windows path handling, `chmod` semantics, app-bundle probing. Confirmed by capturing the failing-test list with the change stashed and again with it applied, then diffing. The baseline was 18; the two `symbolSearchDirs` fixes above repaired two of them.

One regression was introduced and fixed during development rather than shipped: ordering the cross-library check before the same-file candidate list made `Device:R_Sma` report "use `Device:R_Sma` instead", suggesting the exact input back at the caller. `test/draft-hardening.test.ts` caught it, and it is what motivated the evidence ordering above.

### Manual verification

Against a real KiCad 10.0.5 install on Windows:

```text
TPS63900   -> Regulator_Switching [EXACT]
SHT40      -> Sensor_Humidity (fuzzy)      # the SHT4x near-miss
FDC1004    -> Sensor_Proximity (fuzzy)
TPS22860   -> NOT FOUND                    # correct: genuinely absent
```

The last line is the one worth checking on review: a looser matcher would have proposed `TPS22810` here, which is a different part.

---

## Invariant checklist

- [ ] N/A **Spec-gated in**: no change to tool exposure or the unlock path.
- [ ] N/A **Verification-gated out**: no change to the ERC/DRC gates or rollback.
- [ ] N/A **`check`/`verify` stays LLM-free and network-free**: this path is filesystem-only and reachable from `check` only as it already was; no provider, key, or network use added.
- [x] **No sexp serialization**: the parser stays read-only. Cross-library search reads `.kicad_sym` text and matches symbol names; nothing is written or round-tripped.
- [ ] N/A **Sync-obligations ledger**: untouched.
- [ ] N/A **Secrets**: no credential handling; no new transcript output.
- [ ] N/A **Spec coherence**: no spec-level behavior change. Resolution reports a corrected lib_id where it previously reported a dead end; the refusal contract (never guess a pinout) is preserved, including for `TPS22860`.
