### PR TITLE
fix(sync): report a configured schematic that is missing from disk

### DIFF
--- a/openspec/changes/build-copperhead-phase-1/specs/cli-surface/spec.md
+++ b/openspec/changes/build-copperhead-phase-1/specs/cli-surface/spec.md
@@ -58,6 +58,10 @@ With `--json`, commands SHALL emit machine-readable results with stable keys.
 - **WHEN** `sync` runs on a consistent repo, or runs twice in a row
 - **THEN** it exits 0 reporting no inconsistencies, and the second consecutive run makes no edits and no commit
 
+#### Scenario: Configured schematic absent (AC-7.6)
+- **WHEN** `sync` runs on a repo whose configured `schematic` names a file that is not on disk
+- **THEN** it reports the missing file and the checks it disarmed (drift, forbidden pins), exits non-zero rather than reporting no inconsistencies, and does not hand the missing file to the resolve phase
+
 ### Requirement: Dry-run mode
 With `--dry-run`, `do` SHALL print the proposed diff and write no files.
 

--- a/openspec/changes/build-copperhead-phase-1/specs/cli-surface/spec.md
+++ b/openspec/changes/build-copperhead-phase-1/specs/cli-surface/spec.md
@@ -61,6 +61,7 @@ With `--json`, commands SHALL emit machine-readable results with stable keys.
 #### Scenario: Configured schematic absent (AC-7.6)
 - **WHEN** `sync` runs on a repo whose configured `schematic` names a file that is not on disk
 - **THEN** it reports the missing file and the checks it disarmed (drift, forbidden pins), exits non-zero rather than reporting no inconsistencies, and does not hand the missing file to the resolve phase
+- **AND** any resolvable items found alongside it are reported as deferred rather than unfixable
 
 ### Requirement: Dry-run mode
 With `--dry-run`, `do` SHALL print the proposed diff and write no files.

--- a/openspec/changes/build-copperhead-phase-1/tasks.md
+++ b/openspec/changes/build-copperhead-phase-1/tasks.md
@@ -97,6 +97,7 @@
 - [x] 10.3 Implement the resolve phase: spec-gated agent run seeded with the report, truth precedence (KiCad = as-built facts, specs/budgets = requirements), single commit with DECISIONS/CHANGELOG entries (AC-7.1, AC-7.2)
 - [x] 10.4 Implement violation flagging: inconsistencies that imply a requirement violation are reported with both sides and the governing spec, never rewritten, exit non-zero (AC-7.3)
 - [x] 10.6 Implement the configured-but-absent schematic case: report the missing file and the disarmed checks, exit non-zero, never hand it to the resolve phase (AC-7.6)
+- [x] 10.7 Report resolvable items found alongside a missing schematic as deferred rather than unfixable (AC-7.6)
 - [ ] 10.5 Tests: doc-drift fixture resolved then `check` clean; dual-write gap repaired both directions; violation fixture flagged not rewritten; clean repo no-op and double-run idempotence (AC-7.5)
 
 ## 11. Submission readiness

--- a/openspec/changes/build-copperhead-phase-1/tasks.md
+++ b/openspec/changes/build-copperhead-phase-1/tasks.md
@@ -96,6 +96,7 @@
 - [x] 10.2 Implement `sync --dry-run`: print the full report (doc, claim, actual, proposed resolution), write nothing (AC-7.4)
 - [x] 10.3 Implement the resolve phase: spec-gated agent run seeded with the report, truth precedence (KiCad = as-built facts, specs/budgets = requirements), single commit with DECISIONS/CHANGELOG entries (AC-7.1, AC-7.2)
 - [x] 10.4 Implement violation flagging: inconsistencies that imply a requirement violation are reported with both sides and the governing spec, never rewritten, exit non-zero (AC-7.3)
+- [x] 10.6 Implement the configured-but-absent schematic case: report the missing file and the disarmed checks, exit non-zero, never hand it to the resolve phase (AC-7.6)
 - [ ] 10.5 Tests: doc-drift fixture resolved then `check` clean; dual-write gap repaired both directions; violation fixture flagged not rewritten; clean repo no-op and double-run idempotence (AC-7.5)
 
 ## 11. Submission readiness

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -475,7 +475,7 @@ Format: Given / When / Then. "Fixture" = the open-telegraph repo (or the tiny te
 - **AC-7.3 (never resolve a violation silently)** With an inconsistency that reflects a requirement violation (e.g. a part whose leakage breaks the sleep-current budget), `sync` does **not** rewrite either side to agree; it flags the violation with both sides and the governing spec/budget, and exits non-zero.
 - **AC-7.4 (dry run)** `sync --dry-run` prints every detected inconsistency (doc, claim, actual, proposed resolution) and writes nothing (`git status` unchanged).
 - **AC-7.5 (clean and idempotent)** On a consistent repo, `sync` exits 0 with "no inconsistencies", makes no edits and no commit; running `sync` twice in a row makes the second run a no-op.
-- **AC-7.6 (configured schematic absent)** With `schematic` set in config to a path that does not exist, `sync` reports the missing file and the checks it disarmed (drift, forbidden pins) and exits non-zero; it does not report "no inconsistencies", and the missing file is not handed to the resolve phase. `check` fails the same repo state for the same reason.
+- **AC-7.6 (configured schematic absent)** With `schematic` set in config to a path that does not exist, `sync` reports the missing file and the checks it disarmed (drift, forbidden pins) and exits non-zero; it does not report "no inconsistencies", and the missing file is not handed to the resolve phase.
 
 ### AC-15 · Turn-budget continue & loop efficiency (issue #15)
 

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -475,7 +475,7 @@ Format: Given / When / Then. "Fixture" = the open-telegraph repo (or the tiny te
 - **AC-7.3 (never resolve a violation silently)** With an inconsistency that reflects a requirement violation (e.g. a part whose leakage breaks the sleep-current budget), `sync` does **not** rewrite either side to agree; it flags the violation with both sides and the governing spec/budget, and exits non-zero.
 - **AC-7.4 (dry run)** `sync --dry-run` prints every detected inconsistency (doc, claim, actual, proposed resolution) and writes nothing (`git status` unchanged).
 - **AC-7.5 (clean and idempotent)** On a consistent repo, `sync` exits 0 with "no inconsistencies", makes no edits and no commit; running `sync` twice in a row makes the second run a no-op.
-- **AC-7.6 (configured schematic absent)** With `schematic` set in config to a path that does not exist, `sync` reports the missing file and the checks it disarmed (drift, forbidden pins) and exits non-zero; it does not report "no inconsistencies", and the missing file is not handed to the resolve phase.
+- **AC-7.6 (configured schematic absent)** With `schematic` set in config to a path that does not exist, `sync` reports the missing file and the checks it disarmed (drift, forbidden pins) and exits non-zero; it does not report "no inconsistencies", and the missing file is not handed to the resolve phase. Resolvable items found alongside it are reported as deferred rather than unfixable, so the run says why it stopped short of resolving them.
 
 ### AC-15 · Turn-budget continue & loop efficiency (issue #15)
 

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -475,6 +475,7 @@ Format: Given / When / Then. "Fixture" = the open-telegraph repo (or the tiny te
 - **AC-7.3 (never resolve a violation silently)** With an inconsistency that reflects a requirement violation (e.g. a part whose leakage breaks the sleep-current budget), `sync` does **not** rewrite either side to agree; it flags the violation with both sides and the governing spec/budget, and exits non-zero.
 - **AC-7.4 (dry run)** `sync --dry-run` prints every detected inconsistency (doc, claim, actual, proposed resolution) and writes nothing (`git status` unchanged).
 - **AC-7.5 (clean and idempotent)** On a consistent repo, `sync` exits 0 with "no inconsistencies", makes no edits and no commit; running `sync` twice in a row makes the second run a no-op.
+- **AC-7.6 (configured schematic absent)** With `schematic` set in config to a path that does not exist, `sync` reports the missing file and the checks it disarmed (drift, forbidden pins) and exits non-zero; it does not report "no inconsistencies", and the missing file is not handed to the resolve phase. `check` fails the same repo state for the same reason.
 
 ### AC-15 · Turn-budget continue & loop efficiency (issue #15)
 

--- a/src/commands/repl-inspect.ts
+++ b/src/commands/repl-inspect.ts
@@ -11,7 +11,7 @@ import { loadConfig } from '../config.js';
 import { checkDrift } from '../memory/drift.js';
 import { loadConstraints } from '../memory/constraints.js';
 import { parseBomTable } from '../memory/bom-table.js';
-import { syncVerify, formatSyncReport } from './sync.js';
+import { syncVerify, formatSyncReport, type SyncViolationItem } from './sync.js';
 import { listSymbols, listNets, pinNets } from '../kicad/sexp.js';
 import { openspecValidate } from '../openspec/cli.js';
 import { copper, dim, ok, warn, err } from '../agent/theme.js';
@@ -47,6 +47,23 @@ async function resolveSchematic(
   return { schPath };
 }
 
+/**
+ * Headline wording for the non-auto-resolved items.
+ *
+ * The headline shows counts without the descriptions that follow it, so
+ * calling a missing file a "requirement violation" here has nothing to correct
+ * it. AC-7.3 uses that term for a design fact that breaks a budget or a spec,
+ * and the two are worth telling apart at a glance.
+ */
+function summariseViolations(violations: SyncViolationItem[]): string {
+  const missing = violations.filter((v) => v.kind === 'schematic-missing').length;
+  const requirement = violations.length - missing;
+  const parts: string[] = [];
+  if (requirement) parts.push(`${requirement} requirement violation(s)`);
+  if (missing) parts.push(`${missing} schematic missing`);
+  return parts.join(', ');
+}
+
 /** `/sync` — verify-only inconsistency report (never auto-resolves). */
 export async function formatSyncInspect(repoRoot: string): Promise<string> {
   const report = await syncVerify(repoRoot);
@@ -55,7 +72,7 @@ export async function formatSyncInspect(repoRoot: string): Promise<string> {
     !report.resolvable.length && !report.violations.length
       ? ok('  sync: clean')
       : report.violations.length
-        ? err(`  sync: ${report.violations.length} requirement violation(s), ${report.resolvable.length} resolvable`)
+        ? err(`  sync: ${summariseViolations(report.violations)}, ${report.resolvable.length} resolvable`)
         : warn(`  sync: ${report.resolvable.length} resolvable inconsistency(ies)`);
   return ['', copper('  Sync'), traceRule(12), '', headline, '', ...body.split('\n').map((l) => `  ${l}`), ''].join(
     '\n',

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -25,7 +25,14 @@ export interface SyncItem {
 }
 
 export interface SyncViolationItem {
-  kind: 'requirement-violation';
+  /**
+   * `schematic-missing` sits with the violations rather than the resolvable
+   * items on purpose: every resolvable item is handed to the LLM resolve
+   * phase, and a schematic that is not on disk is not something an agent
+   * should try to write its way out of. Restoring the file or fixing the
+   * path is a human decision, which is exactly what violations mean here.
+   */
+  kind: 'requirement-violation' | 'schematic-missing';
   description: string;
   governedBy: string;
 }
@@ -40,7 +47,21 @@ export async function syncVerify(repoRoot: string): Promise<SyncReport> {
   const resolvable: SyncItem[] = [];
   const violations: SyncViolationItem[] = [];
 
-  if (config.schematic && existsSync(path.join(repoRoot, config.schematic))) {
+  // Both schematic-gated sections below share this condition, so it is resolved
+  // once. A schematic that is configured but absent silently disarmed drift and
+  // the forbidden-pin check together, and `sync` still reported no
+  // inconsistencies and exited 0 (issue #188).
+  const schematicPath = config.schematic ? path.join(repoRoot, config.schematic) : null;
+  const schematicUsable = schematicPath !== null && existsSync(schematicPath);
+  if (config.schematic && !schematicUsable) {
+    violations.push({
+      kind: 'schematic-missing',
+      description: `schematic configured at ${config.schematic} but the file is missing, so drift and constraint checks did not run`,
+      governedBy: '.copperhead/config.json',
+    });
+  }
+
+  if (schematicUsable && config.schematic) {
     for (const m of await checkDrift(repoRoot, config.docs, config.schematic)) {
       resolvable.push({
         kind: 'drift',
@@ -130,8 +151,8 @@ export async function syncVerify(repoRoot: string): Promise<SyncReport> {
   }
 
   // requirement violations: never auto-resolved (AC-7.3)
-  if (config.schematic && existsSync(path.join(repoRoot, config.schematic))) {
-    const pins = await pinNets(path.join(repoRoot, config.schematic));
+  if (schematicUsable) {
+    const pins = await pinNets(schematicPath);
     for (const v of checkForbiddenPins(registry, pins)) {
       violations.push({
         kind: 'requirement-violation',

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -35,6 +35,14 @@ export interface SyncViolationItem {
   kind: 'requirement-violation' | 'schematic-missing';
   description: string;
   governedBy: string;
+  /**
+   * The configured schematic path, on a `schematic-missing` item. Carried as
+   * data rather than only inside `description`, so `sync --json` answers "is
+   * the configured schematic missing, and where" the same way `check --json`
+   * does with its own `schematicMissing` field. Both halves of #188 should
+   * present the same fact the same way.
+   */
+  schematic?: string;
 }
 
 export interface SyncReport {
@@ -58,6 +66,7 @@ export async function syncVerify(repoRoot: string): Promise<SyncReport> {
       kind: 'schematic-missing',
       description: `schematic configured at ${config.schematic} but the file is missing, so drift and constraint checks did not run`,
       governedBy: '.copperhead/config.json',
+      schematic: config.schematic,
     });
   }
 
@@ -178,11 +187,23 @@ export function formatSyncReport(report: SyncReport): string {
     }
   }
   if (report.violations.length) {
-    lines.push(`${report.violations.length} REQUIREMENT VIOLATION(S) (not auto-resolved; human decision needed):`);
+    // Widened from "REQUIREMENT VIOLATION(S)": a file that is absent from disk
+    // is a check that could not run, not a requirement violation, and AC-7.3
+    // defines that term narrowly. What the whole list does share is that none
+    // of it is auto-resolved, so that is what the heading now says.
+    lines.push(`${report.violations.length} NOT AUTO-RESOLVED (human decision needed):`);
     for (const v of report.violations) {
-      lines.push(`- ${v.description}`);
+      lines.push(`- [${v.kind}] ${v.description}`);
       lines.push(`    governed by: ${v.governedBy}`);
     }
+  }
+  // Any violation exits before the resolve phase, so the resolvable items above
+  // are detected but not acted on. Say so: "reported but not fixed" reads like a
+  // failure unless the user knows it is deferred and why.
+  if (report.violations.length && report.resolvable.length) {
+    lines.push(
+      `note: the ${report.resolvable.length} resolvable item(s) above are deferred, not unfixable. sync stops before the resolve phase while anything is unresolved above; clear that first, then re-run.`,
+    );
   }
   return lines.join('\n');
 }

--- a/test/sync-missing-schematic.test.ts
+++ b/test/sync-missing-schematic.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { writeFile, rm } from 'node:fs/promises';
+import { runInit } from '../src/memory/scaffold.js';
+import { syncVerify, formatSyncReport, type SyncReport } from '../src/commands/sync.js';
+import { tempFixtureRepo } from './helpers.js';
+
+/**
+ * `sync` counterpart to the `check` half of #188. Drift and the forbidden-pin
+ * check are both gated on the schematic existing, so a configured but absent
+ * schematic disarmed the two of them together and `sync` still reported no
+ * inconsistencies and exited 0.
+ *
+ * The report carries this as a violation rather than a resolvable item: the CLI
+ * hands every resolvable item to the LLM resolve phase, and a file that is not
+ * on disk is not something an agent should write its way out of.
+ */
+
+const FIXTURE_SCH = 'hardware/open-key.kicad_sch';
+
+async function syncWith(schematic: string | null, opts: { removeFile?: boolean } = {}): Promise<SyncReport> {
+  const { repo, cleanup } = await tempFixtureRepo();
+  try {
+    await runInit({ repoRoot: repo });
+    await writeFile(
+      path.join(repo, '.copperhead', 'config.json'),
+      JSON.stringify({ docs: 'docs/', schematic, board: null, budgets: {} }, null, 2),
+      'utf8',
+    );
+    if (opts.removeFile && schematic) {
+      await rm(path.join(repo, schematic), { force: true });
+    }
+    return await syncVerify(repo);
+  } finally {
+    await cleanup();
+  }
+}
+
+describe('sync with a configured but missing schematic', () => {
+  it('reports it, where it previously found nothing at all', async () => {
+    const report = await syncWith('hardware/moved-board.kicad_sch');
+    const missing = report.violations.filter((v) => v.kind === 'schematic-missing');
+
+    expect(missing).toHaveLength(1);
+    expect(missing[0]!.description).toContain('hardware/moved-board.kicad_sch');
+    expect(missing[0]!.governedBy).toBe('.copperhead/config.json');
+  });
+
+  it('says the checks did not run, not that nothing was wrong', async () => {
+    const report = await syncWith('hardware/moved-board.kicad_sch');
+    const text = formatSyncReport(report);
+
+    expect(text).not.toBe('sync: no inconsistencies');
+    expect(text).toContain('the file is missing');
+    // the point of the message: silence here meant "not checked", not "clean"
+    expect(text).toContain('did not run');
+  });
+
+  it('is a violation, not a resolvable item, so no agent is asked to fix it', async () => {
+    const report = await syncWith('hardware/moved-board.kicad_sch');
+
+    // the CLI exits 2 on violations before it ever reaches the resolve phase
+    expect(report.violations.length).toBeGreaterThan(0);
+    expect(report.resolvable.map((i) => i.kind)).not.toContain('schematic-missing');
+  });
+
+  it('behaves the same when the file is deleted after being configured', async () => {
+    const report = await syncWith(FIXTURE_SCH, { removeFile: true });
+
+    expect(report.violations.filter((v) => v.kind === 'schematic-missing')).toHaveLength(1);
+  });
+
+  it('stays silent when no schematic is configured', async () => {
+    const report = await syncWith(null);
+
+    expect(report.violations.filter((v) => v.kind === 'schematic-missing')).toEqual([]);
+  });
+
+  it('stays silent when the configured schematic is present', async () => {
+    const report = await syncWith(FIXTURE_SCH);
+
+    expect(report.violations.filter((v) => v.kind === 'schematic-missing')).toEqual([]);
+  });
+});

--- a/test/sync-missing-schematic.test.ts
+++ b/test/sync-missing-schematic.test.ts
@@ -18,7 +18,10 @@ import { tempFixtureRepo } from './helpers.js';
 
 const FIXTURE_SCH = 'hardware/open-key.kicad_sch';
 
-async function syncWith(schematic: string | null, opts: { removeFile?: boolean } = {}): Promise<SyncReport> {
+async function syncWith(
+  schematic: string | null,
+  opts: { removeFile?: boolean; dropDecisions?: boolean } = {},
+): Promise<SyncReport> {
   const { repo, cleanup } = await tempFixtureRepo();
   try {
     await runInit({ repoRoot: repo });
@@ -29,6 +32,9 @@ async function syncWith(schematic: string | null, opts: { removeFile?: boolean }
     );
     if (opts.removeFile && schematic) {
       await rm(path.join(repo, schematic), { force: true });
+    }
+    if (opts.dropDecisions) {
+      await rm(path.join(repo, 'docs', 'DECISIONS.md'), { force: true });
     }
     return await syncVerify(repo);
   } finally {
@@ -80,5 +86,41 @@ describe('sync with a configured but missing schematic', () => {
     const report = await syncWith(FIXTURE_SCH);
 
     expect(report.violations.filter((v) => v.kind === 'schematic-missing')).toEqual([]);
+  });
+});
+
+describe('how the missing schematic is presented', () => {
+  it('carries the path as data, not only inside the description', async () => {
+    const report = await syncWith('hardware/moved-board.kicad_sch');
+    const item = report.violations.find((v) => v.kind === 'schematic-missing');
+
+    // `check --json` exposes `schematicMissing`; `sync --json` should not make a
+    // consumer parse a sentence to learn the same fact
+    expect(item?.schematic).toBe('hardware/moved-board.kicad_sch');
+  });
+
+  it('is not called a requirement violation', async () => {
+    const report = await syncWith('hardware/moved-board.kicad_sch');
+    const text = formatSyncReport(report);
+
+    // AC-7.3 uses that term for a design fact breaking a budget or a spec
+    expect(text).not.toContain('REQUIREMENT VIOLATION');
+    expect(text).toContain('NOT AUTO-RESOLVED');
+    expect(text).toContain('[schematic-missing]');
+  });
+
+  it('says the resolvable items are deferred rather than unfixable', async () => {
+    // dropping a transparency doc gives a coverage item alongside the violation
+    const report = await syncWith('hardware/moved-board.kicad_sch', { dropDecisions: true });
+    expect(report.resolvable.length).toBeGreaterThan(0);
+
+    const text = formatSyncReport(report);
+    expect(text).toContain('deferred, not unfixable');
+  });
+
+  it('does not add the deferred note when there is nothing deferred', async () => {
+    const report = await syncWith('hardware/moved-board.kicad_sch');
+    expect(report.resolvable).toEqual([]);
+    expect(formatSyncReport(report)).not.toContain('deferred');
   });
 });


### PR DESCRIPTION
## What

`copperhead sync` no longer reports a clean run when `config.schematic` names a file that is not on disk. It reports the missing schematic and exits 2.

## Why

Closes #188. This is the `sync` half; #191 is the `check` half and is already approved. Splitting them because the fix is a different shape in each command, per the review discussion on #191.

Drift and the forbidden-pin constraint check are both gated on the schematic existing, written out twice in [sync.ts](src/commands/sync.ts). When the file is absent the two skip together and nothing else notices, so the command reports clean having verified nothing.

Reproduced on `a2471b3`, with an init-ed repo whose `schematic` points at a path that does not exist:

```text
$ copperhead --repo <sandbox> sync --dry-run
sync: no inconsistencies
exit=0
```

The contrast with `check` on the same repo state (with #191 applied) is the reason this is worth fixing rather than leaving to the exit code of the other command:

```text
check -> exit 1, "schematic configured at hardware/board.kicad_sch but the file is missing"
sync  -> exit 0, "sync: no inconsistencies"
```

## Design

The missing schematic goes into `violations[]`, not `resolvable[]`.

That is the load-bearing decision here, so the reasoning: [cli.ts](src/cli.ts) hands every resolvable item to `syncResolve`, which runs the agent loop against them. A schematic that is not on disk is not something an agent should try to write its way out of, and asking it to would be inviting it to invent one. Restoring the file or correcting the path is a human decision, which is exactly what `violations[]` already means in this command (AC-7.3, "never auto-resolved"). It also produces the right exit code for free, since violations exit 2 before the resolve phase is reached.

`SyncViolationItem['kind']` widens from the single `'requirement-violation'` to a union with `'schematic-missing'`, so the two can be told apart by a caller reading `--json`. The `formatSyncReport` heading is unchanged: "not auto-resolved; human decision needed" is accurate for this case too.

The two guards are resolved once into `schematicUsable`, the same consolidation #191 does in `check.ts`.

## Spec / OpenSpec

No spec-level behavior change. AC-7.3 is preserved and this leans on it: the new item is a violation precisely so it is never auto-resolved.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | targeted, see below | 6 new pass, no regressions |
| Live-LLM (opt-in) | n/a | n/a |

New: [sync-missing-schematic.test.ts](test/sync-missing-schematic.test.ts), 6 tests, all pass here.

On the parent commit 4 of the 6 fail. The other 2 are the negative controls (no schematic configured, and schematic present), which correctly pass on both sides:

```text
× reports it, where it previously found nothing at all      -> expected [] to have a length of 1
× says the checks did not run, not that nothing was wrong   -> expected 'sync: no inconsistencies' not to be 'sync: no inconsistencies'
× is a violation, not a resolvable item                     -> expected 0 to be greater than 0
× behaves the same when the file is deleted after config    -> expected [] to have a length of 1
✓ stays silent when no schematic is configured
✓ stays silent when the configured schematic is present
```

Regressions: `gating-sync.test.ts` is the only existing suite that exercises `syncVerify`. Ran it on this branch and on the parent and diffed the failing-test lists: 1 failure each, identical, pre-existing in this environment.

### Manual test log (required)

Sandbox: fixture schematic copied into a fresh git repo, `copperhead init` run, then `.copperhead/config.json` pointed at a path that does not exist.

**Disclosure:** KiCad is not installed on this machine, so `COPPERHEAD_KICAD_CLI` points at a stub that answers `version`, purely to get past preflight. It is never invoked in these runs, because every schematic-reading step is skipped by the condition under test.

```text
$ copperhead --repo /tmp/ch-sync188 sync --dry-run
1 REQUIREMENT VIOLATION(S) (not auto-resolved; human decision needed):
- schematic configured at hardware/board.kicad_sch but the file is missing, so drift and constraint checks did not run
    governed by: .copperhead/config.json
exit=2
```

Control, restoring the file at the configured path and changing nothing else:

```text
$ cp fixture.kicad_sch hardware/board.kicad_sch
$ copperhead --repo /tmp/ch-sync188 sync --dry-run
sync: no inconsistencies
exit=0
```

## Docs

None. The behavior is a report line and an exit code, both shown above. Happy to add the `schematic-missing` kind to the configuration reference if you want the `--json` shape written up.

---

## Invariant checklist

- [ ] N/A **Spec-gated in**: agent tool list untouched.
- [ ] N/A **Verification-gated out**: no mutation or repair path touched. `syncResolve` is unchanged.
- [ ] N/A **`check`/`verify` stays LLM-free**: `check.ts` untouched in this PR (that is #191).
- [x] **No sexp serialization**: `src/kicad/` untouched. `pinNets` stays read-only and now takes the already-resolved path.
- [ ] N/A **Sync-obligations ledger**: not touched. This is `commands/sync.ts`, not the agent ledger.
- [ ] N/A **Secrets**: no transcript, summary, or env path touched. The new line contains only a config-relative path.
- [x] **Spec coherence**: no spec-level behavior change; AC-7.3 is relied on rather than modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sync verification now detects configured schematics that are missing and reports their paths.
  * Missing schematics are shown as unchecked, with dependent drift, constraint, and pin checks skipped.
  * Missing schematics are excluded from automatic resolution, including after a configured file is deleted.
  * Sync reports distinguish missing schematics from other requirement violations and explain deferred resolution items.
  * Sync and check commands now fail when a required configured schematic is unavailable.
  * Interactive sync inspection now separates missing schematics from other requirement violations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->