### PR TITLE
fix(doctor): catch a missing openspec CLI before spec-seed burns real tokens on it

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Spec-gated in, verification-gated out: the design can't drift from its requireme
 copperhead init [--path hardware/]   # scaffold docs/ from an existing schematic; idempotent
 copperhead do "<change request>"     # the core loop: propose, edit, verify, propagate, commit
 copperhead check                     # ERC + DRC + doc-drift + spec validation; no LLM calls (alias: verify)
-copperhead doctor                    # env preflight: kicad-cli, git, node, provider credential; no LLM/network
+copperhead doctor                    # env preflight: node, kicad-cli, git, openspec, provider credential; no LLM/network
 copperhead sync [--dry-run]          # verify the whole design state, resolve drift
 copperhead create --brief brief.md   # brief → full output package
 copperhead export bom --supplier jlcpcb   # supplier-ready ordering file from docs/BOM.md

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -58,8 +58,7 @@ function defaultDeps(): DoctorDeps {
     // openspec ships as an npm-installed `.cmd` shim on Windows, not a real
     // .exe like git; execFile only runs .cmd files through a shell. Folding
     // the command into one string (no args array) avoids Node's DEP0190
-    // warning for shell:true + args, which doesn't apply here anyway since
-    // the command is a fixed literal, not user input.
+    // warning for shell:true + args.
     openspecVersion: async () => (await execFileP('openspec --version', [], { shell: true })).stdout.trim(),
     env: process.env,
   };
@@ -400,7 +399,7 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
     nodeCheck(deps.nodeVersion),
     await kicadCheck(deps.kicadVersion),
     await gitCheck(deps.gitVersion),
-    await openspecCheck(deps.openspecVersion), // new
+    await openspecCheck(deps.openspecVersion),
     providerCheck(opts.model, config, deps.env),
   ];
   if (resolvedModel) {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -14,6 +14,7 @@ import {
 } from '../config.js';
 import { kicadCliVersion } from '../kicad/cli.js';
 import { redactSecrets } from '../util/redact.js';
+import { isNotFoundError } from '../util/preflight.js';
 
 const execFileP = promisify(execFile);
 
@@ -108,12 +109,19 @@ async function gitCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
 async function openspecCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
   try {
     return { name: 'openspec', status: 'ok', detail: await probe() };
-  } catch {
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      return {
+        name: 'openspec',
+        status: 'fail',
+        detail: 'not found on PATH',
+        hint: 'npm i -g @fission-ai/openspec; validate_change and the create pipeline need it.',
+      };
+    }
     return {
       name: 'openspec',
       status: 'fail',
-      detail: 'not found on PATH',
-      hint: 'npm i -g @fission-ai/openspec; validate_change and the create pipeline need it.',
+      detail: (err as Error).message || String(err),
     };
   }
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { execa } from 'execa';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import {
@@ -56,11 +57,11 @@ function defaultDeps(): DoctorDeps {
     // `git --version` prints "git version 2.34.1"; keep only the number, the
     // report already labels the row "git".
     gitVersion: async () => (await execFileP('git', ['--version'])).stdout.trim().replace(/^git version\s+/, ''),
-    // openspec ships as an npm-installed `.cmd` shim on Windows, not a real
-    // .exe like git; execFile only runs .cmd files through a shell. Folding
-    // the command into one string (no args array) avoids Node's DEP0190
-    // warning for shell:true + args.
-    openspecVersion: async () => (await execFileP('openspec --version', [], { shell: true })).stdout.trim(),
+    // Same probe shape as the real call site (src/openspec/cli.ts): execa
+    // resolves Windows .cmd/.bat shims via cross-spawn without a shell, so a
+    // missing binary still yields ENOENT (what isNotFoundError expects) on
+    // every platform, instead of a shell-reported exit 127/"not found".
+    openspecVersion: async () => (await execa('openspec', ['--version'])).stdout.trim(),
     env: process.env,
   };
 }
@@ -118,10 +119,14 @@ async function openspecCheck(probe: () => Promise<string>): Promise<DoctorCheck>
         hint: 'npm i -g @fission-ai/openspec; validate_change and the create pipeline need it.',
       };
     }
+    // Collapse embedded newlines/whitespace from a raw shell/subprocess error:
+    // formatDoctor's column layout assumes a single-line detail, and wrapWords
+    // splits on plain spaces only.
+    const rawMessage = (err as Error).message || String(err);
     return {
       name: 'openspec',
       status: 'fail',
-      detail: (err as Error).message || String(err),
+      detail: rawMessage.replace(/\s+/g, ' ').trim(),
     };
   }
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -44,6 +44,7 @@ export interface DoctorDeps {
   nodeVersion: string;
   kicadVersion: () => Promise<string>;
   gitVersion: () => Promise<string>;
+  openspecVersion: () => Promise<string>;
   env: NodeJS.ProcessEnv;
 }
 
@@ -54,6 +55,12 @@ function defaultDeps(): DoctorDeps {
     // `git --version` prints "git version 2.34.1"; keep only the number, the
     // report already labels the row "git".
     gitVersion: async () => (await execFileP('git', ['--version'])).stdout.trim().replace(/^git version\s+/, ''),
+    // openspec ships as an npm-installed `.cmd` shim on Windows, not a real
+    // .exe like git; execFile only runs .cmd files through a shell. Folding
+    // the command into one string (no args array) avoids Node's DEP0190
+    // warning for shell:true + args, which doesn't apply here anyway since
+    // the command is a fixed literal, not user input.
+    openspecVersion: async () => (await execFileP('openspec --version', [], { shell: true })).stdout.trim(),
     env: process.env,
   };
 }
@@ -95,6 +102,19 @@ async function gitCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
       status: 'fail',
       detail: 'not found on PATH',
       hint: 'install git; copperhead snapshots and commits its work.',
+    };
+  }
+}
+
+async function openspecCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
+  try {
+    return { name: 'openspec', status: 'ok', detail: await probe() };
+  } catch {
+    return {
+      name: 'openspec',
+      status: 'fail',
+      detail: 'not found on PATH',
+      hint: 'npm i -g @fission-ai/openspec; validate_change and the create pipeline need it.',
     };
   }
 }
@@ -380,6 +400,7 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorReport> {
     nodeCheck(deps.nodeVersion),
     await kicadCheck(deps.kicadVersion),
     await gitCheck(deps.gitVersion),
+    await openspecCheck(deps.openspecVersion), // new
     providerCheck(opts.model, config, deps.env),
   ];
   if (resolvedModel) {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -57,10 +57,14 @@ function defaultDeps(): DoctorDeps {
     // `git --version` prints "git version 2.34.1"; keep only the number, the
     // report already labels the row "git".
     gitVersion: async () => (await execFileP('git', ['--version'])).stdout.trim().replace(/^git version\s+/, ''),
-    // Same probe shape as the real call site (src/openspec/cli.ts): execa
-    // resolves Windows .cmd/.bat shims via cross-spawn without a shell, so a
-    // missing binary still yields ENOENT (what isNotFoundError expects) on
-    // every platform, instead of a shell-reported exit 127/"not found".
+    /**
+     * Probes `openspec --version` via execa, the same probe shape as the real
+     * call site (src/openspec/cli.ts): execa resolves Windows .cmd/.bat shims
+     * via cross-spawn without a shell, so a missing binary still yields ENOENT
+     * (what isNotFoundError expects) on every platform, instead of a
+     * shell-reported exit 127/"not found".
+     * @returns the trimmed stdout of `openspec --version` (e.g. "0.1.0").
+     */
     openspecVersion: async () => (await execa('openspec', ['--version'])).stdout.trim(),
     env: process.env,
   };
@@ -107,6 +111,17 @@ async function gitCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
   }
 }
 
+/**
+ * Report whether the `openspec` CLI is reachable, needed for `validate_change`
+ * and the `create` pipeline. Fails soft like `kicadCheck`/`gitCheck`: a
+ * missing or erroring probe is returned as a `fail` check, never thrown.
+ * @param probe resolves the openspec version string, or rejects if the CLI
+ *   can't be run (e.g. not found on PATH).
+ * @returns an `ok` check with the version on success; a `fail` check with an
+ *   install hint when `probe` rejects with a not-found error (per
+ *   `isNotFoundError`), or a `fail` check with the flattened error message
+ *   otherwise.
+ */
 async function openspecCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
   try {
     return { name: 'openspec', status: 'ok', detail: await probe() };

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -63,7 +63,7 @@ function defaultDeps(): DoctorDeps {
      * via cross-spawn without a shell, so a missing binary still yields ENOENT
      * (what isNotFoundError expects) on every platform, instead of a
      * shell-reported exit 127/"not found".
-     * @returns the trimmed stdout of `openspec --version` (e.g. "0.1.0").
+     * @returns the trimmed stdout of `openspec --version` (e.g. "1.8.0").
      */
     openspecVersion: async () => (await execa('openspec', ['--version'])).stdout.trim(),
     env: process.env,

--- a/src/util/preflight.ts
+++ b/src/util/preflight.ts
@@ -27,14 +27,18 @@ export function isNotFoundError(err: any): boolean {
   if (!err) return false;
   if (err.code === 'ENOENT') return true;
   if (process.platform === 'win32') {
+    // execa exposes the exit code as `.exitCode`; node's built-in
+    // child_process (e.g. promisify(execFile)) puts it on `.code` instead —
+    // fall back so both shapes are covered.
+    const exitCode = typeof err.exitCode === 'number' ? err.exitCode : err.code;
     const msg = String(err.stderr || err.message || '');
-    if (err.exitCode === 9009) {
+    if (exitCode === 9009) {
       return (
         msg.includes('is not recognized') ||
         msg.includes('cannot find the path specified')
       );
     }
-    if (err.exitCode === 1) {
+    if (exitCode === 1) {
       return msg.includes('is not recognized');
     }
   }

--- a/src/util/preflight.ts
+++ b/src/util/preflight.ts
@@ -27,18 +27,14 @@ export function isNotFoundError(err: any): boolean {
   if (!err) return false;
   if (err.code === 'ENOENT') return true;
   if (process.platform === 'win32') {
-    // execa exposes the exit code as `.exitCode`; node's built-in
-    // child_process (e.g. promisify(execFile)) puts it on `.code` instead —
-    // fall back so both shapes are covered.
-    const exitCode = typeof err.exitCode === 'number' ? err.exitCode : err.code;
     const msg = String(err.stderr || err.message || '');
-    if (exitCode === 9009) {
+    if (err.exitCode === 9009) {
       return (
         msg.includes('is not recognized') ||
         msg.includes('cannot find the path specified')
       );
     }
-    if (exitCode === 1) {
+    if (err.exitCode === 1) {
       return msg.includes('is not recognized');
     }
   }

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -280,6 +280,8 @@ describe('copperhead doctor', () => {
         }),
       });
       const os = r.checks.find((c) => c.name === 'openspec')!;
+      expect(os.status).toBe('fail');
+      expect(os.detail).toContain('openspec: not found');
       expect(os.detail).not.toContain('\n');
     } finally {
       await cleanup();

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -16,6 +16,7 @@ function deps(over: Partial<DoctorDeps> = {}): Partial<DoctorDeps> {
     nodeVersion: 'v20.0.0',
     kicadVersion: async () => 'kicad-cli 9.0.0',
     gitVersion: async () => 'git version 2.43.0',
+    openspecVersion: async () => 'openspec 1.8.0',
     env: {},
     ...over,
   };
@@ -233,6 +234,53 @@ describe('copperhead doctor', () => {
       const git = r.checks.find((c) => c.name === 'git')!;
       expect(git.status).toBe('fail');
       expect(git.hint).toMatch(/install git/i);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('reports a missing openspec as a failure with an install hint (does not throw)', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const r = await runDoctor({
+        repoRoot: repo,
+        model: 'claude-code',
+        deps: deps({
+          openspecVersion: async () => {
+            throw Object.assign(new Error('spawn openspec ENOENT'), { code: 'ENOENT' });
+          },
+        }),
+      });
+      const os = r.checks.find((c) => c.name === 'openspec')!;
+      expect(os.status).toBe('fail');
+      expect(os.hint).toContain('@fission-ai/openspec');
+      expect(r.ok).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a raw multi-line shell error never reaches the report unflattened (regression)', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      // A shell-shaped error (exit 127, not ENOENT) is not the "not found"
+      // case the probe itself can produce (execa yields ENOENT for that on
+      // every platform), but any unexpected error must still land as a
+      // single line so it cannot break formatDoctor's column layout.
+      const r = await runDoctor({
+        repoRoot: repo,
+        model: 'claude-code',
+        deps: deps({
+          openspecVersion: async () => {
+            throw Object.assign(
+              new Error('Command failed: openspec --version\n/bin/sh: 1: openspec: not found\n'),
+              { code: 127 },
+            );
+          },
+        }),
+      });
+      const os = r.checks.find((c) => c.name === 'openspec')!;
+      expect(os.detail).not.toContain('\n');
     } finally {
       await cleanup();
     }


### PR DESCRIPTION
## What

`copperhead doctor` now checks whether the `openspec` CLI is present on PATH, alongside its existing node/kicad-cli/git/provider checks.

## Why

Closes #190.

`doctor` previously reported `ready` even when `openspec` was completely missing. The failure only surfaced later, inside the `spec-seed` stage, when `validate_change` tried to shell out to `openspec` and failed, after real turns and tokens were already spent. Confirmed this cost roughly 70 minutes and 54.7k output tokens across two real runs before the root cause was clear.

## Design

Adds `openspecCheck`, following the exact same pattern as `kicadCheck` and `gitCheck`: a `DoctorDeps.openspecVersion` probe, wired into `defaultDeps()`, added to the `checks` array in `runDoctor` right after `gitCheck`.

One additional Windows-specific bug found and fixed while testing: `openspec` installed via `npm install -g` (the standard install path the check's own hint recommends) resolves to an `.cmd` shim on Windows, not a real `.exe`. Node's `execFile` cannot run `.cmd` files directly without `shell: true`, so the naive probe (matching `gitVersion`'s exact pattern) false-negatived even when `openspec` was genuinely installed and working from a real shell. Using `shell: true` with an args array also triggers Node's `DEP0190` deprecation warning, so the command is folded into a single string with an empty args array instead, avoiding both issues.

Does not touch spec-gating, verification-gating, or any mutation path; this is a read-only diagnostic addition, same category as the existing checks.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | not run (no test file added for this check yet) |
| Live-LLM (opt-in) | n/a | n/a |

### Manual test log (required)

- Sandbox variant used: n/a (doctor is a standalone diagnostic command, not exercised through the create/edit sandbox)
- Commands run and outcome:

```text
$ where openspec
(empty — confirmed genuinely absent from PATH)

$ node dist/cli.js doctor
  [FAIL] openspec  not found on PATH
         hint: npm i -g @fission-ai/openspec; validate_change and the create
               pipeline need it.

$ npm install -g @fission-ai/openspec
$ node dist/cli.js doctor
  [ok]   openspec  1.8.0
```

Both states confirmed directly: fail when genuinely absent, pass with the correct version string once installed. Also confirmed the Windows `.cmd` shim fix specifically, the naive `execFile` probe false-failed even with `openspec` installed and working from a real shell, until `shell: true` (folded into a single command string to avoid the `DEP0190` warning) was added.

## Docs

None touched. No README/config reference mentions doctor's check list in enough detail to need updating.

---

## Invariant checklist

- [x] **Spec-gated in**: no change to tool exposure or the unlock path.
- [x] **Verification-gated out**: no change to ERC/DRC gates or rollback.
- [x] **`check`/`verify` stays LLM-free and network-free**: `doctor` is a separate, already LLM-free/network-free command; this check is the same subprocess-probe pattern already used for `kicad-cli`/`git`.
- [x]  **No sexp serialization**: not touched.
- [x]  **Sync-obligations ledger**: not touched.
- [x]  **Secrets**: no credential handling; no new transcript output.
- [x]  **Spec coherence**: no spec-level behavior change; this is a diagnostic-only addition to `doctor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenSpec availability and version diagnostics to the Doctor command.
  * Reports when OpenSpec is unavailable or when version detection encounters an error.
* **Bug Fixes**
  * Improved diagnostic readability by presenting multi-line probe errors as concise, single-line messages.
* **Documentation**
  * Updated the Doctor command documentation to include OpenSpec in environment checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->