### PR TITLE
test(draft): exercise the drafting engine as a component, off the disk path

### DIFF
--- a/test/draft-engine-component.test.ts
+++ b/test/draft-engine-component.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest';
+import {
+  declaredNets,
+  drawnNets,
+  intentOf,
+  part,
+  pinPoint,
+  place,
+  pointKey,
+  symbolOf,
+  tryValidate,
+  U,
+} from './support/draft-harness.js';
+import type { SchematicIntent } from '../src/kicad/draft/ir.js';
+
+/**
+ * The drafting engine as a component: IR in, placement model out, nothing else
+ * in the loop. No repo, no vendored cache, no kicad-cli, no CLI, no agent — see
+ * test/support/draft-harness.ts for the seam.
+ *
+ * The other draft suites each pin one board: the reference IR drafts to these
+ * exact bytes, this geometry lands at these coordinates. Those catch
+ * regressions on the boards they name. What they cannot say is whether a
+ * contract holds for boards nobody wrote a fixture for.
+ *
+ * So this file is organised the other way round: a family of intents, and
+ * contracts asserted across all of them. A change that satisfies the reference
+ * board by special-casing it fails here on the sibling that was not special-cased.
+ */
+
+/** Voltage divider off a 3-pin header — the reference topology, inline. */
+const divider: SchematicIntent = intentOf({
+  parts: [
+    part('J1', 'CopperConn:Conn_01x03', 'Conn_01x03', 'Power'),
+    part('U1', 'CopperMCU:MCU8', 'MCU8', 'MCU'),
+    part('R1', 'Device:R', '10k', 'MCU'),
+    part('R2', 'Device:R', '10k', 'MCU'),
+    part('C1', 'Device:C', '100n', 'MCU'),
+  ],
+  nets: [
+    { name: 'VCC', pins: ['J1.1', 'U1.1', 'C1.1'] },
+    { name: 'GND', pins: ['J1.2', 'U1.2', 'R2.2', 'C1.2'] },
+    { name: 'SIG_IN', pins: ['J1.3', 'R1.1'] },
+    { name: 'DIV', pins: ['R1.2', 'R2.1', 'U1.3'] },
+  ],
+  noConnect: ['U1.4', 'U1.5', 'U1.6', 'U1.7', 'U1.8'],
+});
+
+/** Four caps in a row across one rail pair: the alignment-heavy shape. */
+const decoupling: SchematicIntent = intentOf({
+  parts: [
+    part('U1', 'CopperMCU:MCU8', 'MCU8', 'MCU'),
+    ...[1, 2, 3, 4].map((i) => part(`C${i}`, 'Device:C', '100n', 'Power')),
+  ],
+  nets: [
+    { name: 'VCC', pins: ['U1.1', 'C1.1', 'C2.1', 'C3.1', 'C4.1'] },
+    { name: 'GND', pins: ['U1.2', 'C1.2', 'C2.2', 'C3.2', 'C4.2'] },
+  ],
+  noConnect: ['U1.3', 'U1.4', 'U1.5', 'U1.6', 'U1.7', 'U1.8'],
+});
+
+/** Two MCUs on shared rails with a signal between them: cross-group routing. */
+const twoMcu: SchematicIntent = intentOf({
+  parts: [
+    part('U1', 'CopperMCU:MCU8', 'MCU8', 'Left'),
+    part('U2', 'CopperMCU:MCU8', 'MCU8', 'Right'),
+    part('R1', 'Device:R', '100', 'Left'),
+  ],
+  nets: [
+    { name: 'VCC', pins: ['U1.1', 'U2.1'] },
+    { name: 'GND', pins: ['U1.2', 'U2.2'] },
+    { name: 'LINK', pins: ['U1.4', 'R1.1'] },
+    { name: 'LINK_TERM', pins: ['R1.2', 'U2.3'] },
+  ],
+  noConnect: ['U1.3', 'U1.5', 'U1.6', 'U1.7', 'U1.8', 'U2.4', 'U2.5', 'U2.6', 'U2.7', 'U2.8'],
+});
+
+/** A series RC from a pin to ground: the drop-chain shape, minimal. */
+const seriesChain: SchematicIntent = intentOf({
+  parts: [
+    part('U1', 'CopperMCU:MCU8', 'MCU8', 'MCU'),
+    part('R1', 'Device:R', '1k', 'MCU'),
+    part('C1', 'Device:C', '10n', 'MCU'),
+    part('C2', 'Device:C', '100n', 'MCU'),
+  ],
+  nets: [
+    { name: 'VCC', pins: ['U1.1', 'C2.1'] },
+    { name: 'GND', pins: ['U1.2', 'C1.2', 'C2.2'] },
+    { name: 'SENSE', pins: ['U1.4', 'R1.1'] },
+    { name: 'FILT', pins: ['R1.2', 'C1.1'] },
+  ],
+  noConnect: ['U1.3', 'U1.5', 'U1.6', 'U1.7', 'U1.8'],
+});
+
+/**
+ * The smallest board the IR permits: rails only, every signal pin unused. A
+ * single part cannot be it — a net needs two endpoints — so the floor is one
+ * part plus its decoupling cap.
+ */
+const minimal: SchematicIntent = intentOf({
+  parts: [part('U1', 'CopperMCU:MCU8', 'MCU8', 'MCU'), part('C1', 'Device:C', '100n', 'MCU')],
+  nets: [
+    { name: 'VCC', pins: ['U1.1', 'C1.1'] },
+    { name: 'GND', pins: ['U1.2', 'C1.2'] },
+  ],
+  noConnect: ['U1.3', 'U1.4', 'U1.5', 'U1.6', 'U1.7', 'U1.8'],
+});
+
+const BOARDS: { name: string; intent: SchematicIntent }[] = [
+  { name: 'divider', intent: divider },
+  { name: 'decoupling', intent: decoupling },
+  { name: 'twoMcu', intent: twoMcu },
+  { name: 'seriesChain', intent: seriesChain },
+  { name: 'minimal', intent: minimal },
+];
+
+/** True when a coordinate is an exact multiple of the 1.27 mm grid. */
+const onGrid = (v: number): boolean => Math.abs(v / U - Math.round(v / U)) < 1e-9;
+
+describe.each(BOARDS)('engine contracts hold for every board: $name', ({ intent }) => {
+  /**
+   * The load-bearing one. Every other check in this file is about how the sheet
+   * reads; this is about whether it is the circuit that was asked for. Read
+   * back through the production parser, so it fails if the engine draws a net
+   * the IR never declared or drops one it did.
+   */
+  it('draws exactly the declared netlist, pin for pin', async () => {
+    const drawn = await drawnNets(intent);
+    const declared = declaredNets(intent);
+    const actual = new Map([...declared.keys()].map((pin) => [pin, drawn.get(pin)]));
+    expect(actual).toEqual(new Map([...declared]));
+  });
+
+  /**
+   * A merge is the one defect the engine may never ship — the sheet would be
+   * wrong rather than ugly — so the report must come back empty, not merely
+   * warn. draftSchematicToText refuses on a non-empty list; this asserts the
+   * refusal never has cause to fire.
+   */
+  it('shorts nothing: no two nets share a point', async () => {
+    const { report } = await place(intent);
+    expect(report.mergedNets).toEqual([]);
+  });
+
+  it('places every declared part exactly once, carrying its value', async () => {
+    const placed = await place(intent);
+    // `#PWR`/`#FLG` refdes are the engine's own power ports and flags, not IR parts.
+    const parts = placed.model.symbols.filter((s) => !s.ref.startsWith('#'));
+    expect(parts.map((s) => s.ref).sort()).toEqual(intent.parts.map((p) => p.ref).sort());
+    for (const p of intent.parts) {
+      expect({ ref: p.ref, value: symbolOf(placed, p.ref).value }).toEqual({ ref: p.ref, value: p.value });
+    }
+  });
+
+  /**
+   * KiCad joins connections on exact coordinates: a pin off the 1.27 grid
+   * cannot be wired to without a stub the engine did not plan, so off-grid is
+   * a connectivity bug that happens to look like a cosmetic one.
+   */
+  it('lands every connected pin on the 1.27 grid', async () => {
+    const placed = await place(intent);
+    for (const pin of declaredNets(intent).keys()) {
+      const [ref, number] = pin.split('.') as [string, string];
+      const { x, y } = pinPoint(placed, ref, number);
+      expect({ pin, x: onGrid(x), y: onGrid(y) }).toEqual({ pin, x: true, y: true });
+    }
+  });
+
+  /**
+   * An unconnected pin needs its no-connect marker on the pin itself. One
+   * placed a grid step away leaves ERC reporting the pin unconnected AND the
+   * marker dangling, which is how a stale marker survives a re-draft.
+   */
+  it('marks every no-connect on the pin it belongs to', async () => {
+    const placed = await place(intent);
+    const declared = intent.noConnect ?? [];
+    expect(placed.report.noConnects).toBe(declared.length);
+    const markers = new Set(placed.model.noConnects.map((n) => pointKey(n.x, n.y)));
+    for (const pin of declared) {
+      const [ref, number] = pin.split('.') as [string, string];
+      const { x, y } = pinPoint(placed, ref, number);
+      expect({ pin, marked: markers.has(pointKey(x, y)) }).toEqual({ pin, marked: true });
+    }
+  });
+
+  /**
+   * The engine is pure by construction — no clock, no random, no ambient
+   * config — and the byte-level goldens depend on it. Asserted on the model
+   * rather than the text so a failure names the field that drifted.
+   */
+  it('is deterministic: two placements of one intent are identical', async () => {
+    const a = await place(intent);
+    const b = await place(intent);
+    expect(b.model).toEqual(a.model);
+    expect(b.report).toEqual(a.report);
+  });
+});
+
+describe('rails and signals are told apart from pin types alone', () => {
+  it('classifies undeclared nets by what they connect to', async () => {
+    const { report } = await place(divider);
+    const byName = new Map(report.netClasses.map((n) => [n.name, n.class]));
+    expect(byName.get('VCC')).toBe('rail');
+    expect(byName.get('GND')).toBe('ground');
+    expect(byName.get('SIG_IN')).toBe('signal');
+    expect(byName.get('DIV')).toBe('signal');
+    expect(report.netClasses.every((n) => !n.overridden)).toBe(true);
+  });
+
+  /**
+   * A rail is drawn as a per-pin power port, never as a wire spanning the
+   * sheet, so every rail gets a pwrFlag and no signal does.
+   */
+  it('gives every rail a power flag and no signal one', async () => {
+    const { report } = await place(divider);
+    expect(report.pwrFlags).toEqual(['GND', 'VCC']);
+  });
+});
+
+describe('the engine refuses an IR it cannot draw faithfully', () => {
+  it('names a pin that no symbol has, and lists the ones it does', async () => {
+    const bad = intentOf({
+      ...minimal,
+      nets: [...minimal.nets, { name: 'GHOST', pins: ['U1.99', 'C1.1'] }],
+    });
+    const v = await tryValidate(bad);
+    expect(v.ok).toBe(false);
+    const detail = v.findings.map((f) => f.detail).join('; ');
+    expect(detail).toContain('U1 has no pin 99');
+    expect(detail).toContain('[1, 2, 3, 4, 5, 6, 7, 8]');
+  });
+
+  it('names a net endpoint whose refdes was never declared', async () => {
+    const bad = intentOf({
+      ...minimal,
+      nets: [...minimal.nets, { name: 'GHOST', pins: ['U9.1', 'C1.1'] }],
+    });
+    const v = await tryValidate(bad);
+    expect(v.ok).toBe(false);
+    expect(v.findings.map((f) => f.detail).join('; ')).toContain('U9');
+  });
+});
+
+describe('sheet size follows content', () => {
+  it('a two-part board and a five-part board both get a real paper size', async () => {
+    const small = await place(minimal);
+    const big = await place(twoMcu);
+    expect(small.report.paper).toBeTruthy();
+    expect(big.report.paper).toBeTruthy();
+    // Both are valid KiCad paper names; the contract is that the engine picks
+    // one from content rather than defaulting unconditionally.
+    expect([small.report.paper, big.report.paper].every((p) => /^A\d$/.test(p))).toBe(true);
+  });
+});

--- a/test/support/draft-harness.ts
+++ b/test/support/draft-harness.ts
@@ -1,0 +1,180 @@
+/**
+ * Component-level harness for the schematic drafting engine.
+ *
+ * The engine proper is `draftSchematicPlacement` (engine.ts): a pure function
+ * from a ValidatedIntent to a placement model. Everything impure sits around
+ * it — the intent file, the vendored symbol cache, the project scaffold, ERC.
+ * The existing draft suites exercise the engine through that whole stack, so
+ * each one opens with the same mkdtemp/cp/rm block and a failure can come from
+ * anywhere in it.
+ *
+ * This harness cuts in at the pure seam instead:
+ *
+ *   - one process-wide `SymbolSource` built with `vendor: false`, so symbol
+ *     resolution reads the fixture libraries and writes nothing, anywhere;
+ *   - a repo root that deliberately does not exist, proving nothing reaches
+ *     for one (the vendored-cache probe is an `existsSync` that simply misses);
+ *   - `docsDir: null`, so SUBSYSTEMS.md and BOM.md cross-checks stay out of it.
+ *
+ * `place()` and `emitText()` therefore touch no directory the tests own. The
+ * one exception is `drawnNets()`, which materializes a sheet to a temp file so
+ * the production parser can read it back; it is the only helper here that
+ * writes, and it cleans up after itself.
+ *
+ * What belongs in a component test written against this file: contracts about
+ * the geometry the engine produces from an IR. What does not: ERC, the CLI,
+ * the agent tool, vendoring, byte-level goldens. Those have their own suites.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { SymbolSource, type ResolvedSymbol } from '../../src/kicad/draft/symsource.js';
+import {
+  validateIntent,
+  type IntentNet,
+  type IntentPart,
+  type IrFinding,
+  type SchematicIntent,
+  type ValidatedIntent,
+} from '../../src/kicad/draft/ir.js';
+import { draftSchematicPlacement, type SchematicDraftReport } from '../../src/kicad/draft/engine.js';
+import { emitSchematic, knum, type EmitSymbol, type PlacementModel } from '../../src/kicad/emit.js';
+import { pinAbsolute, pinNets } from '../../src/kicad/sexp.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/** The four hand-authored fixture libraries: Device, CopperConn, CopperMCU, CopperStack. */
+export const SYMLIB = path.join(HERE, '..', 'fixtures', 'symlib');
+
+/** KiCad's grid unit (mm). Pin coordinates are multiples of this by construction. */
+export const U = 1.27;
+
+/**
+ * A root that does not exist. `SymbolSource` only uses it to probe for a
+ * vendored cache, and a miss falls straight through to `searchDirs`, so a
+ * bogus path is the cheapest possible proof that nothing here needs a repo.
+ */
+const NO_REPO = path.join(tmpdir(), 'copperhead-component-harness-no-repo');
+
+/**
+ * Shared across the whole suite: resolution is a pure read under `vendor: false`,
+ * and the instance caches per lib_id, so the fixture libraries are parsed once
+ * for the entire file rather than once per test.
+ */
+const symsource = new SymbolSource(NO_REPO, [SYMLIB], false);
+
+/** Fixed date so the title block never depends on the clock. */
+export const TODAY = '2020-01-01';
+
+/** Project name the engine stamps into uuids and the title block. */
+export const PROJECT = 'board';
+
+export interface Placed {
+  model: PlacementModel;
+  report: SchematicDraftReport;
+  symbols: Map<string, ResolvedSymbol>;
+  intent: SchematicIntent;
+}
+
+/** Fill in the version field so tests can write the interesting part only. */
+export function intentOf(spec: {
+  parts: IntentPart[];
+  nets: IntentNet[];
+  noConnect?: string[];
+  hints?: SchematicIntent['hints'];
+}): SchematicIntent {
+  return { version: 1, ...spec };
+}
+
+/** Shorthand for a part in the default group, which most component cases do not vary. */
+export function part(ref: string, libId: string, value: string, group = 'Main'): IntentPart {
+  return { ref, libId, value, group };
+}
+
+/** Validate without asserting, for the cases whose subject is the finding list. */
+export async function tryValidate(
+  intent: SchematicIntent,
+): Promise<{ ok: boolean; findings: IrFinding[]; validated: ValidatedIntent | null }> {
+  return validateIntent(intent, symsource, null);
+}
+
+/**
+ * Validate and place. Throws with the findings joined when the IR is rejected —
+ * a component test that meant to exercise geometry should fail naming the IR
+ * problem, not on `undefined` three assertions later.
+ */
+export async function place(intent: SchematicIntent): Promise<Placed> {
+  const v = await tryValidate(intent);
+  if (!v.ok || !v.validated) {
+    throw new Error(`intent rejected: ${v.findings.map((f) => f.detail).join('; ')}`);
+  }
+  const { model, report } = draftSchematicPlacement(v.validated, PROJECT, TODAY);
+  return { model, report, symbols: v.validated.symbols, intent };
+}
+
+/** Place and serialize, still without touching the working tree. */
+export async function emitText(intent: SchematicIntent): Promise<string> {
+  const { model } = await place(intent);
+  return emitSchematic(model);
+}
+
+/** The placed symbol for a refdes. Throws rather than returning undefined. */
+export function symbolOf(placed: Placed, ref: string): EmitSymbol {
+  const sym = placed.model.symbols.find((s) => s.ref === ref);
+  if (!sym) throw new Error(`no symbol placed for ${ref} (placed: ${placed.model.symbols.map((s) => s.ref).join(', ')})`);
+  return sym;
+}
+
+/**
+ * Absolute sheet coordinate of a pin. The engine never mirrors a symbol, so
+ * the transform is placement rotation only.
+ */
+export function pinPoint(placed: Placed, ref: string, pinNumber: string): { x: number; y: number } {
+  const sym = symbolOf(placed, ref);
+  // ValidatedIntent.symbols is keyed by refdes, not lib_id: two parts sharing a
+  // library get one entry each (ir.ts:204).
+  const resolved = placed.symbols.get(ref);
+  if (!resolved) throw new Error(`no resolved symbol for ${ref} (${sym.libId})`);
+  const pin = resolved.pins.find((p) => p.number === pinNumber);
+  if (!pin) throw new Error(`${ref} (${sym.libId}) has no pin ${pinNumber}`);
+  return pinAbsolute(sym.at, null, pin);
+}
+
+/**
+ * Identity of a point on the sheet, as the sheet will state it.
+ *
+ * The placement model carries raw floats — a pin can come out at
+ * 48.260000000000005 where its neighbour is at 48.26 — but the emitter writes
+ * both through `knum`, so KiCad sees one coordinate and joins them. Comparing
+ * model floats directly would call that a miss. This is the same identity the
+ * merged-net guard uses, and for the same reason.
+ */
+export const pointKey = (x: number, y: number): string => `${knum(x)},${knum(y)}`;
+
+/** `REF.PIN -> net` exactly as the IR declared it. */
+export function declaredNets(intent: SchematicIntent): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const net of intent.nets) for (const p of net.pins) out.set(p, net.name);
+  return out;
+}
+
+/**
+ * `REF.PIN -> net` as the drawn sheet actually connects, read back through the
+ * production parser rather than by re-deriving connectivity here — a check
+ * that re-implemented the netlister would only agree with itself.
+ *
+ * The one helper that writes: `pinNets` takes a path. It is a single file in a
+ * temp dir, removed before returning.
+ */
+export async function drawnNets(intent: SchematicIntent): Promise<Map<string, string>> {
+  const text = await emitText(intent);
+  const dir = await mkdtemp(path.join(tmpdir(), 'copperhead-component-'));
+  try {
+    const file = path.join(dir, `${PROJECT}.kicad_sch`);
+    await writeFile(file, text, 'utf8');
+    return new Map((await pinNets(file)).map((p) => [`${p.ref}.${p.pinNumber}`, p.net]));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## What

Adds a component-level test suite for the schematic drafting engine: [draft-engine-component.test.ts](test/draft-engine-component.test.ts) (35 tests, 71ms) and the harness it runs on, [draft-harness.ts](test/support/draft-harness.ts). Tests only, no production source changes.

## Why

Every existing draft suite reaches the engine through the whole stack: a temp repo, an intent file on disk, a vendored symbol cache, sometimes ERC. Each one opens with the same mkdtemp/cp/rm block (roughly 15 copies across the draft tests), and a failure can come from anywhere in that stack rather than from the geometry under test.

The second gap is coverage shape. [draft-engine.test.ts](test/draft-engine.test.ts), [golden-corpus.test.ts](test/golden-corpus.test.ts), and [draft-reference-boards.test.ts](test/draft-reference-boards.test.ts) each pin a named board to named bytes, which catches regressions on the boards they name. What they cannot say is whether a contract holds for a board nobody wrote a fixture for.

## Design

**The seam.** `draftSchematicPlacement` ([engine.ts:301](src/kicad/draft/engine.ts#L301)) is already pure: `ValidatedIntent` in, placement model out, no filesystem, no clock, no random. What kept it off a component test was `SymbolSource`, which every existing suite feeds through a repo on disk. Under `vendor: false` ([symsource.ts:349](src/kicad/draft/symsource.ts#L349)) resolution never writes, so the harness points it at a repo root that deliberately does not exist: the vendored-cache probe is an `existsSync` that simply misses and falls through to the fixture libraries. `place()` and `emitText()` therefore touch no directory the tests own.

One process-wide `SymbolSource` is shared across the file. Resolution is a pure read under `vendor: false` and the instance caches per lib_id, so the four fixture libraries are parsed once for the whole suite rather than once per test.

**Connectivity is read back, not re-derived.** `drawnNets()` is the single helper that writes. It materializes a sheet to a temp file so the production `pinNets` parser reads connectivity back. A test that re-implemented the netlister would only ever agree with itself.

**Point identity is the emitted coordinate.** The placement model carries raw floats: a pin lands at 48.260000000000005 where its neighbour is at 48.26. Both go through `knum` on the way out, so KiCad sees one coordinate and joins them. `pointKey()` compares the way the emitter writes, the same identity the merged-net guard uses and for the same reason. Comparing model floats directly reports a miss that the sheet does not have.

**Organised across boards, not down one.** Five intents (divider, decoupling row, two-MCU link, series RC chain, minimal) crossed with six contracts asserted on all of them:

1. the drawn netlist equals the declared netlist, pin for pin
2. `report.mergedNets` is empty: no two nets share a point
3. every declared part placed exactly once, carrying its value
4. every connected pin on the 1.27 grid
5. every no-connect marker on the pin it belongs to
6. determinism: two placements of one intent are deep-equal

A change that satisfies the reference board by special-casing it fails here on the sibling that was not special-cased.

Two things surfaced while writing this, both worth knowing and neither a bug: a net needs at least two endpoints, so a genuinely single-part board is not expressible (the `minimal` fixture is one part plus its decoupling cap), and `ValidatedIntent.symbols` is keyed by refdes rather than lib_id ([ir.ts:204](src/kicad/draft/ir.ts#L204)).

## Spec / OpenSpec

No spec-level behavior change: this adds tests against existing engine contracts and touches no production source. SPEC.md and the change artifacts stay as they are.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | pass (805 passed, 20 skipped, 57 files) |
| Live-LLM (opt-in) | keyed on `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `COPPERHEAD_TEST_CODEX` | n/a (not configured locally; this PR adds no LLM-touching test) |

New tests: 35 in [draft-engine-component.test.ts](test/draft-engine-component.test.ts). No changed or deleted tests. No known pre-existing failures.

`npm test` was run with `COPPERHEAD_MIN_FREE_MB=100`: the disk preflight default trips on this machine for environmental reasons unrelated to the change.

### Manual test log (required)

The change touches no CLI surface, agent loop, provider, or KiCad-layer source, so there is nothing new to exercise by hand at the CLI. What is worth recording instead is the check that the new contracts are not vacuous: the engine was mutated twice, the suite run against each mutation, and the engine restored byte-identical to HEAD afterwards (`git diff src/` empty).

- Sandbox variant used (`create` / `edit`): n/a, tests-only change
- Commands run and outcome:

```text
$ sed -i 's/^const STUB = 2;$/const STUB = 2.5;/' src/kicad/draft/engine.ts
$ npx vitest run test/draft-engine-component.test.ts
  x 'seriesChain' > lands every connected pin on the 1.27 grid
  Tests  1 failed | 34 passed (35)
  -> off-grid stub length caught by the grid contract

$ # restored, then: stub labels nudged 1.27mm off their anchor (engine.ts:1259)
$ npx vitest run test/draft-engine-component.test.ts
  x 'divider'  > draws exactly the declared netlist, pin for pin
  x 'twoMcu'   > draws exactly the declared netlist, pin for pin
  Tests  2 failed | 33 passed (35)

  AssertionError: expected Map{ 'J1.1' => 'VCC', ...(11) } to deeply equal ...
  -   "R1.1" => "SIG_IN",     +   "R1.1" => null,
  -   "R1.2" => "DIV",        +   "R1.2" => null,
  -   "R2.1" => "DIV",        +   "R2.1" => null,
  -> detached labels caught by the netlist contract, naming the exact pins

$ git diff --stat src/kicad/draft/engine.ts
  (empty: engine restored)

$ npx vitest run test/draft-engine-component.test.ts
  Tests  35 passed (35)   Duration 556ms
```

## Docs

None. The harness documents its own seam and the reasoning behind each contract in file-level and per-test doc comments; nothing in README or the configuration reference changes.

---

## Invariant checklist

- [x] **Spec-gated in**: N/A, no change to the agent tool list.
- [x] **Verification-gated out**: N/A, no mutation path touched.
- [x] **`check`/`verify` stays LLM-free and network-free**: unaffected; the new suite is itself LLM-free and network-free, and imports no provider.
- [x] **No sexp serialization**: preserved. The harness reads through `pinNets` and `pinAbsolute` only; the one file it writes is emitter output from `emitSchematic`, never a parsed-and-reserialized sheet.
- [x] **Sync-obligations ledger**: N/A, no hook or ledger change.
- [x] **Secrets**: N/A, no transcript, summary, or key handling touched.
- [x] **Spec coherence**: N/A, no spec-level behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for schematic drafting, including netlist preservation, symbol placement, pin connectivity, no-connect markers, rail classification, power flags, validation diagnostics, deterministic output, and paper sizing.
  * Added reusable test utilities for schematic construction, placement, symbol and pin inspection, net extraction, validation, and output verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->