### PR TITLE
feat(export): circuit-json export as a second draft backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ copperhead doctor                    # env preflight: node, kicad-cli, git, open
 copperhead sync [--dry-run]          # verify the whole design state, resolve drift
 copperhead create --brief brief.md   # brief → full output package
 copperhead export bom --supplier jlcpcb   # supplier-ready ordering file from docs/BOM.md
+copperhead export circuit-json            # tscircuit circuit-json view of the drafted schematic
 ```
 
 Global flags: `--repo <path>` (default: cwd) and `--json` for machine-readable output. `--model` is available on `do`, `sync`, `create`, and `doctor`; `--interactive` only on `do` and `create`; `do` also takes `--dry-run`, `--max-turns`, and `--allow-dirty`.
@@ -166,6 +167,10 @@ copperhead export bom --supplier mouser --spares 15     # Mouser cart CSV, 15% s
 - Rows without an MPN, and rows still flagged `UNVERIFIED`, are excluded from the supplier file and named in a warnings footer on stderr. `--include-unverified` opts the flagged-but-MPN'd rows back in (it never includes MPN-less rows). `create` stage 6 also emits `outputs/jlcpcb-bom.csv` automatically.
 
 `docs/BOM.md` may carry optional `Manufacturer` and `LCSC` columns beyond the base `Refdes | Value | Footprint | MPN | Rationale`; the exporter matches columns by header, so add them when you want them populated in supplier files; `init` scaffolds the base columns only. Only *appending* columns is safe: keep `Refdes | Value | Footprint` first and in that order, because the drift check (`check`/`sync`, which the exporter gates on) reads those three by position, so reordering them makes it compare the wrong cells and refuse the export with a spurious drift message.
+
+### Interchange (`export circuit-json`)
+
+`copperhead export circuit-json` writes a [tscircuit circuit-json](https://github.com/tscircuit/circuit-json) view of the drafted schematic to `outputs/circuit.json` (override with `--out <path>`): the logical netlist as `source_*` elements from the intent IR, the drawn geometry as `schematic_*` elements from the engine's placement model. Same contract as `export bom`: deterministic, LLM-free, network-free. It covers copperhead-drafted sheets only, and refuses when re-drafting the intent does not reproduce the on-disk schematic byte-for-byte, so the file always depicts the sheet as drawn and verified. The output is a derived read-only view: circuit-json never enters the mutation path, and KiCad files remain the sole source of truth.
 
 Nothing is a black box: decisions land in an append-only `docs/DECISIONS.md`, every run writes a human-readable summary next to its transcript, and a per-run `docs/CHANGELOG.md` narrates the design history.
 

--- a/openspec/changes/add-circuit-json-export/.openspec.yaml
+++ b/openspec/changes/add-circuit-json-export/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/add-circuit-json-export/design.md
+++ b/openspec/changes/add-circuit-json-export/design.md
@@ -49,7 +49,7 @@ circuit-json ids are strings (`source_component_0`, `schematic_component_3`, …
 | `PlacementModel.wires` grouped by net | `schematic_trace` with a polyline route |
 | `PlacementModel.labels` | `schematic_net_label` |
 
-Coordinates: KiCad schematic space is mm with +y down; circuit-json schematic space is mm with +y up. The mapping negates y (positions and rotation sense) and is centralized in one `toCj({x, y})` helper with a unit test pinning a known symbol, so the convention lives in exactly one place. Exact field names follow the pinned `circuit-json` version's types; the schema-validation tests are the enforcement, so a field-name drift fails loudly in CI rather than silently emitting junk.
+Coordinates: KiCad schematic space is mm with +y down; circuit-json schematic space is unit-based with +y up, and tscircuit renderers size text/ports in those units (grid step 0.2 units). The mapping negates y and scales one KiCad 100 mil grid step (2.54 mm) to one 0.2-unit step (`SCH_UNITS_PER_MM`), so renders keep tscircuit-native proportions; raw mm coordinates render with ~13x-too-small text. Both live in one `toCj({x, y})` helper with a unit test pinning a known symbol, so the convention lives in exactly one place. Exact field names follow the pinned `circuit-json` version's types; the schema-validation tests are the enforcement, so a field-name drift fails loudly in CI rather than silently emitting junk.
 
 ### CJ-D6: CLI shape and output path
 

--- a/openspec/changes/add-circuit-json-export/design.md
+++ b/openspec/changes/add-circuit-json-export/design.md
@@ -1,0 +1,67 @@
+# add-circuit-json-export — Design
+
+## Context
+
+The draft pipeline is a small compiler: `schematic.intent.json` (IR, no coordinates) → `draftSchematicPlacement()` (engine, computes all geometry into a `PlacementModel`, `src/kicad/draft/engine.ts:328`) → `emitSchematic()` (backend, deterministic KiCad text, `src/kicad/emit.ts`). This change adds a second backend over the same lowered model, serializing to tscircuit's circuit-json interchange format, exposed as `copperhead export circuit-json` beside the existing `export bom` (which sets the contract: deterministic, LLM-free, network-free, writes to `outputs/`, `src/commands/export.ts`).
+
+Constraints inherited from issue #178 and SPEC §1.3: circuit-json is a derived read-only view only; no circuit-json or KiCad serializer may enter the mutation path; `sexp.ts` stays read-only and is not touched by this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Deterministic circuit-json export of a drafted schematic: same intent → byte-identical JSON on any machine.
+- The exported JSON depicts exactly the sheet that was drafted and ERC-checked, and the command refuses when it cannot promise that.
+- Output validates against the `circuit-json` package's own Zod schemas (proven in tests, offline).
+
+**Non-Goals:**
+
+- Lifting circuit-json from a `.kicad_sch` (init'd or hand-edited projects): the command refuses these with an actionable message.
+- circuit-json import, `pcb_*` elements, viewer integration, create-pipeline integration (all recorded out of scope in the proposal).
+
+## Decisions
+
+### CJ-D1: Serialize from ValidatedIntent + PlacementModel, not from the .kicad_sch
+
+The engine already computed every position; re-deriving nets from drawn wires and labels is the hard, error-prone direction (a lifter). The serializer is a pure function `buildCircuitJson(validated, model)` with no I/O, mirroring how `emitSchematic(model)` is pure. Alternative rejected: intent-only export (no geometry, renderers would autolayout a different-looking sheet than the one copperhead drew).
+
+### CJ-D2: Staleness gate — re-draft and compare against the on-disk schematic
+
+`export circuit-json` re-runs the engine on the on-disk intent and emits KiCad text via the existing `emitSchematic()`; if that text does not byte-match the on-disk `.kicad_sch`, the export refuses ("schematic does not match the intent; re-draft first"). This is what makes the "depicts the drafted sheet" promise checkable rather than asserted, and it is cheap because both stages are deterministic. The title-block date is read from the on-disk schematic's `(date "…")` entry so a sheet drafted on an earlier day still compares equal (the engine takes `today` as an input precisely so identical IR emits identical bytes on any day).
+
+### CJ-D3: Plain-JSON emission; `circuit-json` is a devDependency only
+
+The serializer builds plain objects and `JSON.stringify`s them with a fixed 2-space indent and canonical element order. The npm package `circuit-json` (pinned exact version) is used only in tests, where every emitted element is parsed with the package's `any_circuit_element` Zod schema. Alternative rejected: using the package's builders at runtime — adds a runtime dependency and version coupling for no expressive gain; the format is JSON.
+
+### CJ-D4: Deterministic ids from canonical order
+
+circuit-json ids are strings (`source_component_0`, `schematic_component_3`, …). Ids are assigned ordinally after sorting elements canonically (components by refdes natural order, nets by name, traces by net then wire index — the same discipline `emit.ts` uses for UUIDs). Same intent → same ids → byte-identical file. No wall-clock, no randomness (repo-wide rule; also required for the CJ-D2 comparison).
+
+### CJ-D5: Element mapping and coordinate convention
+
+| copperhead source | circuit-json elements |
+| --- | --- |
+| `IntentPart` + `ResolvedSymbol` | `source_component` with `ftype: simple_chip` universally (typed ftypes like `simple_resistor` require parsed electrical values the free-text intent value cannot promise; `display_value` carries the value), one `source_port` per `DraftPin` |
+| `IntentNet` | `source_net`; its `pins` become the `source_trace`'s `connected_source_port_ids` |
+| `noConnect` ("REF.PIN") | the matching `source_port` is simply absent from every `source_trace` (circuit-json has no no-connect marker) |
+| `EmitSymbol.at` + symbol body bounds | `schematic_component` (center + size; the schema has no rotation field — orientation is carried by the port positions, and the engine only places at rotation 0) |
+| symbol pin connection points | `schematic_port` (position derived from symbol `at` + rotated `DraftPin` offset) |
+| `PlacementModel.wires` grouped by net | `schematic_trace` with a polyline route |
+| `PlacementModel.labels` | `schematic_net_label` |
+
+Coordinates: KiCad schematic space is mm with +y down; circuit-json schematic space is mm with +y up. The mapping negates y (positions and rotation sense) and is centralized in one `toCj({x, y})` helper with a unit test pinning a known symbol, so the convention lives in exactly one place. Exact field names follow the pinned `circuit-json` version's types; the schema-validation tests are the enforcement, so a field-name drift fails loudly in CI rather than silently emitting junk.
+
+### CJ-D6: CLI shape and output path
+
+`copperhead export circuit-json [--out <repo-relative path>]`, default `outputs/circuit.json`. Same refusal style as `export bom`: missing intent file → actionable error naming the file and the drafted-projects-only scope; staleness (CJ-D2) → error telling the user to re-draft. The command module keeps `export.ts`'s header contract: never imports a provider, no network.
+
+## Risks / Trade-offs
+
+- [circuit-json format evolves under 0.0.x versioning] → exact-pin the devDependency; tests validate every element against the package schemas, so an upgrade that changes field names fails tests instead of shipping bad output.
+- [Rotation/mirror conventions differ subtly between KiCad and tscircuit renderers] → the engine only emits rotations in {0, 90, 180, 270} and never mirrors; the single `toCj` helper plus a fixture-pinning test bounds the blast radius.
+- [CJ-D2 comparison is byte-exact, so any future emit.ts format change invalidates old drafts' exports] → acceptable: the refusal message says to re-draft, and re-drafting is the supported regeneration path for drafted sheets.
+- [`ftype: simple_chip` for every part loses component-kind typing] → deliberate: typed ftypes demand parsed values (resistance, capacitance) and a wrong parse would be worse than an untyped part; affects only downstream cosmetic rendering, never connectivity.
+
+## Open Questions
+
+None blocking. Whether `create` should emit the file as a stage-6 sibling artifact is deferred until the standalone command is proven (same sequencing supplier-bom-export used).

--- a/openspec/changes/add-circuit-json-export/proposal.md
+++ b/openspec/changes/add-circuit-json-export/proposal.md
@@ -1,0 +1,29 @@
+# add-circuit-json-export — Proposal
+
+## Why
+
+A drafted design's only machine-readable artifact is the emitted `.kicad_sch`, so every external consumer (netlist tooling, converters, fixtures) has to lift KiCad s-expression text. The tscircuit ecosystem already speaks one interchange format, circuit-json (typed JSON elements with published Zod schemas), and the draft pipeline already computes everything needed to emit it: the intent IR carries the logical netlist and the engine's placement model carries the geometry. Tracked as issue #231; scoped to comply with the standing constraint from issue #178 that circuit-json may only ever be a derived read-only view.
+
+## What Changes
+
+- New deterministic serializer module that maps the draft engine's `PlacementModel` plus the validated intent to a circuit-json document: `IntentPart` → `source_component` (+ `source_port` per pin), `IntentNet` → `source_net`/`source_trace`, `noConnect` carried through, and the engine's computed placement filling the `schematic_component`/`schematic_port` layer.
+- New CLI subcommand `copperhead export circuit-json`, sitting beside `export bom` with the identical contract: deterministic, zero LLM calls, zero network calls, output written to `outputs/`.
+- `copperhead create` is NOT modified: the export is a standalone command in v1 (the create pipeline can adopt it later, mirroring how supplier BOM export was proven standalone first).
+- Out of scope, recorded so nobody re-litigates: lifting circuit-json from a `.kicad_sch` (init'd/hand-edited projects), circuit-json import (circuit-json → KiCad), any viewer integration, and any `pcb_*` element emission.
+
+## Capabilities
+
+### New Capabilities
+
+- `circuit-json-export`: derived read-only circuit-json serialization of a drafted schematic (source layer from the intent IR, schematic layer from the engine placement model), exposed as `copperhead export circuit-json`.
+
+### Modified Capabilities
+
+- `cli-surface`: the command set grows `export circuit-json [--out <path>]`; `export` becomes a command family with two subcommands.
+
+## Impact
+
+- New code: `src/kicad/draft/circuit-json.ts` (serializer), wiring in `src/commands/export.ts` and `src/cli.ts`.
+- No changes to `src/kicad/sexp.ts` (stays read-only, untouched), `src/kicad/emit.ts`, the draft engine, agent tools, or any mutation path — both repo invariants (spec-gated in, verification-gated out) are unaffected.
+- New dev dependency `circuit-json` (types + Zod schemas), used in tests to validate emitted output; the runtime serializer emits plain JSON and does not require the package at runtime.
+- Tests: golden/determinism tests (same intent → byte-identical JSON) and schema-validation tests against the `circuit-json` package, all offline.

--- a/openspec/changes/add-circuit-json-export/specs/circuit-json-export/spec.md
+++ b/openspec/changes/add-circuit-json-export/specs/circuit-json-export/spec.md
@@ -1,0 +1,36 @@
+# circuit-json-export — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Derived circuit-json export of a drafted schematic
+`copperhead export circuit-json [--out <path>]` SHALL serialize the drafted schematic to a tscircuit circuit-json document (default `outputs/circuit.json`) built from the on-disk intent IR and the draft engine's recomputed placement model: each intent part becomes a `source_component` with one `source_port` per resolved symbol pin, each intent net becomes a `source_net` and a `source_trace` connecting its ports, placed symbols become `schematic_component`/`schematic_port` elements, net wires become `schematic_trace` routes, and net labels become `schematic_net_label` elements. The export SHALL be deterministic (identical intent yields a byte-identical file), make zero LLM and zero network calls, and never modify any KiCad file.
+
+#### Scenario: Export from a drafted fixture
+- **WHEN** `export circuit-json` runs on a repo whose `.kicad_sch` was drafted from its `schematic.intent.json`
+- **THEN** `outputs/circuit.json` is written, every element parses against the pinned `circuit-json` package's element schemas, and the set of `source_component` refdes values equals the intent's part refdes set
+
+#### Scenario: Deterministic bytes
+- **WHEN** `export circuit-json` runs twice on the same drafted repo
+- **THEN** the two output files are byte-identical
+
+#### Scenario: Connectivity carried faithfully
+- **WHEN** the intent declares a net with pins `["U1.1", "R1.2"]`
+- **THEN** the emitted `source_trace` for that net connects exactly the `source_port` elements for U1 pin 1 and R1 pin 2, and a pin listed in `noConnect` appears in no `source_trace`
+
+### Requirement: Drafted-projects-only refusal
+The export SHALL refuse, with a non-zero exit and an actionable message, when the intent file is absent (project not drafted by copperhead) or when re-drafting the intent does not reproduce the on-disk `.kicad_sch` byte-for-byte (hand-edited or stale sheet). The refusal SHALL name the file to fix and the supported path (draft/re-draft); it SHALL never fall back to lifting the `.kicad_sch`.
+
+#### Scenario: No intent file
+- **WHEN** `export circuit-json` runs in a repo with a `.kicad_sch` but no `schematic.intent.json`
+- **THEN** the command exits non-zero and the message names `schematic.intent.json` and states that circuit-json export covers drafted schematics only
+
+#### Scenario: Stale or hand-edited schematic
+- **WHEN** the on-disk `.kicad_sch` differs from what re-drafting the intent emits
+- **THEN** the command exits non-zero, tells the user to re-draft, and writes no output file
+
+### Requirement: Read-only derived view
+The circuit-json serializer SHALL be a pure function of the validated intent and placement model with no file I/O, SHALL NOT be reachable from any agent mutation tool, and this capability SHALL NOT add any parser or serializer to the KiCad mutation path (`sexp.ts` remains read-only and unchanged).
+
+#### Scenario: No mutation-path coupling
+- **WHEN** the agent tool list is built (with or without a validated proposal)
+- **THEN** no tool exposes circuit-json serialization, and no KiCad file write path imports the serializer

--- a/openspec/changes/add-circuit-json-export/specs/cli-surface/spec.md
+++ b/openspec/changes/add-circuit-json-export/specs/cli-surface/spec.md
@@ -1,0 +1,22 @@
+# cli-surface — Delta Spec
+
+## MODIFIED Requirements
+
+### Requirement: Command set
+The `copperhead` CLI SHALL provide the commands `create --brief <file>`, `init [--path <dir>]`, `do "<change request>"`, `check`, `sync`, `export bom --supplier <jlcpcb|digikey|mouser> [--boards <n>] [--spares <percent>] [--include-unverified]`, and `export circuit-json [--out <path>]`, plus the global flags `--repo <path>`, `--dry-run`, and `--json`.
+
+#### Scenario: Help lists all Phase 1 commands
+- **WHEN** `copperhead --help` is run
+- **THEN** the output lists `create`, `init`, `do`, `check`, `sync`, and `export` with one-line descriptions and the global flags
+
+#### Scenario: Unknown command
+- **WHEN** an unrecognized command is invoked
+- **THEN** the CLI exits non-zero with a usage message and no stack trace
+
+#### Scenario: export bom flag validation
+- **WHEN** `export bom` is invoked with an unknown `--supplier` value
+- **THEN** the CLI exits non-zero listing the supported suppliers
+
+#### Scenario: export circuit-json listed
+- **WHEN** `copperhead export --help` is run
+- **THEN** the output lists both `bom` and `circuit-json` subcommands with one-line descriptions

--- a/openspec/changes/add-circuit-json-export/tasks.md
+++ b/openspec/changes/add-circuit-json-export/tasks.md
@@ -1,0 +1,33 @@
+# add-circuit-json-export — Tasks
+
+## 1. Setup
+
+- [x] 1.1 Add `circuit-json` (exact-pinned) to devDependencies; confirm it imports offline in a scratch test
+- [x] 1.2 Locate the intent-file path convention used by `draft`/`create` (config vs fixed path) and the fixture repo with a drafted sheet to test against; add a minimal drafted fixture if none exists
+
+## 2. Serializer
+
+- [x] 2.1 Create `src/kicad/draft/circuit-json.ts`: `buildCircuitJson(validated: ValidatedIntent, model: PlacementModel): CircuitJsonDocument` — pure, no I/O
+- [x] 2.2 Source layer: `source_component` per part (ftype from libId-prefix map, default `simple_chip`), `source_port` per `DraftPin`, `source_net` + `source_trace` per intent net, `noConnect` pins in no trace (design CJ-D5)
+- [x] 2.3 Schematic layer: `schematic_component` from `EmitSymbol.at`, `schematic_port` from rotated pin offsets, `schematic_trace` from wires grouped by net, `schematic_net_label` from labels; single `toCj` y-negation helper (CJ-D5)
+- [x] 2.4 Deterministic ids from canonical sort order (CJ-D4) and stable `JSON.stringify` serialization (2-space indent, fixed key order per element)
+
+## 3. Command
+
+- [x] 3.1 Add `runExportCircuitJson()` to `src/commands/export.ts`: load intent, validate, re-draft, staleness gate vs on-disk `.kicad_sch` using the file's title-block date (CJ-D2), write `outputs/circuit.json`
+- [x] 3.2 Refusals: missing intent file, stale/hand-edited sheet — actionable messages, non-zero exit, no partial output (spec: drafted-projects-only refusal)
+- [x] 3.3 Wire `export circuit-json [--out <path>]` into `src/cli.ts` beside `export bom`, honoring `--repo` and `--json`
+
+## 4. Tests
+
+- [x] 4.1 Schema validation: every emitted element parses with the pinned `circuit-json` package's Zod schemas on the drafted fixture
+- [x] 4.2 Determinism: two runs on the same fixture are byte-identical; refdes/net sets in the JSON equal the intent's
+- [x] 4.3 Connectivity: net pins map to the right `source_port` ids; `noConnect` pin absent from all traces
+- [x] 4.4 Coordinate pin test: one known symbol's `schematic_component` position/rotation matches the y-negated `EmitSymbol.at`
+- [x] 4.5 Refusal paths: no intent file; mutated `.kicad_sch` byte → non-zero exit, correct message, no output written
+
+## 5. Finish
+
+- [x] 5.1 `npm run typecheck`, `npm test` (offline), `npm run build` all green
+- [x] 5.2 `openspec validate add-circuit-json-export` passes
+- [x] 5.3 Update docs: README/CLI help text mention `export circuit-json`; note the derived-read-only constraint (issue #178) in the command's header comment

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@openai/codex-sdk": "^0.144.6",
         "@types/node": "^22.13.10",
+        "circuit-json": "0.0.465",
         "markdownlint-cli2": "0.23.2",
         "tsx": "^4.19.3",
         "typescript": "^5.8.2",
@@ -1740,6 +1741,16 @@
         "node": ">= 16"
       }
     },
+    "node_modules/circuit-json": {
+      "version": "0.0.465",
+      "resolved": "https://registry.npmjs.org/circuit-json/-/circuit-json-0.0.465.tgz",
+      "integrity": "sha512-C/H9PzLVuZD2kYb65S9cGqK84Udj42pPr6dWLE/Qkzu5gJFHSqoQbhPpwupKNtXzTwOTBwESKjXOXUcXPgPRJw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "format-si-unit": "*"
+      }
+    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -2304,6 +2315,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/format-si-unit": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/format-si-unit/-/format-si-unit-0.0.11.tgz",
+      "integrity": "sha512-SwieOaIOcoS6+uu6vGgis7CjJv6KXeFlgIlCriEu9JTYKL7tw0PceVgRbTMC5b9Aiis0KdktcS7LVFXLWZKXPw==",
+      "dev": true,
+      "peer": true,
+      "peerDependencies": {
+        "typescript": "^5.0.0"
       }
     },
     "node_modules/forwarded": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "@openai/codex-sdk": "^0.144.6",
     "@types/node": "^22.13.10",
+    "circuit-json": "0.0.465",
     "markdownlint-cli2": "0.23.2",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { runDemo, demoTourText } from './commands/demo.js';
 import { runRepl } from './commands/repl.js';
 import {
   runExportBom,
+  runExportCircuitJson,
   parseSupplier,
   parseBoards,
   parseSpares,
@@ -461,6 +462,27 @@ exportCmd
     } catch (err) {
       // ExportError carries an actionable message (bad flag, missing BOM, drift);
       // anything else is unexpected. Both exit non-zero with no stack trace.
+      console.error(err instanceof ExportError ? err.message : (err as Error).message);
+      process.exit(1);
+    }
+  });
+
+exportCmd
+  .command('circuit-json')
+  .description('write a tscircuit circuit-json view of the drafted schematic (drafted sheets only)')
+  .option('--out <path>', 'repo-relative output path', 'outputs/circuit.json')
+  .action(async (opts: { out: string }) => {
+    const repo = repoOf(program.opts());
+    const json = Boolean(program.opts().json);
+    try {
+      const res = await runExportCircuitJson({ repoRoot: repo, out: opts.out });
+      if (json) {
+        console.log(JSON.stringify(res, null, 2));
+      } else {
+        console.log(`wrote ${res.outPath} (${res.elementCount} element(s))`);
+      }
+      process.exit(0);
+    } catch (err) {
       console.error(err instanceof ExportError ? err.message : (err as Error).message);
       process.exit(1);
     }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -4,6 +4,8 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { loadConfig } from '../config.js';
 import { checkDrift } from '../memory/drift.js';
 import { buildExport, parseBom, SUPPLIERS, isSupplier, type Supplier, type ExportResult } from '../kicad/bom-export.js';
+import { draftSchematicToText, defaultIntentPath } from '../kicad/draft/draft.js';
+import { buildCircuitJson, serializeCircuitJson } from '../kicad/draft/circuit-json.js';
 
 /**
  * `copperhead export bom` (capability supplier-bom-export): deterministic,
@@ -88,6 +90,67 @@ export async function emitCreateJlcpcbBom(repoRoot: string): Promise<string | nu
   await mkdir(path.join(repoRoot, OUT_DIR), { recursive: true });
   await writeFile(path.join(repoRoot, outPath), csv, 'utf8');
   return outPath;
+}
+
+export interface ExportCircuitJsonOptions {
+  repoRoot: string;
+  /** Repo-relative output path; defaults to `outputs/circuit.json`. */
+  out?: string;
+}
+
+export interface ExportCircuitJsonResult {
+  outPath: string;
+  elementCount: number;
+}
+
+/**
+ * `copperhead export circuit-json` (capability circuit-json-export): a derived
+ * read-only circuit-json view of a DRAFTED schematic. Same contract as
+ * `export bom`: deterministic, LLM-free, network-free. Drafted sheets only —
+ * re-drafts the intent and refuses unless the result byte-matches the on-disk
+ * schematic, so the export always depicts the sheet as drawn, never a lift of
+ * hand-edited KiCad text (issue #178: circuit-json is only ever a derived view).
+ */
+export async function runExportCircuitJson(opts: ExportCircuitJsonOptions): Promise<ExportCircuitJsonResult> {
+  const config = await loadConfig(opts.repoRoot);
+  if (!config.schematic || !existsSync(path.join(opts.repoRoot, config.schematic))) {
+    throw new ExportError('no schematic configured in .copperhead/config.json — run copperhead init or create first');
+  }
+  const intentRel = defaultIntentPath(config.schematic);
+  if (!existsSync(path.join(opts.repoRoot, intentRel))) {
+    throw new ExportError(
+      `no ${intentRel} — circuit-json export covers copperhead-drafted schematics only ` +
+        '(the intent IR plus the engine placement are its inputs); draft the sheet with copperhead draft or create',
+    );
+  }
+
+  const onDisk = await readFile(path.join(opts.repoRoot, config.schematic), 'utf8');
+  // Re-draft with the sheet's own title-block date so a sheet drafted on an
+  // earlier day still compares equal (the engine takes the date as an input
+  // precisely so identical IR emits identical bytes on any day).
+  const dateOnSheet = /\(date "([^"]*)"\)/.exec(onDisk)?.[1];
+  const res = await draftSchematicToText({
+    repoRoot: opts.repoRoot,
+    schematic: config.schematic,
+    intentPath: intentRel,
+    docsDir: config.docs,
+    ...(dateOnSheet ? { today: dateOnSheet } : {}),
+  });
+  if (!res.ok) {
+    throw new ExportError(`intent does not validate; fix ${intentRel} and re-draft:\n${res.message}`);
+  }
+  if (res.text !== onDisk) {
+    throw new ExportError(
+      `${config.schematic} does not match what ${intentRel} drafts — the sheet is stale or was edited outside the ` +
+        'draft pipeline; re-draft with copperhead draft schematic, then export again',
+    );
+  }
+
+  const elements = buildCircuitJson(res.validated, res.model);
+  const outPath = opts.out ?? path.join(OUT_DIR, 'circuit.json');
+  await mkdir(path.dirname(path.join(opts.repoRoot, outPath)), { recursive: true });
+  await writeFile(path.join(opts.repoRoot, outPath), serializeCircuitJson(elements), 'utf8');
+  return { outPath, elementCount: elements.length };
 }
 
 /** Validate `--supplier`; throws ExportError listing the supported values. */

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -110,6 +110,14 @@ export interface ExportCircuitJsonResult {
  * re-drafts the intent and refuses unless the result byte-matches the on-disk
  * schematic, so the export always depicts the sheet as drawn, never a lift of
  * hand-edited KiCad text (issue #178: circuit-json is only ever a derived view).
+ *
+ * There is exactly ONE circuit-json build, from the intent plus the engine's
+ * placement model; the `.kicad_sch` is never parsed into circuit-json, so the
+ * gate is NOT two circuit-jsons compared. The re-draft's KiCad text equalling
+ * the on-disk sheet byte-for-byte is what licenses the single serialization to
+ * claim it depicts the drawn schematic: both backends (KiCad text, circuit-json)
+ * are pure functions of the same lowered model, so text equality transfers the
+ * claim without a second lift path existing at all.
  */
 export async function runExportCircuitJson(opts: ExportCircuitJsonOptions): Promise<ExportCircuitJsonResult> {
   const config = await loadConfig(opts.repoRoot);

--- a/src/kicad/draft/circuit-json.ts
+++ b/src/kicad/draft/circuit-json.ts
@@ -14,9 +14,17 @@ import type { ValidatedIntent } from './ir.js';
  * no wall clock, no randomness — identical intent yields identical bytes.
  */
 
-/** KiCad sheet space is mm with +y down; circuit-json is mm with +y up. The
- * y-negation lives here and nowhere else. */
-const toCj = (x: number, y: number): { x: number; y: number } => ({ x: n4(x), y: n4(-y) });
+/** KiCad sheet space is mm with +y down; circuit-json schematic space is
+ * unit-based with +y up, where tscircuit's grid step is 0.2 units. One KiCad
+ * 100 mil grid step (2.54 mm) maps to one 0.2-unit step, so renderers draw
+ * text, ports, and wires at their native proportions instead of mm-scale
+ * geometry that shrinks them ~13x. The scale and y-negation live here and
+ * nowhere else. */
+export const SCH_UNITS_PER_MM = 0.2 / 2.54;
+const toCj = (x: number, y: number): { x: number; y: number } => ({
+  x: n4(x * SCH_UNITS_PER_MM),
+  y: n4(-y * SCH_UNITS_PER_MM),
+});
 
 /** Trim float noise the same way knum does, but numerically. */
 const n4 = (v: number): number => {
@@ -70,8 +78,8 @@ export function buildCircuitJson(validated: ValidatedIntent, model: PlacementMod
         ? toCj(at.x + (b.minX + b.maxX) / 2, at.y - (b.minY + b.maxY) / 2)
         : toCj(at.x, at.y);
       const size = b
-        ? { width: n4(b.maxX - b.minX), height: n4(b.maxY - b.minY) }
-        : { width: 2.54, height: 2.54 };
+        ? { width: n4((b.maxX - b.minX) * SCH_UNITS_PER_MM), height: n4((b.maxY - b.minY) * SCH_UNITS_PER_MM) }
+        : { width: 0.2, height: 0.2 };
       schematicComponents.push({
         type: 'schematic_component',
         schematic_component_id: `schematic_component_${ci}`,

--- a/src/kicad/draft/circuit-json.ts
+++ b/src/kicad/draft/circuit-json.ts
@@ -1,0 +1,167 @@
+import type { PlacementModel } from '../emit.js';
+import type { ValidatedIntent } from './ir.js';
+
+/**
+ * circuit-json serializer (capability circuit-json-export): a derived
+ * READ-ONLY view of a drafted sheet, built from the validated intent (source
+ * layer) and the engine's placement model (schematic layer). Pure function,
+ * no I/O, and never reachable from any mutation path — the constraint from
+ * issue #178 is that circuit-json is only ever a derived view.
+ *
+ * Emits plain JSON objects whose shapes are pinned by the `circuit-json`
+ * devDependency's Zod schemas in tests; the package is not a runtime import.
+ * Determinism discipline matches emit.ts: canonical sort orders, ordinal ids,
+ * no wall clock, no randomness — identical intent yields identical bytes.
+ */
+
+/** KiCad sheet space is mm with +y down; circuit-json is mm with +y up. The
+ * y-negation lives here and nowhere else. */
+const toCj = (x: number, y: number): { x: number; y: number } => ({ x: n4(x), y: n4(-y) });
+
+/** Trim float noise the same way knum does, but numerically. */
+const n4 = (v: number): number => {
+  const r = Math.round(v * 10000) / 10000;
+  return Object.is(r, -0) ? 0 : r;
+};
+
+/** Natural refdes order: R2 before R10, C1 before R1. */
+const compareRef = (a: string, b: string): number => {
+  const ma = /^([A-Za-z#]+)(\d*)$/.exec(a);
+  const mb = /^([A-Za-z#]+)(\d*)$/.exec(b);
+  if (ma && mb && ma[1] !== mb[1]) return ma[1]! < mb[1]! ? -1 : 1;
+  if (ma && mb) return Number(ma[2] || 0) - Number(mb[2] || 0);
+  return a < b ? -1 : a > b ? 1 : 0;
+};
+
+export type CircuitJsonElement = Record<string, unknown>;
+
+export function buildCircuitJson(validated: ValidatedIntent, model: PlacementModel): CircuitJsonElement[] {
+  const parts = [...validated.intent.parts].sort((a, b) => compareRef(a.ref, b.ref));
+  const nets = [...validated.intent.nets].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  const symbolAt = new Map(model.symbols.map((s) => [s.ref, s.at]));
+
+  const sourceComponents: CircuitJsonElement[] = [];
+  const sourcePorts: CircuitJsonElement[] = [];
+  const schematicComponents: CircuitJsonElement[] = [];
+  const schematicPorts: CircuitJsonElement[] = [];
+  /** `REF.PIN` → source_port id, for trace endpoints. */
+  const portId = new Map<string, string>();
+
+  parts.forEach((part, ci) => {
+    const componentId = `source_component_${ci}`;
+    // Every ftype except simple_chip demands parsed electrical values
+    // (resistance, capacitance, …) the intent's free-text value cannot promise;
+    // simple_chip carries any part faithfully with the value as display text.
+    sourceComponents.push({
+      type: 'source_component',
+      source_component_id: componentId,
+      ftype: 'simple_chip',
+      name: part.ref,
+      display_value: part.value,
+    });
+
+    const sym = validated.symbols.get(part.ref)!;
+    const at = symbolAt.get(part.ref);
+    if (at) {
+      // Symbol space is +y up; a rot-0 placement maps (px, py) → (x + px, y - py)
+      // (engine pinAt), so body extents flip sign in y before centering.
+      const b = sym.body;
+      const center = b
+        ? toCj(at.x + (b.minX + b.maxX) / 2, at.y - (b.minY + b.maxY) / 2)
+        : toCj(at.x, at.y);
+      const size = b
+        ? { width: n4(b.maxX - b.minX), height: n4(b.maxY - b.minY) }
+        : { width: 2.54, height: 2.54 };
+      schematicComponents.push({
+        type: 'schematic_component',
+        schematic_component_id: `schematic_component_${ci}`,
+        source_component_id: componentId,
+        center,
+        size,
+        symbol_display_value: part.value,
+      });
+    }
+
+    const pins = [...sym.pins].sort((a, b) => compareRef(`P${a.number}`, `P${b.number}`));
+    for (const pin of pins) {
+      const id = `source_port_${sourcePorts.length}`;
+      portId.set(`${part.ref}.${pin.number}`, id);
+      const pinNumber = /^\d+$/.test(pin.number) ? Number(pin.number) : undefined;
+      sourcePorts.push({
+        type: 'source_port',
+        source_port_id: id,
+        source_component_id: componentId,
+        name: pin.number,
+        ...(pinNumber === undefined ? {} : { pin_number: pinNumber }),
+      });
+      if (at) {
+        schematicPorts.push({
+          type: 'schematic_port',
+          schematic_port_id: `schematic_port_${schematicPorts.length}`,
+          source_port_id: id,
+          center: toCj(at.x + pin.x, at.y - pin.y),
+        });
+      }
+    }
+  });
+
+  const sourceNets: CircuitJsonElement[] = [];
+  const sourceTraces: CircuitJsonElement[] = [];
+  const schematicTraces: CircuitJsonElement[] = [];
+  const netId = new Map<string, string>();
+  nets.forEach((net, ni) => {
+    const id = `source_net_${ni}`;
+    netId.set(net.name, id);
+    sourceNets.push({ type: 'source_net', source_net_id: id, name: net.name, member_source_group_ids: [] });
+    const traceId = `source_trace_${ni}`;
+    sourceTraces.push({
+      type: 'source_trace',
+      source_trace_id: traceId,
+      connected_source_port_ids: [...net.pins].sort(compareRef).map((p) => portId.get(p)!),
+      connected_source_net_ids: [id],
+    });
+    const edges = model.wires
+      .filter((w) => w.net === net.name)
+      .sort((a, b) => a.index - b.index)
+      .map((w) => ({ from: toCj(w.x1, w.y1), to: toCj(w.x2, w.y2) }));
+    if (edges.length) {
+      schematicTraces.push({
+        type: 'schematic_trace',
+        schematic_trace_id: `schematic_trace_${schematicTraces.length}`,
+        source_trace_id: traceId,
+        edges,
+        junctions: [],
+      });
+    }
+  });
+
+  const labels = [...model.labels]
+    .filter((l) => netId.has(l.name))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0) || a.x - b.x || a.y - b.y);
+  const netLabels: CircuitJsonElement[] = labels.map((l, i) => ({
+    type: 'schematic_net_label',
+    schematic_net_label_id: `schematic_net_label_${i}`,
+    source_net_id: netId.get(l.name)!,
+    text: l.name,
+    center: toCj(l.x, l.y),
+    anchor_position: toCj(l.x, l.y),
+    // A rot-0 KiCad label extends rightward from its anchor; 180 extends left.
+    anchor_side: l.rot === 180 ? 'right' : 'left',
+  }));
+
+  return [
+    ...sourceComponents,
+    ...sourcePorts,
+    ...sourceNets,
+    ...sourceTraces,
+    ...schematicComponents,
+    ...schematicPorts,
+    ...schematicTraces,
+    ...netLabels,
+  ];
+}
+
+/** Canonical file bytes: 2-space indent, trailing newline. */
+export function serializeCircuitJson(elements: CircuitJsonElement[]): string {
+  return JSON.stringify(elements, null, 2) + '\n';
+}

--- a/src/kicad/draft/circuit-json.ts
+++ b/src/kicad/draft/circuit-json.ts
@@ -120,16 +120,42 @@ export function buildCircuitJson(validated: ValidatedIntent, model: PlacementMod
       connected_source_port_ids: [...net.pins].sort(compareRef).map((p) => portId.get(p)!),
       connected_source_net_ids: [id],
     });
-    const edges = model.wires
-      .filter((w) => w.net === net.name)
-      .sort((a, b) => a.index - b.index)
-      .map((w) => ({ from: toCj(w.x1, w.y1), to: toCj(w.x2, w.y2) }));
-    if (edges.length) {
+    // One schematic_trace per CONTIGUOUS wire chain, not per net: renderers
+    // (circuit-to-svg, circuitjson.com) draw a trace's edges as one connected
+    // route, so a net's disjoint branches must be separate traces or they
+    // render as phantom diagonals between branch endpoints.
+    const wires = model.wires.filter((w) => w.net === net.name).sort((a, b) => a.index - b.index);
+    const parent = new Map<string, string>();
+    const find = (k: string): string => {
+      let r = k;
+      while (parent.get(r) !== r) r = parent.get(r)!;
+      for (let c = k; c !== r; ) {
+        const next = parent.get(c)!;
+        parent.set(c, r);
+        c = next;
+      }
+      return r;
+    };
+    const union = (a: string, b: string) => {
+      if (!parent.has(a)) parent.set(a, a);
+      if (!parent.has(b)) parent.set(b, b);
+      parent.set(find(a), find(b));
+    };
+    const endKey = (x: number, y: number) => `${n4(x)},${n4(y)}`;
+    for (const w of wires) union(endKey(w.x1, w.y1), endKey(w.x2, w.y2));
+    const chains = new Map<string, typeof wires>();
+    for (const w of wires) {
+      const root = find(endKey(w.x1, w.y1));
+      const list = chains.get(root);
+      if (list) list.push(w);
+      else chains.set(root, [w]);
+    }
+    for (const chain of [...chains.values()].sort((a, b) => a[0]!.index - b[0]!.index)) {
       schematicTraces.push({
         type: 'schematic_trace',
         schematic_trace_id: `schematic_trace_${schematicTraces.length}`,
         source_trace_id: traceId,
-        edges,
+        edges: chain.map((w) => ({ from: toCj(w.x1, w.y1), to: toCj(w.x2, w.y2) })),
         junctions: [],
       });
     }

--- a/src/kicad/draft/draft.ts
+++ b/src/kicad/draft/draft.ts
@@ -1,9 +1,9 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { emitSchematic } from '../emit.js';
+import { emitSchematic, type PlacementModel } from '../emit.js';
 import { SymbolSource } from './symsource.js';
-import { parseIntent, validateIntent, formatIrFindings, INTENT_FILENAME, type IrFinding } from './ir.js';
+import { parseIntent, validateIntent, formatIrFindings, INTENT_FILENAME, type IrFinding, type ValidatedIntent } from './ir.js';
 import { draftSchematicPlacement, type SchematicDraftReport } from './engine.js';
 
 /**
@@ -31,6 +31,10 @@ export type SchematicDraftResult =
       report: SchematicDraftReport;
       text: string;
       schematicPath: string;
+      /** Lowered placement model and validated intent, for derived read-only
+       * views (circuit-json export). Never an input to any mutation path. */
+      model: PlacementModel;
+      validated: ValidatedIntent;
       /** Engine-generated lib blocks (copperhead_power) to vendor. */
       generatedLibs: { libId: string; sourceText: string }[];
       /** Library-sourced lib_ids, for cache/table maintenance. */
@@ -97,6 +101,8 @@ export async function draftSchematicToText(opts: SchematicDraftOptions): Promise
     report,
     text,
     schematicPath: path.join(opts.repoRoot, opts.schematic),
+    model,
+    validated,
     generatedLibs: model.libSymbols.filter((l) => l.libId.startsWith('copperhead_power:')),
     vendoredLibIds: [...validated.symbols.values()].map((s) => s.libId),
   };

--- a/test/circuit-json-export.test.ts
+++ b/test/circuit-json-export.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdtemp, cp, rm, writeFile, mkdir, readFile, appendFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { execa } from 'execa';
+import { any_circuit_element } from 'circuit-json';
+import { runExportCircuitJson, ExportError } from '../src/commands/export.js';
+import { draftSchematic } from '../src/kicad/draft/draft.js';
+import { buildCircuitJson } from '../src/kicad/draft/circuit-json.js';
+import type { ValidatedIntent, SchematicIntent } from '../src/kicad/draft/ir.js';
+import type { PlacementModel } from '../src/kicad/emit.js';
+import type { ResolvedSymbol } from '../src/kicad/draft/symsource.js';
+
+/**
+ * circuit-json export (capability circuit-json-export): a derived read-only
+ * view of a drafted sheet. The pinned `circuit-json` package's own Zod schemas
+ * are the format oracle, so a field-name drift in the serializer fails here
+ * rather than shipping junk. All offline.
+ */
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DRAFT_FIXTURE = path.join(ROOT, 'test', 'fixtures', 'draft');
+const SYMLIB = path.join(ROOT, 'test', 'fixtures', 'symlib');
+
+async function draftedRepo(): Promise<{ repo: string; cleanup: () => Promise<void> }> {
+  const repo = await mkdtemp(path.join(tmpdir(), 'copperhead-cjexport-'));
+  await cp(path.join(DRAFT_FIXTURE, 'schematic.intent.json'), path.join(repo, 'schematic.intent.json'));
+  await cp(path.join(DRAFT_FIXTURE, 'docs'), path.join(repo, 'docs'), { recursive: true });
+  await mkdir(path.join(repo, '.copperhead'), { recursive: true });
+  await writeFile(
+    path.join(repo, '.copperhead', 'config.json'),
+    JSON.stringify({ schematic: 'board.kicad_sch', docs: 'docs/' }),
+    'utf8',
+  );
+  const res = await draftSchematic({
+    repoRoot: repo,
+    schematic: 'board.kicad_sch',
+    intentPath: 'schematic.intent.json',
+    docsDir: path.join(repo, 'docs'),
+    symbolDirs: [SYMLIB],
+  });
+  if (!res.ok) throw new Error(res.message);
+  return { repo, cleanup: () => rm(repo, { recursive: true, force: true }) };
+}
+
+type Element = Record<string, any>;
+
+async function exportedElements(repo: string): Promise<Element[]> {
+  const res = await runExportCircuitJson({ repoRoot: repo });
+  return JSON.parse(await readFile(path.join(repo, res.outPath), 'utf8')) as Element[];
+}
+
+describe('export circuit-json', () => {
+  it('emits schema-valid elements covering the intent, deterministically', async () => {
+    const { repo, cleanup } = await draftedRepo();
+    try {
+      const elements = await exportedElements(repo);
+      expect(elements.length).toBeGreaterThan(0);
+      for (const el of elements) {
+        const parsed = any_circuit_element.safeParse(el);
+        expect(parsed.success, `element ${el.type} failed schema: ${JSON.stringify(el)}`).toBe(true);
+      }
+
+      const intent = JSON.parse(await readFile(path.join(repo, 'schematic.intent.json'), 'utf8')) as SchematicIntent;
+      const refdes = elements.filter((e) => e.type === 'source_component').map((e) => e.name as string);
+      expect(new Set(refdes)).toEqual(new Set(intent.parts.map((p) => p.ref)));
+      const netNames = elements.filter((e) => e.type === 'source_net').map((e) => e.name as string);
+      expect(new Set(netNames)).toEqual(new Set(intent.nets.map((n) => n.name)));
+
+      // Determinism: a second run yields byte-identical output.
+      const first = await readFile(path.join(repo, 'outputs', 'circuit.json'), 'utf8');
+      await runExportCircuitJson({ repoRoot: repo });
+      const second = await readFile(path.join(repo, 'outputs', 'circuit.json'), 'utf8');
+      expect(second).toBe(first);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('carries connectivity faithfully: net pins map to ports, noConnect pins are traceless', async () => {
+    const { repo, cleanup } = await draftedRepo();
+    try {
+      const elements = await exportedElements(repo);
+      const intent = JSON.parse(await readFile(path.join(repo, 'schematic.intent.json'), 'utf8')) as SchematicIntent;
+
+      const componentByRef = new Map(
+        elements.filter((e) => e.type === 'source_component').map((e) => [e.name as string, e.source_component_id]),
+      );
+      const portKey = new Map(
+        elements
+          .filter((e) => e.type === 'source_port')
+          .map((e) => [e.source_port_id as string, `${[...componentByRef.entries()].find(([, id]) => id === e.source_component_id)![0]}.${e.name}`]),
+      );
+      const netIdByName = new Map(
+        elements.filter((e) => e.type === 'source_net').map((e) => [e.name as string, e.source_net_id]),
+      );
+
+      for (const net of intent.nets) {
+        const trace = elements.find(
+          (e) => e.type === 'source_trace' && (e.connected_source_net_ids as string[]).includes(netIdByName.get(net.name) as string),
+        )!;
+        const connected = (trace.connected_source_port_ids as string[]).map((id) => portKey.get(id)!);
+        expect(new Set(connected)).toEqual(new Set(net.pins));
+      }
+
+      const allTracedPorts = new Set(
+        elements.filter((e) => e.type === 'source_trace').flatMap((e) => e.connected_source_port_ids as string[]),
+      );
+      for (const nc of intent.noConnect ?? []) {
+        const id = [...portKey.entries()].find(([, key]) => key === nc)?.[0];
+        expect(id, `noConnect pin ${nc} should exist as a source_port`).toBeDefined();
+        expect(allTracedPorts.has(id!), `noConnect pin ${nc} must not appear in any source_trace`).toBe(false);
+      }
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('pins the coordinate convention: y negates from KiCad sheet space', () => {
+    const symbols = new Map<string, ResolvedSymbol>([
+      [
+        'R1',
+        {
+          libId: 'Device:R',
+          sourceText: '',
+          pins: [{ number: '1', name: '~', etype: 'passive', x: 0, y: 3.81, angle: 270 }],
+          body: { minX: -1, minY: -2, maxX: 1, maxY: 2 },
+          isPower: false,
+          multiUnit: false,
+        },
+      ],
+    ]);
+    const validated: ValidatedIntent = {
+      intent: {
+        version: 1,
+        parts: [{ ref: 'R1', libId: 'Device:R', value: '1k', group: 'G' }],
+        nets: [{ name: 'N1', pins: ['R1.1'] }],
+      },
+      symbols,
+      docGroups: null,
+    };
+    const model: PlacementModel = {
+      projectName: 't',
+      paper: 'A4',
+      title: { title: 't', date: '2020-01-01', rev: 'A' },
+      libSymbols: [],
+      symbols: [
+        {
+          ref: 'R1',
+          libId: 'Device:R',
+          value: '1k',
+          footprint: '',
+          at: { x: 100, y: 50, rot: 0 },
+          refAt: { x: 0, y: 0 },
+          valueAt: { x: 0, y: 0 },
+          pinNumbers: ['1'],
+        },
+      ],
+      wires: [{ x1: 100, y1: 46.19, x2: 110, y2: 46.19, net: 'N1', index: 0 }],
+      junctions: [],
+      labels: [{ name: 'N1', x: 110, y: 46.19, rot: 0 }],
+      noConnects: [],
+      rectangles: [],
+      captions: [],
+    };
+
+    const elements = buildCircuitJson(validated, model);
+    const comp = elements.find((e) => e.type === 'schematic_component') as Element;
+    // Body center in symbol space is (0, 0), so the component centers on its origin, y negated.
+    expect(comp.center).toEqual({ x: 100, y: -50 });
+    expect(comp.size).toEqual({ width: 2, height: 4 });
+    const port = elements.find((e) => e.type === 'schematic_port') as Element;
+    // Pin (0, 3.81) symbol space → sheet (100, 50 - 3.81) → circuit-json y negated.
+    expect(port.center).toEqual({ x: 100, y: -46.19 });
+    const label = elements.find((e) => e.type === 'schematic_net_label') as Element;
+    expect(label.center).toEqual({ x: 110, y: -46.19 });
+    expect(label.anchor_side).toBe('left');
+    const trace = elements.find((e) => e.type === 'schematic_trace') as Element;
+    expect(trace.edges).toEqual([{ from: { x: 100, y: -46.19 }, to: { x: 110, y: -46.19 } }]);
+  });
+
+  it('is listed beside bom under export --help (cli-surface)', async () => {
+    const res = await execa('npx', ['tsx', 'src/cli.ts', 'export', '--help'], {
+      cwd: ROOT,
+      reject: false,
+      env: { NO_COLOR: '1' },
+    });
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain('bom');
+    expect(res.stdout).toContain('circuit-json');
+  }, 60_000);
+
+  it('refuses when there is no intent file, naming the drafted-only scope', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'copperhead-cjexport-'));
+    try {
+      await mkdir(path.join(repo, '.copperhead'), { recursive: true });
+      await writeFile(
+        path.join(repo, '.copperhead', 'config.json'),
+        JSON.stringify({ schematic: 'board.kicad_sch', docs: 'docs/' }),
+        'utf8',
+      );
+      await writeFile(path.join(repo, 'board.kicad_sch'), '(kicad_sch)', 'utf8');
+      await expect(runExportCircuitJson({ repoRoot: repo })).rejects.toThrow(/schematic\.intent\.json.*drafted/s);
+      expect(existsSync(path.join(repo, 'outputs', 'circuit.json'))).toBe(false);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a stale or hand-edited schematic and writes nothing', async () => {
+    const { repo, cleanup } = await draftedRepo();
+    try {
+      await appendFile(path.join(repo, 'board.kicad_sch'), '\n', 'utf8');
+      await expect(runExportCircuitJson({ repoRoot: repo })).rejects.toThrow(ExportError);
+      await expect(runExportCircuitJson({ repoRoot: repo })).rejects.toThrow(/re-draft/);
+      expect(existsSync(path.join(repo, 'outputs', 'circuit.json'))).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+});

--- a/test/circuit-json-export.test.ts
+++ b/test/circuit-json-export.test.ts
@@ -167,18 +167,21 @@ describe('export circuit-json', () => {
     };
 
     const elements = buildCircuitJson(validated, model);
+    // Coordinates scale from KiCad mm to tscircuit grid units (2.54 mm → 0.2
+    // units) and negate y. 100 mm → 7.874, 50 mm → 3.937, 46.19 mm → 3.637,
+    // 110 mm → 8.6614 (all rounded to 4 decimals by the serializer).
     const comp = elements.find((e) => e.type === 'schematic_component') as Element;
-    // Body center in symbol space is (0, 0), so the component centers on its origin, y negated.
-    expect(comp.center).toEqual({ x: 100, y: -50 });
-    expect(comp.size).toEqual({ width: 2, height: 4 });
+    // Body center in symbol space is (0, 0), so the component centers on its origin.
+    expect(comp.center).toEqual({ x: 7.874, y: -3.937 });
+    expect(comp.size).toEqual({ width: 0.1575, height: 0.315 });
     const port = elements.find((e) => e.type === 'schematic_port') as Element;
-    // Pin (0, 3.81) symbol space → sheet (100, 50 - 3.81) → circuit-json y negated.
-    expect(port.center).toEqual({ x: 100, y: -46.19 });
+    // Pin (0, 3.81) symbol space → sheet (100, 50 - 3.81) → scaled, y negated.
+    expect(port.center).toEqual({ x: 7.874, y: -3.637 });
     const label = elements.find((e) => e.type === 'schematic_net_label') as Element;
-    expect(label.center).toEqual({ x: 110, y: -46.19 });
+    expect(label.center).toEqual({ x: 8.6614, y: -3.637 });
     expect(label.anchor_side).toBe('left');
     const trace = elements.find((e) => e.type === 'schematic_trace') as Element;
-    expect(trace.edges).toEqual([{ from: { x: 100, y: -46.19 }, to: { x: 110, y: -46.19 } }]);
+    expect(trace.edges).toEqual([{ from: { x: 7.874, y: -3.637 }, to: { x: 8.6614, y: -3.637 } }]);
   });
 
   it('is listed beside bom under export --help (cli-surface)', async () => {


### PR DESCRIPTION
## What

Adds `copperhead export circuit-json [--out <path>]`: a deterministic, LLM-free, network-free export of a drafted schematic to the tscircuit [circuit-json](https://github.com/tscircuit/circuit-json) interchange format, written to `outputs/circuit.json` beside the existing `export bom`.

## Why

A drafted design's only machine-readable artifact is the emitted `.kicad_sch`, so every external consumer has to lift KiCad s-expression text. circuit-json opens the tscircuit ecosystem (renderers, converters, netlist tooling) from data the draft pipeline already computes. Closes #231; complies with the constraint from #178 that circuit-json may only ever be a derived read-only view.

## Design

The draft pipeline is treated as a compiler with a second backend: [circuit-json.ts](src/kicad/draft/circuit-json.ts) is a pure serializer over the validated intent (source layer: `source_component`/`source_port`/`source_net`/`source_trace`) and the engine's `PlacementModel` (schematic layer: `schematic_component`/`schematic_port`/`schematic_trace`/`schematic_net_label`). Load-bearing decisions (full rationale in [design.md](openspec/changes/add-circuit-json-export/design.md), CJ-D1 to CJ-D6):

- **Staleness gate (CJ-D2)**: the command re-drafts the intent and refuses unless the emitted KiCad text byte-matches the on-disk `.kicad_sch`. There is exactly one circuit-json build; the schematic is never parsed into circuit-json. Both backends are pure functions of the same lowered model, so text equality licenses the JSON's claim to depict the drawn sheet.
- **Determinism (CJ-D4)**: ordinal ids from canonical sort orders, no wall clock (the title-block date is read from the sheet), byte-identical output for identical intent.
- **Plain JSON emission (CJ-D3)**: the `circuit-json` npm package is an exact-pinned devDependency used only in tests as the format oracle (Zod schema validation per element).
- One additive change to [draft.ts](src/kicad/draft/draft.ts): the ok-result now also returns `model` and `validated` for derived views.

## Spec / OpenSpec

OpenSpec change [add-circuit-json-export](openspec/changes/add-circuit-json-export/) (validates clean, all tasks checked): new capability delta spec [circuit-json-export](openspec/changes/add-circuit-json-export/specs/circuit-json-export/spec.md), modified [cli-surface](openspec/changes/add-circuit-json-export/specs/cli-surface/spec.md) command set. No SPEC.md acceptance criteria change; the capability is additive.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | pass (778 passed, 20 skipped, 57 files) |
| Live-LLM (opt-in) | keyed on provider env vars | n/a (nothing in this PR touches a provider) |

New tests in [circuit-json-export.test.ts](test/circuit-json-export.test.ts): per-element Zod schema validation against the pinned `circuit-json` package, byte-determinism across runs, connectivity fidelity (net pins map to the right ports, `noConnect` pins traceless), a coordinate-convention pin test, both refusal paths, and the `export --help` listing.

### Manual test log (required)

- Sandbox variant used: drafted fixture repo (`test/fixtures/draft` intent drafted via the engine into a temp repo)
- Commands run and outcome:

```text
$ node dist/cli.js --repo <sandbox> export circuit-json
wrote outputs/circuit.json (61 element(s))            # exit 0

$ node dist/cli.js --repo <sandbox> --json export circuit-json
{ "outPath": "outputs/circuit.json", "elementCount": 61 }   # exit 0

$ echo >> <sandbox>/board.kicad_sch                   # hand-edit the sheet
$ node dist/cli.js --repo <sandbox> export circuit-json
board.kicad_sch does not match what schematic.intent.json drafts ...
re-draft with copperhead draft schematic, then export again   # exit 1

$ node dist/cli.js export --help
lists both `bom` and `circuit-json` subcommands       # exit 0
```

Additionally exercised against the ten real-design examples on the `test/real-netlist-corpus` branch (via `circuit-json-corpus-run`): all ten re-draft byte-identical and export schema-valid circuit-json (154 to 3,049 elements per board).

## Docs

[README.md](README.md): command list entry plus an Interchange section documenting the drafted-sheets-only scope and the derived-read-only constraint. Command header comments in [export.ts](src/commands/export.ts) state the contract.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A (no agent tool changes; the serializer is unreachable from any mutation tool)
- [ ] **Verification-gated out**: N/A (export runs downstream of the existing gates and mutates nothing)
- [x] **`check`/`verify` stays LLM-free and network-free**: untouched; the new command module keeps `export.ts`'s no-provider contract
- [x] **No sexp serialization**: `sexp.ts` untouched and never invoked by this path; the export never parses KiCad text
- [ ] **Sync-obligations ledger**: N/A
- [ ] **Secrets**: N/A (no transcripts, keys, or env handling touched)
- [x] **Spec coherence**: `openspec validate add-circuit-json-export` passes; proposal, design, delta specs, and tasks move together in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `copperhead export circuit-json` for deterministic, offline Circuit JSON generation from drafted schematics.
  - Defaults to `outputs/circuit.json` and supports custom output paths.
  - Preserves connectivity, labels, traces, wires, components, and no-connect information.
  - Supports JSON output and concise CLI success reporting.

- **Validation**
  - Rejects missing, stale, or manually edited schematics with actionable errors and no invalid output.

- **Documentation**
  - Added CLI usage, behavior, limitations, and export design documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->