### PR TITLE
spec(create): propose the stage-4 unresolvable-parts checkpoint (#206)

### DIFF
--- a/openspec/changes/add-unresolvable-parts-checkpoint/design.md
+++ b/openspec/changes/add-unresolvable-parts-checkpoint/design.md
@@ -1,0 +1,44 @@
+# add-unresolvable-parts-checkpoint: Design
+
+## Context
+
+`bomSymbolDossier` (src/kicad/dossier.ts) classifies every BOM part deterministically before stage 4's first agent turn, but returns only a rendered prompt string; the absence set exists transiently at the NO-INSTALLED-SYMBOL branch and is immediately stringified. `create` runs the dossier per attempt inside the retry loop, advisory-only, under a 60s timeout. `CreateOptions` carries no confirm callback, so the loop's `confirm` defaults to always-true and `create --interactive`'s spec gate never prompts. The run-to-completion guarantee (SPEC.md §"Run-to-completion") is load-bearing: gates are quality checks the agent must satisfy, not stops that wait for a human, unless `--interactive`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Spend human attention before tokens: absences surfaced at stage-4 entry, decided in seconds, with candidates to pick from.
+- A fail-fast mode for unattended runs that costs one stage-entry to fix and resume, opt-in, never the default.
+- Zero change to the advisory dossier path: same bytes, same never-blocks contract on its own failure.
+
+**Non-Goals:**
+
+- No unconditional gate on dossier coverage: fuzzy MPN-to-symbol matching in a gate would refuse valid BOMs (add-symbol-pin-dossier's reasoning stands).
+- No pre-export review gate; that remains its own unimplemented promise, tracked separately.
+- No network or LLM calls anywhere in the checkpoint.
+
+## Decisions
+
+- **D1: Checkpoint once per stage entry, before the attempt loop — not per attempt.** The gate exists to spend human attention before tokens; retries are the autonomous recovery path, and pausing each retry turns run-to-completion into babysitting. Correctness holds because a failed attempt's rollback (`git reset --hard` + `git clean -fd`) restores `docs/BOM.md` to the stage-3-committed state, so every attempt starts from the BOM the human approved at entry; the per-attempt advisory dossier stays as the safety net. Alternative: a per-attempt gate reusing the resolution for the dossier render — rejected: tighter coupling, restructures the attempt loop, re-pauses on identical BOMs.
+- **D2: The gate runs its own resolution scan; the per-attempt dossier path is left byte-for-byte alone.** Cost: one extra bounded library scan per schematic-stage entry (own 60s timeout). Benefit: zero regression risk in the advisory path, `test/dossier.test.ts` stays the untouched regression net, and because the gate consumes the same classifier, the I15 no-false-absence guard carries over automatically. Alternative: thread the gate's resolution into attempt 1's render (saves one scan) — deferred as a follow-up optimization.
+- **D3: Interactive UX is a `CreateOptions.onPartsCheckpoint` callback resolved by a three-way `selectMenu`** (re-check / continue / stop), TTY-gated in `cli.ts` the way `budgetContinuePrompt` is, with Esc/cancel mapping to stop — the safe default spends nothing. Absent callback (non-TTY, `--json`, tests), the configured `unresolvableParts` mode applies. Alternative: chained y/N `confirmTty` questions — rejected: ambiguous UX ("continue?" inverted between questions), and the injectable-key-stream `selectMenu` already exists.
+- **D4: Precedence — interactive pause > `'stop'` > `'agent'`.** A present human always beats fail-fast; pausing is strictly better than dying when someone can act. `'stop'` only fires when no prompt is available.
+- **D5: The stop condition is `status: 'ok'` resolution with a non-empty absence set — nothing else.** A degraded resolution (no readable libraries, timeout, parse error) proceeds with a warning in both modes, because "could not check" must never fail a run as "checked and absent"; parts disclosed as unresolved-by-error, not-searched, or past the size cap never trigger the gate and are labeled "never actually checked" in every report. This inherits I15's contract at gate strength, where a false absence claim would now kill a run instead of merely misleading a prompt.
+- **D6: The machine-readable stop report is a separate `.copperhead/runs/unresolved-parts.json`** (best-effort, like `writeRunReport`), not a mutation of `report.json`'s stable diffing schema.
+- **D7: The candidate search relaxes the digit-swap refusal.** `oneEditFamilyVariant` refuses digit-for-digit substitutions because it protects a *match* claim (a TPS22810 is not a TPS22860). The checkpoint's `nearestInstalledSymbols` is a *suggestion* list for a human, where the digit sibling is exactly what they want to see; it qualifies by bounded edit distance or shared prefix and is called only from the gate, so the dossier hot path never pays for it.
+
+## Risks / Trade-offs
+
+- [Double scan per schematic entry (gate + attempt-1 dossier)] → both bounded by independent 60s timeouts; measured scans are far cheaper than one agent turn; D2's alternative is the documented follow-up if it ever matters.
+- [False stop on a broken environment] → structurally prevented by D5: every degrade path proceeds-with-warning, pinned by a delta-spec scenario and tests.
+- [A re-check after a worse edit approves stale data] → the re-check loop re-reads and re-resolves every time, so a newly introduced absence is shown before approval; the attempt-1 dossier re-reads the same approved file seconds later.
+- [Prompt collides with the interactive renderer's status line] → the pause fires between stages while the renderer is idle; `onBudgetExhausted` already proves a readline prompt coexists with it, and `selectMenu` restores raw-mode state.
+
+## Migration Plan
+
+Purely additive: default `unresolvableParts: 'agent'` without `--interactive` is byte-identical to today. Rollback is removing the gate call and the config key; the dossier split is invisible to consumers. On archive, SPEC.md's run-to-completion paragraph names the third human gate and §5 gains the config row.
+
+## Open Questions
+
+- None blocking. Whether stage-4 entry should eventually reuse the gate's resolution for the attempt-1 dossier render (D2 alternative) is left to a follow-up measurement.

--- a/openspec/changes/add-unresolvable-parts-checkpoint/proposal.md
+++ b/openspec/changes/add-unresolvable-parts-checkpoint/proposal.md
@@ -1,0 +1,30 @@
+# add-unresolvable-parts-checkpoint: Proposal
+
+## Why
+
+The stage-4 pin dossier resolves every BOM part against the installed libraries before the first agent turn, so at schematic-stage entry the pipeline already holds the complete list of parts with no installed symbol. Today that list has exactly one consumer — the agent — which then spends expensive turns negotiating functional substitutes: on the lemondrop brief (run-logs/2026-08-07T17-52-03, upstream #206), attempt-02 spent ~12 turns swapping the same three parts that attempt-05 later paid to re-derive, at hundreds of thousands of tokens per stage-attempt. Choosing a substitute from a candidate list is a decision a human makes in seconds; the expensive agent work worth keeping is the follow-through (pin map, datasheet consequences), not the deliberation.
+
+Stage 3's `search_symbols` requirement already keeps fresh BOMs from reaching stage 4 with absences; this checkpoint is the cheap exit for legacy or resumed workspaces where the BOM predates that rule.
+
+A prerequisite gap surfaces alongside: `create` never forwards a confirm callback, so `create --interactive`'s advertised spec-approval gate silently auto-approves (the loop defaults `confirm` to always-true). The checkpoint needs that plumbing, and fixing it makes the existing gate real.
+
+## What Changes
+
+- **Resolution split from rendering**: `bomSymbolDossier` becomes `renderDossier(await resolveBomSymbols(...))`, where `resolveBomSymbols` returns the structured result (per-part status: resolved / absent / unreadable, plus errored, not-searched, and overflow disclosure sets, and an explicit empty-with-reason degrade state). The rendered dossier block stays byte-identical; no consumer ever greps rendered text for absence.
+- **Stage-4 parts checkpoint**: once per schematic-stage entry (after the resume check, before the first attempt), the pipeline resolves the BOM and computes the genuine absence set. With `--interactive` on an attended terminal it pauses before any tokens are spent, showing each absent part with its refdes, query, and nearest installed candidates, and offers re-check (the human edits `docs/BOM.md`, the pipeline re-resolves) / continue / stop.
+- **`unresolvableParts` config knob** (`'agent' | 'stop'`, default `'agent'`): `'agent'` preserves run-to-completion exactly as today; `'stop'` fails fast before the first schematic agent turn with a structured report — stdout block plus `.copperhead/runs/unresolved-parts.json` — naming each absent part, its candidates, and the resume command, so the human fixes the BOM and resumes at one stage-entry's cost.
+- **Nearest-candidate search for absences**: a new looser search (`nearestInstalledSymbols`) qualifies suggestions by edit distance or shared prefix, including the digit-sibling variants the dossier's match ranking deliberately refuses — a valid *suggestion* for a human is not a *match* claim. Only the checkpoint pays for it; the advisory dossier path is untouched.
+- **`create --interactive` confirm plumbing**: `create` (and `demo`) forward a real TTY confirm callback into the agent loop, making the existing spec-approval gate prompt instead of silently auto-approving, and the `--interactive` help text and docs name the gates accurately (spec approval, parts checkpoint, pre-export).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `create-pipeline`: stage-4 entry gains the opt-in unresolvable-parts checkpoint and the `unresolvableParts` policy; the dossier requirement's never-blocks clause is amended so the opt-in checkpoint is its only sanctioned gate; `create --interactive` forwards a real confirm callback.
+
+## Impact
+
+- **Code**: `src/kicad/dossier.ts` (resolution/render split); `src/kicad/symlib.ts` (new `nearestInstalledSymbols`); `src/config.ts` (`unresolvableParts` with validate-or-fallback); new `src/commands/parts-gate.ts` (`schematicPartsGate`); `src/commands/create.ts` (gate hook before the attempt loop, stop exit path, `confirm`/`onPartsCheckpoint` in `CreateOptions`); `src/cli.ts` and `src/commands/demo.ts` (TTY-gated checkpoint prompt via `selectMenu`, `confirm: confirmTty`, help text).
+- **Tests**: `test/dossier.test.ts` gains resolution-classification and render-equivalence cases (existing render assertions unchanged — the regression net); new `test/parts-gate.test.ts`; `nearestInstalledSymbols`, config-knob, and `runCreate` integration cases (stop fires before the schematic loop, degraded resolution proceeds with a warning, `confirm` reaches the loop).
+- **Unchanged contracts**: `check`/`verify` stay LLM-free and network-free; spec-gating of edit tools is unaffected; the advisory dossier block is byte-identical and still never blocks on its own failure; default configuration keeps run-to-completion byte-identical to today.
+- **Not in scope**: enforcing dossier coverage as an unconditional stage gate (fuzzy matching in a gate would refuse valid BOMs — same reasoning as add-symbol-pin-dossier); the pre-export review gate (still unimplemented, tracked separately); reusing the checkpoint's resolution for the attempt-1 dossier render (follow-up optimization).

--- a/openspec/changes/add-unresolvable-parts-checkpoint/specs/create-pipeline/spec.md
+++ b/openspec/changes/add-unresolvable-parts-checkpoint/specs/create-pipeline/spec.md
@@ -1,0 +1,117 @@
+# create-pipeline — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Stage-4 unresolvable-parts checkpoint
+
+Once per schematic-stage entry — after the resume check, before the first attempt's agent turn — the pipeline SHALL resolve the BOM against the installed symbol libraries using the same classifier the dossier renders from, and compute the genuine absence set: parts classified absent after both the MPN search and the Value fallback. The resolution/render split introduced for this SHALL NOT change the rendered dossier block by a single byte, and no consumer SHALL derive absence from rendered dossier text.
+
+For each genuinely absent part the checkpoint SHALL gather nearest installed candidates via a looser suggestion search, bounded like the existing search. Suggestions MAY include digit-sibling family variants the dossier's match ranking refuses: a suggestion offered to a human is not a match claim made to an agent. The suggestion search SHALL run only for the checkpoint, never on the advisory dossier path.
+
+When a checkpoint prompt is available (`create --interactive` on an attended terminal) and the absence set is non-empty, the pipeline SHALL pause before the first schematic agent turn, presenting each absent part with its refdes and query, its nearest candidates (or an explicit no-near-matches note), and any never-checked parts labeled as such, and SHALL offer three decisions: re-check (re-read `docs/BOM.md` and re-resolve, repeating the checkpoint against the fresh result), continue (proceed to the agent, which still receives the dossier), or stop. Cancelling the prompt SHALL mean stop: the safe default spends nothing.
+
+When no prompt is available, the `unresolvableParts` config policy applies: `'agent'` (the default) SHALL proceed exactly as today, preserving run-to-completion; `'stop'` SHALL end the run before the first schematic agent turn with a nonzero exit, a stdout report naming each absent part with refdes, query, and candidates, the exact resume command, and a machine-readable `.copperhead/runs/unresolved-parts.json` written best-effort. An available prompt SHALL take precedence over `'stop'`: a present human is always asked instead of the run failing.
+
+The checkpoint SHALL fire only on a successful resolution with a non-empty absence set. A degraded resolution — no readable library, timeout, or error — SHALL proceed with a warning that availability could not be verified, in both modes: "could not check" and "checked and absent" are different facts, and under `'stop'` the difference is a killed run. Parts disclosed as unresolved-by-error, not-searched, or past the size cap SHALL never trigger the checkpoint, and every checkpoint report SHALL list them explicitly as never actually checked.
+
+An unknown `unresolvableParts` value SHALL fall back to `'agent'`; a config typo cannot crash or stop a run.
+
+#### Scenario: Genuine absence stops a 'stop'-configured run before any agent turn
+
+- **WHEN** `unresolvableParts` is `'stop'`, no checkpoint prompt is available, and at least one BOM part matches no installed symbol under its MPN or Value
+- **THEN** the pipeline exits nonzero before the first schematic-stage agent turn, naming each absent part with its refdes, query, and nearest installed candidates, printing the resume command, and writing `.copperhead/runs/unresolved-parts.json`
+
+#### Scenario: A degraded resolution never stops the run
+
+- **WHEN** `unresolvableParts` is `'stop'` but no symbol library is readable, resolution times out, or resolution errors
+- **THEN** the schematic stage proceeds exactly as today, with a warning that symbol availability could not be verified
+
+#### Scenario: Never-checked parts never trigger the checkpoint
+
+- **WHEN** the only incomplete parts are disclosed as unresolved-by-error, not-searched, or past the size cap, and none is classified absent
+- **THEN** no stop and no pause occurs, and any emitted report lists those parts explicitly as never actually checked
+
+#### Scenario: Interactive pause with a re-check loop
+
+- **WHEN** `create --interactive` runs on an attended terminal and the absence set is non-empty
+- **THEN** the pipeline pauses before the first schematic agent turn showing each absence and its candidates; choosing re-check re-reads `docs/BOM.md` and re-resolves; choosing continue proceeds to the agent; choosing stop (or cancelling) exits with the same report as `'stop'`
+
+#### Scenario: No absences, no pause
+
+- **WHEN** `create --interactive` runs and every searched part resolves to an installed symbol
+- **THEN** no pause occurs and a one-line confirmation is logged
+
+#### Scenario: A present human beats fail-fast
+
+- **WHEN** `unresolvableParts` is `'stop'` and a checkpoint prompt is available and absences exist
+- **THEN** the human is asked instead of the run failing
+
+#### Scenario: The default preserves run-to-completion
+
+- **WHEN** `unresolvableParts` is absent or `'agent'` and `--interactive` is not passed
+- **THEN** stage-4 entry behavior is byte-identical to today: the absence list reaches the agent through the dossier and nothing pauses or stops
+
+### Requirement: create forwards the interactive confirm gate
+
+`create` (and `demo`) SHALL forward a real TTY confirm callback into the agent loop when `--interactive` is passed on an attended terminal, so the spec-approval gate prompts instead of silently auto-approving through the loop's always-true default. Off-TTY, no callback is forwarded and gates behave as in autonomous runs. The `--interactive` help text and documentation SHALL name the gates it re-enables accurately.
+
+#### Scenario: The spec-approval gate actually prompts
+
+- **WHEN** `create --interactive` runs on an attended terminal and a stage's proposal validates
+- **THEN** the loop's confirm callback is the TTY prompt, and declining leaves edit tools locked, as the agent-core gate specifies
+
+## MODIFIED Requirements
+
+### Requirement: Stage-4 entry pin dossier
+
+Before each attempt of the schematic stage runs, the pipeline SHALL resolve every BOM part against the installed symbol libraries and inject the result into the stage prompt as a machine-verified dossier, so the agent starts with the pin facts it would otherwise spend turns reconstructing. Resolution SHALL search the part's MPN first and, only when that search returns no match, SHALL search its Value as a separate fallback query — a bogus MPN over a resolvable Value must not read as absence. Matching SHALL include single-edit family variants (an MPN of `STM32F103C8T6` finds the stock `STM32F103C8Tx`; a digit-for-digit substitution is never a match), so a family-suffix spelling is not reported absent. A part whose only name is too short to search reliably SHALL be disclosed as not searched rather than silently dropped. Resolution SHALL be recomputed per attempt, since a rolled-back retry can run against a different BOM than its predecessor.
+
+For each covered part the dossier SHALL name the part's refdes and query, the top-ranked installed lib_id, and that symbol's real pins (number, name, electrical type), following `extends` links. A symbol defining more than one unit SHALL be flagged as one the drafting engine refuses. Alternative candidate lib_ids SHALL be listed so a wrong top match is recoverable without a search turn. A part no installed symbol matches SHALL be named as such, with the instruction to substitute, rather than omitted.
+
+Pure-passive refdes classes (R, C, L) are drawable from their canonical `Device:*` symbols and SHALL be omitted by design.
+
+The dossier SHALL be bounded in size, and the bound covers the complete rendered block: parts beyond it SHALL be named as not included — with the instruction to fetch them via `symbol_pins` — never silently dropped, and the disclosure lines themselves SHALL fit within the bound, truncating their enumeration to an explicit count ("…and N more") rather than exceeding it, so coverage stays explicit even when the disclosure is cut short. Absence from the dossier is never readable as absence from the libraries.
+
+Failures SHALL be reported for what they are: a part whose probe errored SHALL be disclosed as unresolved-by-error — distinct from the size-cap disclosure, since an error is not a size decision and says nothing about availability — while a failure of dossier construction as a whole SHALL yield no block at all. Failure of dossier or resolution construction SHALL NOT block the stage: on any error, on timeout, or when no BOM exists, the stage runs with no dossier block, exactly as before this change. The only sanctioned gates on the resolution result are the opt-in stage-4 unresolvable-parts checkpoint paths (`--interactive` pause, `unresolvableParts: 'stop'`), which fire solely on a successful resolution's genuine absence set — never on a degraded or partial one.
+
+A NO-INSTALLED-SYMBOL line is an absence claim, and the dossier SHALL make one only after at least one library was actually readable: when no `.kicad_sym` resolves in any search directory, the machine has verified nothing, and the dossier SHALL be omitted entirely rather than assert absence for every part. "Could not check" and "checked and absent" are different facts, and a block labeled machine-verified must never render the first as the second.
+
+#### Scenario: Covered part needs no discovery turns
+
+- **WHEN** the BOM names a part whose symbol is installed
+- **THEN** the stage-4 prompt already contains its lib_id and full pin table, and the agent can author `REF.PIN` endpoints without reading any `.kicad_sym`
+
+#### Scenario: Genuinely absent part is surfaced at entry
+
+- **WHEN** a BOM part matches no installed symbol under its MPN or Value
+- **THEN** the dossier says so on the part's own line, so substitution starts on turn 1 instead of after a failed draft
+
+#### Scenario: Size overflow is disclosed
+
+- **WHEN** the rendered dossier would exceed its size bound
+- **THEN** the parts left out are named as not included, with `symbol_pins` given as the way to fetch each, and the complete block — disclosure included — still fits within the bound, ending the enumeration with an explicit "…and N more" count when the names alone would not fit
+
+#### Scenario: A probe error is not a size decision
+
+- **WHEN** one part's search or resolution throws while the rest of the dossier builds
+- **THEN** that part is disclosed as unresolved by error, separate from the size-cap disclosure, and the rest of the dossier renders normally
+
+#### Scenario: Dossier failure does not block the stage
+
+- **WHEN** the BOM is missing or dossier construction throws
+- **THEN** the stage prompt is exactly the pre-change prompt and the stage proceeds
+
+#### Scenario: An unreadable library yields silence, not false absence
+
+- **WHEN** no symbol library is readable in any search directory
+- **THEN** no dossier is injected at all — the block never claims NO INSTALLED SYMBOL for parts the machine could not actually check
+
+#### Scenario: A family-variant MPN is not reported absent
+
+- **WHEN** a BOM row names `STM32F103C8T6` and the installed library holds only the family symbol `STM32F103C8Tx`
+- **THEN** the dossier resolves the row to the family symbol's lib_id and pins instead of claiming NO INSTALLED SYMBOL
+
+#### Scenario: A name too short to search is disclosed
+
+- **WHEN** a BOM row's only name is shorter than the search minimum (a crystal valued `8M` with no MPN)
+- **THEN** the row is listed as not searched, so its absence from the dossier is never read as checked-and-absent

--- a/openspec/changes/add-unresolvable-parts-checkpoint/tasks.md
+++ b/openspec/changes/add-unresolvable-parts-checkpoint/tasks.md
@@ -1,0 +1,42 @@
+# add-unresolvable-parts-checkpoint: Tasks
+
+## 1. Dossier resolution/render split
+
+- [ ] 1.1 `src/kicad/dossier.ts`: `resolveBomSymbols(bomMd, dirs, opts): Promise<BomResolution>` — the existing classification loop returning structured per-part records (`status: 'resolved' | 'absent' | 'unreadable'`, refs, query, fallback, lib_id, units, alternatives, and the exact rendered body line) plus `errored` / `notSearched` / `overflow` sets and an explicit `{status: 'empty', reason}` degrade state; never throws
+- [ ] 1.2 `renderDossier(resolution, opts): string` — body lines plus the existing trailer assembly, unchanged; `bomSymbolDossier` keeps its signature as `renderDossier(await resolveBomSymbols(...))`
+- [ ] 1.3 Tests: classification per bucket (absent, errored, not-searched, overflow) and degrade reasons; render equivalence `renderDossier(await resolveBomSymbols(...)) === await bomSymbolDossier(...)` including under a tight `maxChars`; existing render assertions pass unmodified
+
+## 2. Nearest-candidate suggestion search
+
+- [ ] 2.1 `src/kicad/symlib.ts`: `nearestInstalledSymbols(query, dirs, cap = 5)` — loose pass over installed libraries on canonicalized names, qualifying by bounded edit distance or shared prefix, ordered deterministically, digit-sibling variants allowed (a suggestion is not a match claim)
+- [ ] 2.2 Tests: digit-sibling suggestion found, distance-bounded hit, empty result for an alien query, cap respected
+
+## 3. `unresolvableParts` config knob
+
+- [ ] 3.1 `src/config.ts`: `unresolvableParts: 'agent' | 'stop'` non-optional, `DEFAULTS` `'agent'`, `loadConfig` membership test falling back to the default on any other value
+- [ ] 3.2 Tests: `'stop'` maps, absent key defaults to `'agent'`, a typo falls back to `'agent'`
+
+## 4. The parts gate
+
+- [ ] 4.1 New `src/commands/parts-gate.ts`: `schematicPartsGate({repoRoot, docsDir, mode, onCheckpoint?, log})` → proceed/stop verdict with a `PartsCheckpointReport` (absent parts with candidates; never-checked buckets); degraded resolution proceeds with a warning in both modes; re-check loop re-reads BOM.md and re-resolves; no callback + `'stop'` → stop verdict; no callback + `'agent'` → proceed
+- [ ] 4.2 Tests (`test/parts-gate.test.ts`): stop verdict on genuine absence with candidates populated; proceed + warning on an unreadable library dir; proceed when all resolve; re-check loop sees a fixed BOM shrink the report; cancel maps to stop
+
+## 5. Pipeline wiring
+
+- [ ] 5.1 `src/commands/create.ts`: call the gate once per schematic-stage entry (after the resume check, before the attempt loop); on stop, print the report block (absent parts + candidates, never-checked section, fix hint), write `.copperhead/runs/unresolved-parts.json` best-effort, then the canonical failure exit (resume point, cost table, run report, `ok: false`)
+- [ ] 5.2 `CreateOptions` gains `confirm?` and `onPartsCheckpoint?`; `confirm` is forwarded into the stage `runAgentLoop` call so `--interactive`'s spec-approval gate actually prompts
+- [ ] 5.3 Integration tests (mocked agent loop): `'stop'` + absent part → `ok: false` with no schematic agent call and the JSON report written; unreadable library dir → stage runs with the warning; a provided `confirm` reaches the schematic stage's loop options
+
+## 6. CLI surface
+
+- [ ] 6.1 `src/cli.ts` create action and `src/commands/demo.ts`: TTY-gated `partsCheckpointPrompt` (print report, three-way `selectMenu` re-check / continue / stop, cancel → stop) and `confirm: confirmTty`, both spread conditionally under `--interactive`
+- [ ] 6.2 `--interactive` help text for create and demo names the gates accurately (spec approval, parts checkpoint, pre-export)
+
+## 7. Docs
+
+- [ ] 7.1 `openspec/specs/SPEC.md`: run-to-completion paragraph names the third human gate; §5 config table gains `unresolvableParts` with the `'stop'` opt-out noted
+- [ ] 7.2 `docs/src/content/docs/reference/configuration.md` table row; `docs/src/content/docs/reference/cli.md` gate lists
+
+## 8. Verification
+
+- [ ] 8.1 Typecheck, full suite, build green


### PR DESCRIPTION
## What

Adds the OpenSpec change `add-unresolvable-parts-checkpoint`: planning artifacts only, no code. It proposes offering BOM parts with no installed symbol to the human at schematic-stage entry (an `--interactive` pause with a re-check loop, plus an `unresolvableParts: 'agent' | 'stop'` config knob) instead of spending agent turns negotiating substitutes.

## Why

Closes the planning gap for #206. The stage-4 pin dossier already computes the complete absence set deterministically before the first agent turn, but its only consumer is the agent: on the lemondrop brief, one attempt spent ~12 turns swapping three parts a human could have substituted in seconds. The issue's triage also found a prerequisite bug this change absorbs: `create` never forwards a confirm callback, so `create --interactive`'s advertised spec-approval gate silently auto-approves.

## Design

Load-bearing decisions (full rationale in [design.md](openspec/changes/add-unresolvable-parts-checkpoint/design.md)):

- Checkpoint once per stage entry, before the attempt loop; retries stay autonomous (D1).
- The gate runs its own resolution scan; the advisory dossier path stays byte-identical and `test/dossier.test.ts` remains the regression net (D2).
- Precedence: interactive pause beats `'stop'` beats `'agent'`; cancel means stop (D3, D4).
- The stop condition is a successful resolution with a non-empty genuine absence set, nothing else: degraded resolution (no readable library, timeout, error) proceeds with a warning in both modes, and unresolved/not-searched/overflow parts never trigger the gate (D5). This inherits the dossier's I15 no-false-absence guard at gate strength.
- The candidate list for humans relaxes the digit-swap refusal the match ranking keeps: a suggestion is not a match claim (D7).

## Spec / OpenSpec

- New change: [add-unresolvable-parts-checkpoint](openspec/changes/add-unresolvable-parts-checkpoint/proposal.md) ([design.md](openspec/changes/add-unresolvable-parts-checkpoint/design.md), [tasks.md](openspec/changes/add-unresolvable-parts-checkpoint/tasks.md)).
- Delta spec: [specs/create-pipeline/spec.md](openspec/changes/add-unresolvable-parts-checkpoint/specs/create-pipeline/spec.md) with two ADDED requirements (the checkpoint, the `--interactive` confirm plumbing) and a MODIFIED restatement of the stage-4 dossier requirement whose never-blocks clause now names the opt-in checkpoint as its only sanctioned gate (amends `add-symbol-pin-dossier`).
- SPEC.md is deliberately untouched here: the run-to-completion paragraph and the §5 config table move with the implementation (task 7.1), keeping spec text and behavior in step.
- `openspec validate add-unresolvable-parts-checkpoint` passes.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | n/a (no code changed) |
| Build | `npm run build` | n/a (no code changed) |
| Unit + offline | `npm test` | n/a (no code changed) |
| OpenSpec | `openspec validate add-unresolvable-parts-checkpoint` | pass |

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a
- Commands run and outcome: n/a, planning artifacts only; no runtime surface changed.

## Docs

None in this PR. The configuration reference, CLI reference, and SPEC.md edits are tasks 7.1 and 7.2 of the change.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A (no code).
- [ ] **Verification-gated out**: N/A (no code).
- [ ] **`check`/`verify` stays LLM-free and network-free**: N/A (no code).
- [ ] **No sexp serialization**: N/A (no code).
- [ ] **Sync-obligations ledger**: N/A (no code).
- [ ] **Secrets**: N/A (no code).
- [x] **Spec coherence**: the change artifacts (proposal, design, delta spec, tasks) land together and `openspec validate add-unresolvable-parts-checkpoint` passes; SPEC.md moves with the implementation tasks so spec text never leads behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)