### PR TITLE
fix(check): fail when the configured schematic is missing, and say which file

### DIFF
--- a/openspec/changes/build-copperhead-phase-1/specs/cli-surface/spec.md
+++ b/openspec/changes/build-copperhead-phase-1/specs/cli-surface/spec.md
@@ -28,6 +28,10 @@ The `copperhead` CLI SHALL provide the commands `create --brief <file>`, `init [
 - **WHEN** `check` runs on a schematic with an unconnected pin
 - **THEN** it exits non-zero and prints the violation with its sheet and location
 
+#### Scenario: Configured schematic absent (AC-2.6)
+- **WHEN** `check` runs on a repo whose configured `schematic` names a file that is not on disk
+- **THEN** it exits non-zero and names the configured path in every skip reason it prints, rather than exiting 0 with a generic "no schematic configured" message
+
 ### Requirement: JSON output mode
 With `--json`, commands SHALL emit machine-readable results with stable keys.
 

--- a/openspec/changes/build-copperhead-phase-1/tasks.md
+++ b/openspec/changes/build-copperhead-phase-1/tasks.md
@@ -65,6 +65,7 @@
 
 - [x] 7.1 Implement `copperhead check` (with `verify` alias): ERC + DRC + drift + `openspec validate` + mechanical constraint checks; zero LLM/network calls; non-zero exit on any violation (AC-2.1, AC-2.2)
 - [x] 7.2 Implement `--json` output with stable keys (AC-2.4)
+- [x] 7.4 Implement the configured-but-absent schematic case: exit non-zero and name the configured path in every skip reason (AC-2.6)
 - [x] 7.3 Tests: clean fixture passes < 60 s with network guard asserting no api.* calls; broken-pin fixture fails with location; BOM-drift fixture fails naming doc/claim/actual (AC-2.5)
 
 ## 8. `do` command end-to-end

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -438,6 +438,7 @@ Format: Given / When / Then. "Fixture" = the open-telegraph repo (or the tiny te
 - **AC-2.3** With a BOM.md value edited to disagree with the schematic (e.g. wrong resistor value): drift check fails and names the doc, the claim, and the actual value.
 - **AC-2.4** `--json` emits machine-readable results (parseable, stable keys).
 - **AC-2.5** Runs in < 60 s on the fixture.
+- **AC-2.6 (configured schematic absent)** With `schematic` set in config to a path that does not exist, `check` exits non-zero and names the configured path in every skip reason it prints; it does not exit 0 reporting "no schematic configured".
 
 ### AC-3 · `copperhead do` — core loop
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -35,6 +35,13 @@ export interface CheckResult {
     /** Advisory quantitative score; null when no schematic is configured. */
     score: ScoreReport | null;
   };
+  /**
+   * The configured schematic path, when it is configured but absent from disk.
+   * A repo with no schematic configured has genuinely nothing to verify and
+   * stays green; a repo that was configured to be checked and quietly stopped
+   * being checked is a different thing, and must not read as a pass.
+   */
+  schematicMissing: string | null;
 }
 
 export async function runCheck(repoRoot: string, log: (s: string) => void): Promise<CheckResult> {
@@ -42,9 +49,19 @@ export async function runCheck(repoRoot: string, log: (s: string) => void): Prom
   let erc: CheckReport | null = null;
   let drc: CheckReport | null = null;
 
-  if (config.schematic && existsSync(path.join(repoRoot, config.schematic))) {
-    erc = await runErc(path.join(repoRoot, config.schematic));
+  // ERC, drift and the constraint check all gate on this one condition, so it
+  // is resolved once rather than re-tested three times with the same bug.
+  const schematicPath = config.schematic ? path.join(repoRoot, config.schematic) : null;
+  const schematicUsable = schematicPath !== null && existsSync(schematicPath);
+  const schematicMissing = config.schematic && !schematicUsable ? config.schematic : null;
+
+  if (schematicUsable) {
+    erc = await runErc(schematicPath);
     log(erc.ok ? 'ERC ✓' : formatViolations(erc));
+  } else if (schematicMissing) {
+    // `copperhead init` is the wrong remedy here: the config is fine, the file
+    // it points at is not. Say which path, so a typo or a rename is obvious.
+    log(`ERC skipped: schematic configured at ${schematicMissing} but the file is missing`);
   } else {
     log('ERC skipped (no schematic configured; run copperhead init)');
   }
@@ -58,7 +75,7 @@ export async function runCheck(repoRoot: string, log: (s: string) => void): Prom
 
   let drift: DriftMismatch[] = [];
   let driftWarning: string | null = null;
-  if (config.schematic && existsSync(path.join(repoRoot, config.schematic))) {
+  if (schematicUsable && config.schematic) {
     drift = await checkDrift(repoRoot, config.docs, config.schematic);
     log(drift.length === 0 ? 'drift ✓' : drift.map((m) => `drift: ${m.doc} claims "${m.claim}" but actual is "${m.actual}"`).join('\n'));
     // Informational, never a failure: the zero-symbol drift exemption is for
@@ -76,16 +93,12 @@ export async function runCheck(repoRoot: string, log: (s: string) => void): Prom
   }
 
   let legibility: CheckResult['legibility'];
-  if (config.schematic && existsSync(path.join(repoRoot, config.schematic))) {
-    const report = await checkLegibility(path.join(repoRoot, config.schematic), {
+  if (schematicUsable) {
+    const report = await checkLegibility(schematicPath, {
       docsDir: path.join(repoRoot, config.docs),
       ...(config.legibility ? { config: config.legibility } : {}),
     });
-    const score = scoreFromGeometry(
-      await readSheetGeometry(path.join(repoRoot, config.schematic)),
-      report,
-      config.legibility,
-    );
+    const score = scoreFromGeometry(await readSheetGeometry(schematicPath), report, config.legibility);
     legibility = {
       findings: report.findings,
       counts: report.counts,
@@ -97,21 +110,27 @@ export async function runCheck(repoRoot: string, log: (s: string) => void): Prom
     log(formatLegibility(report));
     log(`legibility score: ${score.composite}/100${score.cap ? ` (capped: ${score.cap.reason})` : ''}`);
   } else {
+    // Same distinction as ERC above: an unset schematic and one configured at a
+    // path that does not exist are different situations, so the skip reason
+    // carried in the report says which one this was.
+    const reason = schematicMissing
+      ? `schematic configured at ${schematicMissing} but the file is missing`
+      : 'no schematic configured';
     legibility = {
       findings: [],
       counts: { error: 0, advisory: 0 },
-      skipped: LEGIBILITY_FAMILIES.map((family) => ({ family, reason: 'no schematic configured' })),
+      skipped: LEGIBILITY_FAMILIES.map((family) => ({ family, reason })),
       disabled: [],
       suppressed: [],
       score: null,
     };
-    log('legibility skipped (no schematic configured)');
+    log(`legibility skipped (${reason})`);
   }
 
   let constraintViolations: ConstraintViolation[] = [];
-  if (config.schematic && existsSync(path.join(repoRoot, config.schematic))) {
+  if (schematicUsable) {
     const registry = await loadConstraints(repoRoot);
-    const pins = await pinNets(path.join(repoRoot, config.schematic));
+    const pins = await pinNets(schematicPath);
     constraintViolations = checkForbiddenPins(registry, pins);
     if (Object.keys(registry).length) {
       log(
@@ -122,7 +141,11 @@ export async function runCheck(repoRoot: string, log: (s: string) => void): Prom
     }
   }
 
+  // `?? true` is right for a check that had nothing to run, but it cannot tell
+  // "nothing to verify" from "everything to verify, silently skipped", so the
+  // missing-schematic case is failed explicitly rather than defaulted to true.
   const ok =
+    schematicMissing === null &&
     (erc?.ok ?? true) &&
     (drc?.ok ?? true) &&
     drift.length === 0 &&
@@ -137,5 +160,6 @@ export async function runCheck(repoRoot: string, log: (s: string) => void): Prom
     openspec,
     constraints: { ok: constraintViolations.length === 0, violations: constraintViolations },
     legibility,
+    schematicMissing,
   };
 }

--- a/test/check-missing-schematic.test.ts
+++ b/test/check-missing-schematic.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { writeFile, rm } from 'node:fs/promises';
+import { runInit } from '../src/memory/scaffold.js';
+import { runCheck, type CheckResult } from '../src/commands/check.js';
+import { tempFixtureRepo } from './helpers.js';
+
+/**
+ * A configured-but-absent schematic must not read as a pass. Two repos are
+ * involved and they are easy to conflate: one with nothing configured, which
+ * has genuinely nothing to verify, and one that was configured to be checked
+ * and quietly stopped being checked when the file moved or was renamed.
+ */
+
+const FIXTURE_SCH = 'hardware/open-key.kicad_sch';
+
+interface Run {
+  res: CheckResult;
+  log: string[];
+}
+
+/** Run `check` over the fixture with `schematic` set to `schematic`. */
+async function runWith(schematic: string | null, opts: { removeFile?: boolean } = {}): Promise<Run> {
+  const { repo, cleanup } = await tempFixtureRepo();
+  try {
+    await runInit({ repoRoot: repo });
+    await writeFile(
+      path.join(repo, '.copperhead', 'config.json'),
+      JSON.stringify({ docs: 'docs/', schematic, board: null, budgets: {} }, null, 2),
+      'utf8',
+    );
+    if (opts.removeFile && schematic) {
+      await rm(path.join(repo, schematic), { force: true });
+    }
+    const log: string[] = [];
+    const res = await runCheck(repo, (s) => log.push(s));
+    return { res, log };
+  } finally {
+    await cleanup();
+  }
+}
+
+describe('check with a configured but missing schematic', () => {
+  it('does not report ok when the configured schematic is absent', async () => {
+    const { res } = await runWith('hardware/moved-board.kicad_sch');
+
+    expect(res.ok).toBe(false);
+    expect(res.schematicMissing).toBe('hardware/moved-board.kicad_sch');
+  }, 60_000);
+
+  it('names the missing path instead of blaming the configuration', async () => {
+    const { log } = await runWith('hardware/moved-board.kicad_sch');
+    const erc = log.find((l) => l.startsWith('ERC skipped'));
+
+    expect(erc).toContain('hardware/moved-board.kicad_sch');
+    expect(erc).toContain('missing');
+    // `copperhead init` is the wrong remedy: the config is fine, the file is not
+    expect(erc).not.toContain('no schematic configured');
+    expect(erc).not.toContain('copperhead init');
+  }, 60_000);
+
+  it('fails the same way when the file is deleted after being configured', async () => {
+    const { res, log } = await runWith(FIXTURE_SCH, { removeFile: true });
+
+    expect(res.ok).toBe(false);
+    expect(res.schematicMissing).toBe(FIXTURE_SCH);
+    expect(log.find((l) => l.startsWith('ERC skipped'))).toContain(FIXTURE_SCH);
+  }, 60_000);
+
+  it('leaves a repo with no schematic configured green and unchanged', async () => {
+    const { res, log } = await runWith(null);
+
+    expect(res.ok).toBe(true);
+    expect(res.schematicMissing).toBeNull();
+    expect(log).toContain('ERC skipped (no schematic configured; run copperhead init)');
+  }, 60_000);
+
+  it('distinguishes the two skips, which previously logged the same line', async () => {
+    const missing = await runWith('hardware/moved-board.kicad_sch');
+    const unset = await runWith(null);
+
+    const ercOf = (r: Run): string | undefined => r.log.find((l) => l.startsWith('ERC skipped'));
+    expect(ercOf(missing)).not.toEqual(ercOf(unset));
+    expect(missing.res.ok).not.toEqual(unset.res.ok);
+  }, 60_000);
+});

--- a/test/init-check.test.ts
+++ b/test/init-check.test.ts
@@ -88,8 +88,18 @@ describe('copperhead check (AC-2)', () => {
       expect(res.erc).toEqual({ ok: true, violations: 0 });
       expect(res.drc).toEqual({ ok: true, violations: 0 });
       expect(res.drift.ok).toBe(true);
-      expect(Object.keys(res).sort()).toEqual(['constraints', 'drc', 'drift', 'erc', 'legibility', 'ok', 'openspec']);
+      expect(Object.keys(res).sort()).toEqual([
+        'constraints',
+        'drc',
+        'drift',
+        'erc',
+        'legibility',
+        'ok',
+        'openspec',
+        'schematicMissing',
+      ]);
       expect(res.legibility.counts.error).toBe(0);
+      expect(res.schematicMissing).toBeNull();
     } finally {
       await cleanup();
     }


### PR DESCRIPTION
## What

`copperhead check` no longer exits 0 when `config.schematic` points at a file that does not exist, and the message names the missing path instead of claiming the schematic is not configured.

## Why

Refs #188 (does not close it).

The issue's Scope section also names [sync.ts](src/commands/sync.ts) lines 43 and 133, which carry the same guard. Those are deliberately not in this PR: `syncVerify` has no `ok` boolean, and its resolvable items are handed to an LLM resolve phase, so a missing schematic needs different handling there (a violation, which is never auto-resolved) rather than the same one-line treatment. Follow-up PR, not a line in this one.

ERC, drift and the forbidden-pin constraint check all gate on the same `config.schematic && existsSync(...)` condition, written out three times in [check.ts](src/commands/check.ts). When the file is absent all three skip together, `ok` is computed with `?? true` for the skipped checks, and the run reports green. A repo that was configured to be checked and quietly stopped being checked looked exactly like one that passed everything. In CI that is a green build, and [create.ts](src/commands/create.ts) calls `runCheck` too.

The message pointed the wrong way as well. Both arms of the guard logged `no schematic configured; run copperhead init`, but the schematic *is* configured: the fix is to correct the path or restore the file, not to re-run `init`.

Reproduced before changing anything. The two cases were byte-identical:

```text
### A. schematic configured at hardware/missing-board.kicad_sch, file absent
  ok = true
  log: ERC skipped (no schematic configured; run copperhead init)

### B. no schematic configured
  ok = true
  log: ERC skipped (no schematic configured; run copperhead init)
```

## Design

The three copies of the guard are resolved once into `schematicUsable` and `schematicMissing`, so the condition cannot drift between the three checks that share it.

The two skips are now split, and treated differently on purpose:

- `config.schematic` unset: skip, keep the existing message, stay green. There is genuinely nothing to verify and `init` has not run, so this is unchanged.
- `config.schematic` set but absent: name the path, do not mention `init`, and fail.

`ok` gains an explicit `schematicMissing === null` term rather than relying on the `?? true` defaults. Those defaults are correct for a check that had nothing to run, but they cannot distinguish "nothing to verify" from "everything to verify, silently skipped".

I picked fail over adding a not-verified state, per the two options in the issue. Failing is what makes CI notice, and the new `schematicMissing` field still lets a caller tell this apart from a real ERC or drift failure. Happy to switch it to a distinct state if you would rather not change the exit code for existing repos.

**Coordination note:** #154 adds a fourth copy of the same `config.schematic && existsSync(...)` guard for `verifySchematicSymbols`. Whichever of these lands second will want to use the shared `schematicUsable` instead of re-testing. Not a blocker either way, just flagging it so the guard does not go back to being duplicated.

## Spec / OpenSpec

No spec-level behavior change, but the check result gains a key, so the AC-2.4 stable-JSON-keys assertion in [init-check.test.ts](test/init-check.test.ts) moves with it. The key set goes from six to seven with `schematicMissing`, which is `null` on every existing path.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | 560 pass / 22 fail / 20 skip, all 22 pre-existing (see below) |
| Live-LLM (opt-in) | n/a | n/a |

New tests: [check-missing-schematic.test.ts](test/check-missing-schematic.test.ts), 5 cases. All 5 pass here.

On the parent commit, 4 of the 5 fail behaviourally. The fifth ("leaves a repo with no schematic configured green and unchanged") fails there only because `schematicMissing` is `undefined` rather than `null`; its behavioural assertions already pass on the parent, which is the point of it being in the file.

Pre-existing failures: the 22 are unrelated to this change. I ran `test/init-check.test.ts` on this branch and on the parent with the same command and got the identical 3 failures both times (`clean fixture`, `broken schematic`, `fab export`), all with root cause `kicad-cli not found on PATH` in this environment. The remaining failures are in `preflight`, `repl`, `safety`, `cli-surface`, `kicad-cli-resolve`, `bootstrap`, `runmeta`, `gating-sync` and `create-hardening`, none of which this PR touches.

### Manual test log (required)

Sandbox variant used: hand-built minimal repo (one `.kicad_sch`, git-init'd, `.copperhead/config.json` written by hand), since the case under test is a *missing* schematic.

**Disclosure:** KiCad is not installed on this machine, so the `kicad-cli` preflight refused to start `check` at all. I set `COPPERHEAD_KICAD_CLI` to a stub that answers `version` so preflight passes. The stub is never invoked by either case below, because both skip ERC and DRC before reaching it. It only gets the command past preflight.

```text
$ copperhead --repo /tmp/ch-manual188 check
# config: { "schematic": "hardware/board.kicad_sch", "board": null }, file absent
ERC skipped: schematic configured at hardware/board.kicad_sch but the file is missing
DRC skipped (no board configured)
exit=1

$ copperhead --repo /tmp/ch-manual188 check
# config: { "schematic": null, "board": null }
ERC skipped (no schematic configured; run copperhead init)
DRC skipped (no board configured)
exit=0

$ copperhead --repo /tmp/ch-manual188 check --json
# config: { "schematic": "hardware/board.kicad_sch", "board": null }, file absent
{
  "ok": false,
  "erc": null,
  "drc": null,
  "drift": { "ok": true, "mismatches": [] },
  "openspec": null,
  "constraints": { "ok": true, "violations": [] },
  "schematicMissing": "hardware/board.kicad_sch"
}
exit=1
```

## Docs

None. The change is a message and an exit code, both covered above. Say the word if you want the `schematicMissing` field written up in the configuration reference.

---

## Invariant checklist

- [ ] N/A **Spec-gated in**: no change to the agent tool list.
- [ ] N/A **Verification-gated out**: no mutation path touched.
- [x] **`check`/`verify` stays LLM-free and network-free**: the change is a filesystem existence test and a boolean. No new imports; [check.ts](src/commands/check.ts) still reaches no provider, key, or network. The AC-2.1 module-graph test passes.
- [x] **No sexp serialization**: `src/kicad/` untouched. `pinNets` is still read-only, and now receives the already-resolved path.
- [ ] N/A **Sync-obligations ledger**: not touched.
- [ ] N/A **Secrets**: no transcript or summary path touched. The new log line contains only a config-relative path.
- [x] **Spec coherence**: no spec-level behavior change; the AC-2.4 key-set assertion moved with the new field, as described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checks now clearly report when a configured schematic is missing.
  * Missing schematics correctly cause validation to fail and skip dependent checks with specific messages.
  * Drift, legibility, and constraint checks now consistently reflect schematic availability.
  * Checks continue to pass as expected when no schematic is configured.
* **Tests**
  * Added coverage for missing or deleted schematics, skip messages, failure reporting, and successful configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

