### PR TITLE
fix(agent): remove the unreachable decision-log obligation

### DIFF
--- a/src/agent/ledger.ts
+++ b/src/agent/ledger.ts
@@ -9,7 +9,6 @@ export type ObligationKind =
   | 'drift'
   | 'legibility'
   | 'changelog'
-  | 'decision-log'
   | 'constraint-dual-write'
   | 'affects-revisit';
 
@@ -82,10 +81,6 @@ export class ObligationsLedger {
     for (const item of affects) {
       this.add('affects-revisit', `${constraintKey} affects ${item}`, constraintKey);
     }
-  }
-
-  onDecision(summary: string): void {
-    this.add('decision-log', summary, 'decision');
   }
 
   get openObligations(): readonly Obligation[] {

--- a/test/ledger-obligations-satisfiable.test.ts
+++ b/test/ledger-obligations-satisfiable.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Structural invariant over the sync-obligations ledger: an obligation that can
+ * be opened must be closeable.
+ *
+ * The commit gate refuses while any obligation is open, so a kind that some
+ * hook adds but nothing clears (and that `finish` does not exclude) would wedge
+ * every run that triggers it. The failure is silent until the exact hook fires,
+ * which is why this is asserted over the source rather than left to a scenario
+ * test to stumble into.
+ *
+ * The sibling failure, a kind that is never opened at all, is what made this
+ * worth pinning: `decision-log` sat in the union with a producer nothing
+ * called, so wiring it up naively would have introduced exactly the wedge above.
+ */
+
+const SRC = path.resolve('src');
+
+async function tsFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await tsFiles(full)));
+    else if (entry.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+/** Every string literal passed to `.<method>(` across src. */
+function literalArgs(source: string, method: string): string[] {
+  const re = new RegExp(`\\.${method}\\(\\s*'([a-z-]+)'`, 'g');
+  return [...source.matchAll(re)].map((m) => m[1]!);
+}
+
+describe('sync-obligations ledger is structurally satisfiable', () => {
+  it('every obligation kind that can be opened can also be closed', async () => {
+    const sources = await Promise.all((await tsFiles(SRC)).map((f) => readFile(f, 'utf8')));
+    const all = sources.join('\n');
+
+    const opened = new Set(literalArgs(all, 'add'));
+    const cleared = new Set(literalArgs(all, 'clear'));
+    // `finish` lets some kinds through because the commit path settles them itself
+    const excluded = new Set([...all.matchAll(/o\.kind !== '([a-z-]+)'/g)].map((m) => m[1]!));
+
+    expect(opened.size).toBeGreaterThan(0);
+
+    const unsatisfiable = [...opened].filter((k) => !cleared.has(k) && !excluded.has(k)).sort();
+    expect(unsatisfiable, `openable but never cleared or excluded: ${unsatisfiable.join(', ')}`).toEqual([]);
+  });
+
+  it('every declared obligation kind has a producer', async () => {
+    const ledger = await readFile(path.join(SRC, 'agent', 'ledger.ts'), 'utf8');
+    const union = ledger.slice(
+      ledger.indexOf('export type ObligationKind'),
+      ledger.indexOf(';', ledger.indexOf('export type ObligationKind')),
+    );
+    const declared = [...union.matchAll(/'([a-z-]+)'/g)].map((m) => m[1]!);
+
+    const sources = await Promise.all((await tsFiles(SRC)).map((f) => readFile(f, 'utf8')));
+    const opened = new Set(literalArgs(sources.join('\n'), 'add'));
+
+    expect(declared.length).toBeGreaterThan(0);
+
+    const dead = declared.filter((k) => !opened.has(k)).sort();
+    expect(dead, `declared but never opened: ${dead.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Removes `decision-log`, an obligation kind that could never be opened, and adds a structural test so the same shape cannot come back.

## Why

Closes #181.

`decision-log` appeared in exactly three places, none of them a call site:

```
src/agent/ledger.ts:12    | 'decision-log'      <- the type union
src/agent/ledger.ts:87    onDecision(summary)   <- the only producer
src/agent/ledger.ts:88    this.add('decision-log', summary, 'decision');
```

`onDecision` had no callers in `src/` or in the tests, and there was no `clear('decision-log', ...)` anywhere either. Confirmed on `a2471b3` before touching anything:

```
$ grep -rn "decision-log\|onDecision" src/ test/ docs/ *.md
src/agent/ledger.ts:12:  | 'decision-log'
src/agent/ledger.ts:87:  onDecision(summary: string): void {
src/agent/ledger.ts:88:    this.add('decision-log', summary, 'decision');
```

## Design

Removing rather than wiring, matching #177 / #179 for `constraint-dual-write`. Decisions are already recorded: `record_decision` appends to DECISIONS.md and pushes to `ctx.decisions`, so nothing is lost by dropping the kind. Whether a design-editing run *must* record a decision is a policy question, and it should not arrive as a side effect of deleting dead code. Happy to send the wiring instead if you would rather have that invariant.

**Why wiring it naively would have been worse than leaving it.** `changelog` is the working analogue and it needs three pieces:

```
ledger.ts:49   this.add('changelog', ...)                              opened by a hook
loop.ts:712    ctx.ledger.clear('changelog')                            cleared by the commit path
tools.ts:805   openObligations.filter((o) => o.kind !== 'changelog')    excluded from blocking
```

`decision-log` had only the first. Calling `onDecision()` from `record_decision` without the other two would open an obligation nothing could satisfy, and `finish` refuses while any obligation is open, so the run could never complete.

## The test

That trap is the reason this PR adds [ledger-obligations-satisfiable.test.ts](test/ledger-obligations-satisfiable.test.ts) rather than just deleting six lines. It asserts two things over the source:

1. every kind that some `.add(...)` can open is either cleared somewhere or excluded from the blocking set
2. every kind declared in the union has a producer

The first is the one that matters, and it fails on the parent commit naming the exact kind:

```
× every obligation kind that can be opened can also be closed
  → openable but never cleared or excluded: decision-log
```

After this change, the opened set and the cleared set match exactly:

```
added:   affects-revisit changelog constraint-dual-write drc drift erc legibility
cleared: affects-revisit changelog constraint-dual-write drc drift erc legibility
```

It is written in the same style as the existing AC-2.1 module-graph scan, since the property is structural and a scenario test would only find it by stumbling onto the exact hook.

**Coordination note:** #179 removes `constraint-dual-write` from the same union in the same file, so whichever of these lands second will conflict on those adjacent lines. The resolution is trivial (both are pure deletions from the union) and the new test stays correct either way: it reads the union at runtime rather than hardcoding the members. Happy to rebase on top of #179 whenever it lands, or to hold this until it does.

## Spec / OpenSpec

No spec-level behavior change. Nothing could open this obligation, so no run behaves differently.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | targeted, see below | 2 new pass, 9 pre-existing failures unchanged |
| Live-LLM (opt-in) | n/a | n/a |

New: [ledger-obligations-satisfiable.test.ts](test/ledger-obligations-satisfiable.test.ts), 2 tests, both pass here. Test 1 fails on the parent commit.

Ran every suite that touches the ledger (`budget-efficiency`, `cli-surface`, `create-hardening`, `dossier`, `draft-tools`, `gating-sync`, `ledger`, `legibility`, `safety`) on this branch and on the parent, and diffed the failing-test lists:

```
my branch: 9 failures
parent:    9 failures
diff:      identical
```

Those 9 are pre-existing in this environment (no `kicad-cli` on PATH, plus the known Windows path cases in `cli-surface` and `safety`), and none of them are in `ledger.test.ts`.

### Manual test log (required)

n/a, and deliberately so: this removes a code path that had no callers, so there is no CLI behavior to exercise. The change is proven by the structural test above rather than by a run. `npm run build` passes, which is what confirms nothing referenced the removed method.

## Docs

None. `decision-log` was not mentioned in any doc, only in the three source lines above.

---

## Invariant checklist

- [ ] N/A **Spec-gated in**: agent tool list untouched.
- [ ] N/A **Verification-gated out**: no mutation or repair path touched.
- [ ] N/A **`check`/`verify` stays LLM-free**: `src/commands/check` does not reach the ledger.
- [ ] N/A **No sexp serialization**: `src/kicad/` untouched.
- [x] **Sync-obligations ledger**: this is the ledger. The hooks that actually fire (`onKicadEdit`, `onDocEdit`, `onConstraintChange`, `onLegibilityResult`) are unchanged, `commit` still refuses while obligations are open, and the new test pins that every openable kind stays closeable.
- [ ] N/A **Secrets**: no transcript, summary, or env path touched.
- [x] **Spec coherence**: no spec-level behavior change, so no SPEC.md or change artifacts move.
