### PR TITLE
fix(draft): labelled stubs avoid foreign contact; name wire merges for what they are

### DIFF
--- a/src/kicad/draft/draft.ts
+++ b/src/kicad/draft/draft.ts
@@ -75,13 +75,19 @@ export async function draftSchematicToText(opts: SchematicDraftOptions): Promise
   if (report.mergedNets.length) {
     const findings = report.mergedNets.map((m) => ({
       detail:
-        `nets ${m.nets.join(' and ')} share a label position at (${m.x}, ${m.y}), which merges them into one net — ` +
-        `the drawn netlist would not match the intent. This is an engine placement fault, not an intent error: the ` +
-        `de-collision pass already treats foreign labels as obstacles and, failing that, moves a label off a shared ` +
-        `point even at the cost of overlapping text, so reaching this state means both labels were immovable ` +
-        `(wired-net labels carry no stub to ride) or the sheet is too dense to separate them. Reshaping the IR is ` +
-        `unlikely to help and should not be attempted more than once — report it against the engine with the intent ` +
-        `that produced it.`,
+        m.via === 'wires'
+          ? `nets ${m.nets.join(' and ')} come into WIRE contact at (${m.x}, ${m.y}) — a wire endpoint or label of one ` +
+            `rests on the other's wire, which KiCad joins into one net, so the drawn netlist would not match the ` +
+            `intent. This is an engine routing/placement fault, not an intent error; the engine's own avoidance ` +
+            `should have prevented it. Reshaping the IR is unlikely to help and should not be attempted more than ` +
+            `once — report it against the engine with the intent that produced it.`
+          : `nets ${m.nets.join(' and ')} share a label position at (${m.x}, ${m.y}), which merges them into one net — ` +
+            `the drawn netlist would not match the intent. This is an engine placement fault, not an intent error: the ` +
+            `de-collision pass already treats foreign labels as obstacles and, failing that, moves a label off a shared ` +
+            `point even at the cost of overlapping text, so reaching this state means both labels were immovable ` +
+            `(wired-net labels carry no stub to ride) or the sheet is too dense to separate them. Reshaping the IR is ` +
+            `unlikely to help and should not be attempted more than once — report it against the engine with the intent ` +
+            `that produced it.`,
     }));
     return { ok: false, findings, message: formatIrFindings(findings) };
   }

--- a/src/kicad/draft/engine.ts
+++ b/src/kicad/draft/engine.ts
@@ -86,7 +86,7 @@ export interface SchematicDraftReport {
    * them into one net in the emitted sheet. Non-empty means the drawing does
    * not implement the IR, so the caller must refuse the draft.
    */
-  mergedNets: { x: number; y: number; nets: string[] }[];
+  mergedNets: { x: number; y: number; nets: string[]; via?: 'labels' | 'wires' }[];
   /**
    * Labels whose TEXT still overlaps a foreign net's label after de-collision.
    * The netlist is correct — these are legibility defects, tolerated up to
@@ -1119,6 +1119,49 @@ export function draftSchematicPlacement(validated: ValidatedIntent, projectName:
 
   // signal nets: local nets wired, everything else labelled at a stub
   const bodies = [...placed.values()].map((p) => p.body);
+  /**
+   * True when any of `segs` touches a FOREIGN connection point: a pin, the
+   * stub end any connected pin grows (predicted — stubs of nets sorted later
+   * are not emitted yet), or an already-emitted wire of another net. KiCad
+   * joins wires at coincident endpoints and at an endpoint on a wire's
+   * interior, so any such contact merges nets (I22, #204). Used by the
+   * trunk-and-branch veto AND the labelled-stub fallback — the cap-to-ground
+   * drop placed a cap whose own 2-unit stub ended exactly on the neighbouring
+   * power pin's stub interior, so stubs need the check as much as trunks.
+   */
+  const touchesForeign = (
+    segs: { x1: number; y1: number; x2: number; y2: number }[],
+    netName: string,
+    ownEps: Set<string>,
+  ): boolean => {
+    for (const [oref, opl] of placed) {
+      for (const pin of opl.sym.pins) {
+        const ep = `${oref}.${pin.number}`;
+        const onet = netByEndpoint.get(ep);
+        if (!onet || onet.name === netName || ownEps.has(ep)) continue;
+        const o = outward(pin);
+        const len = (netClasses.get(onet.name)?.cls ?? 'signal') !== 'signal' && o.dx !== 0 ? STUB + 2 : STUB;
+        const p = pinAt(opl, pin);
+        const end = { x: p.x + o.dx * len * U, y: p.y + o.dy * len * U };
+        if (segs.some((c) => pointOnSeg(p.x, p.y, c) || pointOnSeg(end.x, end.y, c))) return true;
+      }
+    }
+    for (const w of wires) {
+      if (w.net === netName) continue;
+      if (
+        segs.some(
+          (c) =>
+            pointOnSeg(w.x1, w.y1, c) ||
+            pointOnSeg(w.x2, w.y2, c) ||
+            pointOnSeg(c.x1, c.y1, w) ||
+            pointOnSeg(c.x2, c.y2, w),
+        )
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
   let wired = 0;
   let labelled = 0;
   for (const net of [...signalNets].sort((a, b) => a.name.localeCompare(b.name))) {
@@ -1160,53 +1203,11 @@ export function draftSchematicPlacement(validated: ValidatedIntent, projectName:
           candidate.push({ x1: trunkX, y1: meetYs[i - 1]!, x2: trunkX, y2: meetYs[i]! });
         }
         if (candidate.some((c) => bodies.some((b) => segCrossesBody(c.x1, c.y1, c.x2, c.y2, b)))) continue;
-        // No candidate segment may touch a FOREIGN connection point: a pin,
-        // the stub end every connected pin grows (labelled stubs of nets
-        // sorted later are not emitted yet, so they must be predicted), or an
-        // already-emitted wire of another net. KiCad joins wires at coincident
-        // endpoints and at an endpoint on a wire's interior, so a trunk
-        // routed down a column of neighbouring stub ends silently merges
-        // nets — the lemondrop run drew the crystal drive onto TOUCH_IRQ
-        // exactly this way (I22, #204). Mirrors the chain pass's axisClear,
+        // No candidate segment may touch a foreign connection point (I22,
+        // #204): a trunk routed down a column of neighbouring stub ends
+        // silently merges nets. Mirrors the chain pass's axisClear,
         // generalized to every candidate segment.
-        const ownEps = new Set(net.pins);
-        let touchesForeign = false;
-        for (const [oref, opl] of placed) {
-          if (touchesForeign) break;
-          for (const pin of opl.sym.pins) {
-            const ep = `${oref}.${pin.number}`;
-            const onet = netByEndpoint.get(ep);
-            if (!onet || onet.name === net.name || ownEps.has(ep)) continue;
-            const o = outward(pin);
-            const len = (netClasses.get(onet.name)?.cls ?? 'signal') !== 'signal' && o.dx !== 0 ? STUB + 2 : STUB;
-            const p = pinAt(opl, pin);
-            const end = { x: p.x + o.dx * len * U, y: p.y + o.dy * len * U };
-            if (candidate.some((c) => pointOnSeg(p.x, p.y, c) || pointOnSeg(end.x, end.y, c))) {
-              if (process.env.COPPERHEAD_DEBUG_VETO) console.error(`VETO ${net.name}: foreign pin/stub ${ep} (${onet.name}) pin(${p.x},${p.y}) end(${end.x},${end.y})`);
-              touchesForeign = true;
-              break;
-            }
-          }
-        }
-        if (!touchesForeign) {
-          for (const w of wires) {
-            if (w.net === net.name) continue;
-            if (
-              candidate.some(
-                (c) =>
-                  pointOnSeg(w.x1, w.y1, c) ||
-                  pointOnSeg(w.x2, w.y2, c) ||
-                  pointOnSeg(c.x1, c.y1, w) ||
-                  pointOnSeg(c.x2, c.y2, w),
-              )
-            ) {
-              if (process.env.COPPERHEAD_DEBUG_VETO) console.error(`VETO ${net.name}: emitted wire of ${w.net} (${w.x1},${w.y1})-(${w.x2},${w.y2})`);
-              touchesForeign = true;
-              break;
-            }
-          }
-        }
-        if (touchesForeign) continue;
+        if (touchesForeign(candidate, net.name, new Set(net.pins))) continue;
         for (const c of candidate) addWire(net.name, c.x1, c.y1, c.x2, c.y2);
         // one label names the wired net (topmost-leftmost wire point): the net
         // stays identifiable to PINOUT/drift and to a reviewer without a
@@ -1232,10 +1233,30 @@ export function draftSchematicPlacement(validated: ValidatedIntent, projectName:
     }
     if (!asWire) {
       for (const s of stubs) {
-        addWire(net.name, s.ep.at.x, s.ep.at.y, s.end.x, s.end.y);
+        // A stub is a wire too: its endpoint resting on a foreign net's wire
+        // or connection point merges nets exactly like a trunk would (the
+        // cap-to-ground drop's 2-unit stub ended on the neighbouring power
+        // pin's stub interior — I22's third face). Grow the stub a grid unit
+        // at a time until the endpoint is clear; the interior then CROSSES
+        // the foreign wire mid-segment, which does not connect. If no length
+        // clears, emit the plain stub and let the merged-net gate refuse
+        // loudly rather than ship the contact.
+        let end = s.end;
+        const own = new Set(net.pins);
+        for (let extra = 0; extra <= 2; extra++) {
+          const cand = {
+            x: s.ep.at.x + s.o.dx * (STUB + extra) * U,
+            y: s.ep.at.y + s.o.dy * (STUB + extra) * U,
+          };
+          if (!touchesForeign([{ x1: s.ep.at.x, y1: s.ep.at.y, x2: cand.x, y2: cand.y }], net.name, own)) {
+            end = cand;
+            break;
+          }
+        }
+        addWire(net.name, s.ep.at.x, s.ep.at.y, end.x, end.y);
         // labels are always horizontal (drafting standard): leftward pins read
         // outward to the left, everything else extends to the right
-        labels.push({ name: net.name, x: s.end.x, y: s.end.y, rot: s.o.dx === -1 ? 180 : 0 });
+        labels.push({ name: net.name, x: end.x, y: end.y, rot: s.o.dx === -1 ? 180 : 0 });
         stubbedLabels.push({ label: labels.length - 1, wire: wires.length - 1, o: s.o });
         labelled++;
       }
@@ -1487,7 +1508,10 @@ export function draftSchematicPlacement(validated: ValidatedIntent, projectName:
   // pipeline loudly, while a merged net passes ERC-as-warning and flows into
   // layout and fabrication outputs. Reported as a hard finding — the netlist
   // the IR declared is not the netlist that got drawn.
-  const mergedNets = [...findMergedNets(labels), ...findWireContactMerges(wires, labels)];
+  const mergedNets = [
+    ...findMergedNets(labels).map((m) => ({ ...m, via: 'labels' as const })),
+    ...findWireContactMerges(wires, labels).map((m) => ({ ...m, via: 'wires' as const })),
+  ];
 
   // Overlapping label TEXT is the other half of the same pass and deliberately
   // not a gate. The de-collision loop clears what it can and, where it cannot,

--- a/test/net-merge-guard.test.ts
+++ b/test/net-merge-guard.test.ts
@@ -166,3 +166,46 @@ Connector.
     }
   });
 });
+
+describe('labelled-stub fallback avoids foreign contact (I22 third face)', () => {
+  // BUCK_SS shape from lemondrop attempt-06: a two-pin net from an IC pin to
+  // a cap whose other terminal is GND. The chain drop places the cap below
+  // the stub axis, the wired route is correctly vetoed, and the fallback
+  // stub's 2-unit endpoint would land exactly on the neighbouring power
+  // pin's stub interior. The stub must grow past the contact (its interior
+  // then crosses the foreign wire mid-segment, which does not connect), and
+  // the draft must succeed with disjoint nets.
+  it('grows the stub past a foreign power-stub row instead of merging', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'copperhead-capdrop-'));
+    try {
+      await mkdir(path.join(repo, 'docs'), { recursive: true });
+      await writeFile(path.join(repo, 'docs', 'SUBSYSTEMS.md'), '## Main\n', 'utf8');
+      await writeFile(
+        path.join(repo, 'schematic.intent.json'),
+        JSON.stringify({
+          version: 1,
+          parts: [
+            { ref: 'U1', libId: 'CopperMCU:MCU8', value: 'MCU8', footprint: 'X:Y', group: 'Main' },
+            { ref: 'C9', libId: 'Device:C', value: '100n', footprint: 'X:Y', group: 'Main' },
+          ],
+          nets: [
+            { name: 'BUCK_SS', pins: ['U1.3', 'C9.1'] },
+            { name: 'GND', pins: ['C9.2', 'U1.2'] },
+          ],
+          noConnect: ['U1.1', 'U1.4', 'U1.5', 'U1.6', 'U1.7', 'U1.8'],
+        }),
+        'utf8',
+      );
+      const res = await draftSchematicToText({
+        repoRoot: repo,
+        schematic: 'board.kicad_sch',
+        intentPath: 'schematic.intent.json',
+        docsDir: 'docs',
+        symbolDirs: [SYMLIB],
+      });
+      expect(res.ok, res.ok ? '' : (res as { message: string }).message).toBe(true);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes the third face of #204 (harness I22), found live by lemondrop attempt-06.

## Why

A cap-to-ground drop (`BUCK_SS`: U1.9 → C9.1, with C9.2 on GND) places the cap below the pin's stub axis. After #205, the wired route through the neighbouring power-pin row is correctly vetoed — but the labelled fallback then draws the cap's 2-unit stub unconditionally, and its endpoint lands exactly on that power pin's stub interior: the same KiCad endpoint-on-interior join, one pass further down. The agent burned two stage-attempts on it, partly because the finding was rendered with the label-co-location message ("share a label position... both labels were immovable"), which describes a different fault and steered the diagnosis wrong.

## What

1. The trunk veto's foreign-contact check is extracted into a shared `touchesForeign()`, and the labelled-stub fallback uses it: a stub whose endpoint would rest on a foreign wire or connection point grows one grid unit at a time (bounded at +2) until the endpoint clears — the stub's interior then crosses the foreign wire mid-segment, which does not connect. If no length clears, the plain stub is emitted and the merged-net gate refuses loudly rather than shipping the contact.
2. Merged-net findings carry `via: 'labels' | 'wires'` and wire-contact merges get their own message naming the mechanism, so agents (and humans) stop diagnosing routing faults as label-placement faults.
3. Drops the `COPPERHEAD_DEBUG_VETO` instrumentation that slipped into #205.

## Testing

| Check | Result |
| --- | --- |
| Typecheck | pass |
| Full suite | 769 passed, 0 failed |
| Golden corpus | byte-identical (no regeneration needed) |
| Regression | the exact `BUCK_SS`/`GND` shape from attempt-06 drafts clean (new test in `net-merge-guard.test.ts`) |

## Invariant checklist

- [ ] N/A **Spec-gated in**: no tool-list change.
- [x] **Verification-gated out**: unchanged gates; the fallback now avoids what the gate would refuse.
- [x] **check/verify stays LLM-free and network-free**: geometry-only code.
- [x] **No sexp serialization**: engine emitter only.
- [ ] N/A **Sync-obligations ledger / Secrets**: untouched.
- [x] **Deterministic tests**: fixture symbols only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schematic routing to prevent unintended wire contacts with unrelated pins, stubs, and wires.
  * Extended labeled connections when needed to avoid routing conflicts.
  * Clarified merge findings by distinguishing wire-contact collisions from shared-label collisions and reporting affected nets and locations.
* **Tests**
  * Added coverage for labeled-stub routing to verify successful schematic drafting in collision-prone layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->