### PR TITLE
docs: cloud console section

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
             '- Commands: `copperhead init` (scaffold docs/ from a schematic, idempotent), `copperhead do "<change>"` (propose, edit, verify, propagate, commit), `copperhead check` (ERC + DRC + doc drift + spec validation, no LLM calls, CI-safe, alias: `verify`), `copperhead sync` (verify whole design state, resolve drift), `copperhead create --brief brief.md` (product brief to full output package).',
             '- Two invariants: nothing starts without a validated change proposal (the edit tools are structurally unavailable until one exists), and nothing is "done" until ERC/DRC passes (failed verification rolls back to a git snapshot).',
             '- It is not an autorouter, not a new editor (KiCad remains the editor), and not the engineer of record (a human signs off).',
+            '- copperhead cloud (app.copperhead.sh) is the optional hosted console: sign in with GitHub or email, connect a repository through the copperhead GitHub App, and run `copperhead check` hosted with a live streamed transcript. It stores identity, tenancy, and run metadata only, never KiCad files or model keys; the CLI needs no account.',
             `- Source: ${REPO}`,
           ].join('\n'),
           optionalLinks: [
@@ -103,6 +104,16 @@ export default defineConfig({
             { label: 'Schematic legibility rules', link: '/reference/schematic-legibility/' },
             { label: 'How schematics are drafted', link: '/reference/schematic-drafting/' },
             { label: 'The schematic intent file', link: '/reference/schematic-intent/' },
+          ],
+        },
+        {
+          label: 'Cloud console',
+          items: [
+            { label: 'Overview', link: '/cloud/overview/' },
+            { label: 'Sign in and organizations', link: '/cloud/sign-in-and-orgs/' },
+            { label: 'Connect a repository', link: '/cloud/connect-a-repository/' },
+            { label: 'Hosted check runs', link: '/cloud/hosted-checks/' },
+            { label: 'Troubleshooting', link: '/cloud/troubleshooting/' },
           ],
         },
         {

--- a/docs/src/content/docs/cloud/connect-a-repository.md
+++ b/docs/src/content/docs/cloud/connect-a-repository.md
@@ -1,0 +1,36 @@
+---
+title: Connect a repository
+description: Install the copperhead GitHub App, connect a repository as a project, and understand what the console reads from it.
+sidebar:
+  order: 3
+---
+
+A **project** is one connected repository. Connecting is a two-step consent: install the copperhead GitHub App on the repositories you choose, then pick one of them in the console.
+
+## Install the App and connect
+
+1. Open **Projects** and choose **Connect a repository**.
+2. You are sent to GitHub to install the **copperhead** GitHub App. Choose the repositories it may see: all of them, or a selection. This is where repository access is granted; sign-in never asked for it.
+3. Back in the console, the repositories the installation can see are listed live from GitHub. Choose one and connect it.
+
+The console records the repository name and id, the installation it came through, the default branch, and the repository's visibility. All of that is read from GitHub server-side; nothing you type in the console can change it.
+
+## What the App can do
+
+The App holds these repository permissions: contents (read and write), pull requests (read and write), checks (read and write), and metadata (read). Today the console uses them to list repositories, resolve a branch to a commit, and clone at that commit for a run. Writing back (a branch and pull request from an agent run) arrives with hosted agent runs, and it will always be a branch, never a push to your default branch.
+
+## Personal accounts only, for now
+
+The App must be installed on **your own GitHub account**, the one you signed in with. Installing it on a GitHub organization is not supported yet: organization installations arrive together with team organizations in the console, so that an organization's repositories connect to a team, not to whoever clicked first. If you install on an organization today, the console will decline to bind that installation and tell you why.
+
+## Open hardware
+
+A public repository is marked **open hardware** on its project. The flag is derived from the repository's visibility on GitHub, refreshed each time the projects page loads. Flipping a repository from public to private is picked up on the next load. This is the flag pricing will read, and it cannot be set from the console.
+
+## Disconnect
+
+Disconnecting a project (owner or admin) removes only the pointer in copperhead cloud. The repository and the App installation stay exactly as they are; nothing is written to GitHub. Removing the App installation itself is done from the installation's card in the console (owner or admin) or on GitHub under *Settings, Applications*. An installation still referenced by a project asks you to disconnect the project first.
+
+## What is read, and when
+
+Repository state is read live at page load; there is no webhook yet, so a rename or visibility change lands on the next visit. A run reads the repository exactly once: it resolves the branch to a commit sha when you trigger it, and clones that commit when a worker picks it up. The clone is discarded when the run ends.

--- a/docs/src/content/docs/cloud/hosted-checks.md
+++ b/docs/src/content/docs/cloud/hosted-checks.md
@@ -1,0 +1,66 @@
+---
+title: Hosted check runs
+description: Run copperhead check from the browser, watch it stream, cancel it, and read verdicts, limits, and what a run records.
+sidebar:
+  order: 4
+---
+
+`copperhead check` runs ERC, DRC, documentation drift, and spec validation against a repository. It uses no language model and makes no network calls, which is a contract: it is the same deterministic check you run in CI, and it is what the console runs hosted today. See [Verify and sync](/workflows/verify-and-sync/) for what the check itself does.
+
+## Start a run
+
+1. On **Projects** or the **Overview**, find the connected project and choose **Run check**.
+2. The console pins the run to the current head of the repository's default branch, queues it, and opens the run page.
+3. A worker starts, clones the repository at that commit, runs the CLI, and streams the output back.
+
+**Run check** is disabled, with the reason, on a project that is not connected to a repository. If a run cannot be started, the page you came from says why: the branch could not be found, GitHub could not be reached, the project is not connected, or the organization has reached its run limit.
+
+## Watch a run
+
+The run page (`/runs/<id>`) shows:
+
+- the status pill: **Queued** (waiting for a worker), **Running**, then **Passed**, **Failed**, or **Cancelled**
+- when it started, how long it ran, the exact commit it ran against, and the run id
+- the live transcript: the CLI's own output as it happens, plus short notes from the worker (claimed, cloning, starting, finished)
+- once finished, a one-line verdict and, under **Result**, the CLI's machine-readable result
+
+Each run executes in a fresh container started for that run alone, so there is a short cold start; while queued the page says "Starting a worker. The first lines usually take under a minute." The stream reconnects on its own if the connection drops, and the page refreshes itself with the final state when the run finishes.
+
+## Run history and the overview
+
+- **Runs** lists every run in the organization, newest first: kind, project, commit, when it started, how long it took, and status, 25 per page. Each row opens the run.
+- **Overview** summarises the organization: projects and how many are connected, runs in the last 30 days and how many are queued or running, the pass rate over finished runs, and what is active now; then each project with its latest run and a **Run check** control, and the eight most recent runs with a one-line verdict.
+
+## Cancel a run
+
+Open the run and choose **Cancel run**. A queued run is cancelled at once and no worker ever picks it up. A running run is asked to stop; the worker sees the request within a few seconds, stops the CLI, and records **Cancelled**. Once a run has finished, cancel does nothing.
+
+## Verdicts
+
+| Status | Meaning |
+| --- | --- |
+| Passed | ERC, DRC, and drift all clean: the CLI exited 0. |
+| Failed, "The check reported findings." | The CLI ran and reported problems (exit 1). Read the transcript and the result. |
+| Failed, "Could not run: ..." | The CLI did not reach a verdict: the repository could not be cloned, the run timed out, KiCad could not load a file. The reason is shown. |
+| Failed, "The worker stopped responding and the run was reaped." | The worker died mid-run and the platform closed the run out. Run it again. |
+| Cancelled | You or another member cancelled it. |
+
+## Limits
+
+Per organization, until billing arrives:
+
+- at most two runs queued or running at once
+- at most twenty runs in any rolling 24 hours
+- a check run may take up to 10 minutes before it is stopped
+
+## What a run records
+
+- kind, project, branch name and the exact commit sha, who started it and when, when it started and finished, and status
+- the transcript lines shown on the run page
+- a summary: the exit path and, for a finished run, the CLI's `--json` result
+
+Nothing else. The clone is discarded when the run ends, and no artifact of the repository is kept. Fabrication exports (gerbers, STEP, DXF) as downloadable run outputs are the next thing to arrive.
+
+## KiCad version
+
+The worker runs KiCad 9's `kicad-cli`. A board saved in a newer KiCad may fail to load and show as "Could not run"; the transcript names the file.

--- a/docs/src/content/docs/cloud/overview.md
+++ b/docs/src/content/docs/cloud/overview.md
@@ -1,0 +1,36 @@
+---
+title: Cloud console overview
+description: What copperhead cloud is, what it does today, and what it deliberately never stores.
+sidebar:
+  order: 1
+---
+
+[copperhead cloud](https://app.copperhead.sh) is the hosted front door for copperhead. The CLI is the agent and works on your machine with no account at all; the cloud is the account, the tenant, and the place a run is watched. It holds no design truth of its own.
+
+Today the console does four things:
+
+- **Sign in** with GitHub or an email link, into an organization that is provisioned for you.
+- **Connect a repository** through the copperhead GitHub App, as a project.
+- **Run `copperhead check` hosted**, against a pinned commit of the repository, from the browser.
+- **Watch the run** stream live, cancel it, and read its verdict and history.
+
+Hosted agent runs (`do`, `create`), fabrication exports, and team organizations with billing are on the way; the console tells you plainly when a control is not available yet and what unlocks it.
+
+## The three rules the console lives by
+
+**Design truth stays in your repository.** copperhead cloud stores identity, tenancy, pointers, and run metadata: who ran what, on which commit, and what the CLI said. It never stores your KiCad files or becomes a second copy of your design.
+
+**Repository access is an installation, not your sign-in.** Signing in asks GitHub only for your public profile and email. Reading a repository requires the copperhead GitHub App to be installed on it, which is a separate consent. The console mints a short-lived token for that installation, uses it, and drops it; the worker that clones your repository for a run does the same.
+
+**The tenant boundary is enforced in the database.** Every read in the console is filtered by row-level security in Postgres, so an application bug is not enough to show one organization another organization's rows. A link to something you cannot see shows "Not found", indistinguishable from a link that never existed.
+
+## What a run is, in one paragraph
+
+A hosted run is one execution of the copperhead CLI, in a fresh container, against one commit of a connected repository. `check` runs ERC, DRC, documentation drift, and spec validation; it uses no language model and makes no network calls, so nothing about a hosted check depends on a model key. The worker streams the CLI's own transcript back to the run page as it happens, records the verdict and the CLI's machine-readable result, and discards the clone.
+
+## Where to go next
+
+- [Sign in and organizations](/cloud/sign-in-and-orgs/)
+- [Connect a repository](/cloud/connect-a-repository/)
+- [Hosted check runs](/cloud/hosted-checks/)
+- [Troubleshooting](/cloud/troubleshooting/)

--- a/docs/src/content/docs/cloud/sign-in-and-orgs.md
+++ b/docs/src/content/docs/cloud/sign-in-and-orgs.md
@@ -1,0 +1,53 @@
+---
+title: Sign in and organizations
+description: How sign-in works, what an organization is, roles, the org switcher, and your account.
+sidebar:
+  order: 2
+---
+
+## Sign in
+
+Go to [app.copperhead.sh/login](https://app.copperhead.sh/login).
+
+- **Continue with GitHub** signs you in with your GitHub account. Sign-in asks GitHub for your public profile and email address only; it never asks for repository access. Repository access is a separate step, described in [Connect a repository](/cloud/connect-a-repository/).
+- **Email link** sends a one-time link to your address.
+
+Both methods resolve to one user: if you sign in with GitHub and later with the same email, you land in the same account with the same organizations.
+
+The first time you sign in, a short onboarding screen asks for your display name and a name for your organization. That is your personal organization; it is created for you and you are its owner.
+
+Sign out from the account menu.
+
+## Organizations
+
+Everything in the console belongs to an **organization**: projects, runs, members, settings, and the audit log. Every user has a personal organization. Team organizations, with invitations and seats, arrive with billing.
+
+Organizations are never part of the URL. `/projects` is always the active organization's projects; `/runs` its runs. The active organization is shown in the sidebar switcher, and selecting another one you belong to switches the whole console at the same URL.
+
+If you follow a link to a run or project in another organization you belong to, the console switches to that organization for you. A link to something in an organization you do not belong to shows "Not found", exactly as a link that never existed would.
+
+## Roles
+
+| Capability | owner | admin | member |
+| --- | :---: | :---: | :---: |
+| Read projects and runs | yes | yes | yes |
+| Trigger and cancel runs | yes | yes | yes |
+| Connect and disconnect repositories | yes | yes | yes |
+| Rename the organization | yes | yes | no |
+| Remove an App installation binding | yes | yes | no |
+| Read the audit log | yes | yes | no |
+| Invite and remove members, change roles, billing | with team organizations | | |
+
+Every organization always has at least one owner.
+
+## Settings
+
+- **General** shows the organization's display name (owners and admins can change it) and its id, in monospace, for support.
+- **Members** lists members and roles; inviting is disabled until team organizations arrive, and the control says so.
+- **Billing** shows the current plan; managing it is disabled until billing arrives.
+
+## Your account
+
+`/account` shows your profile, the identities linked to your user (GitHub, email), and the danger zone.
+
+Deleting your account deletes the organizations where you are the only member (your personal organization, with its projects and run history) and refuses while you are the sole owner of an organization that still has other members: hand ownership over first. Audit history is kept without your identity.

--- a/docs/src/content/docs/cloud/troubleshooting.md
+++ b/docs/src/content/docs/cloud/troubleshooting.md
@@ -1,0 +1,55 @@
+---
+title: Troubleshooting
+description: The messages you may see in the cloud console and what to do about each.
+sidebar:
+  order: 5
+---
+
+## Sign-in and access
+
+**I signed in with email and then with GitHub; are those two accounts?**
+No. Both resolve to the same user as long as the email address matches. Your organizations and projects are the same in both.
+
+**"Not found" on a link a colleague sent me.**
+The console does not distinguish a wrong id from a run or project in an organization you are not a member of. Ask them to check the organization; team invitations arrive with billing.
+
+## Connecting repositories
+
+**The App installation was declined.**
+The App was installed on a GitHub organization. Only installations on your own account bind today; organization installations arrive with team organizations. Reinstall on your personal account, or wait for team organizations.
+
+**A repository is missing from the list.**
+The installation does not cover it. On GitHub, open *Settings, Applications, copperhead, Configure* and add the repository, then reload the connect page: the list is read live.
+
+**A repository is shown as already connected.**
+One repository connects to an organization at most once. Find it under Projects.
+
+## Runs
+
+**"Run check" is disabled.**
+The project has no repository connected, or its installation was removed. Reconnect it from Projects.
+
+**"The default branch could not be found on the repository."**
+The branch was renamed or deleted, or the installation no longer covers the repository. Fix the default branch on GitHub or reconnect the project.
+
+**"GitHub could not be reached to resolve the branch."**
+A transient GitHub or network problem. Try again in a moment.
+
+**"This org already has two runs queued or running."** or **"...twenty runs in 24 hours."**
+Per-organization limits until billing arrives. Wait for a run to finish, or cancel one from its run page.
+
+**The run stays Queued for several minutes.**
+Workers start on demand and the first one after a quiet period takes longer while its image is fetched. If a run stays queued far beyond that, cancel it and start again; if it repeats, tell us with the run id.
+
+**Failed, "Could not run: ..."**
+The reason is on the run page. "run timed out" means the check exceeded 10 minutes. A KiCad file the worker cannot open usually means the board was saved with a newer KiCad than the worker's KiCad 9.
+
+**Failed, "The worker stopped responding and the run was reaped."**
+The worker died mid-run and the run was closed out. Start it again.
+
+**The transcript stopped updating.**
+The stream reconnects on its own and resumes where it left off; a page reload shows everything recorded so far. When the run finishes the page refreshes itself.
+
+## Reporting a problem
+
+Include the run id (shown on the run page in monospace) or the organization id (Settings, General). Neither is secret, and both let us find exactly what happened.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -42,6 +42,11 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     passes. The agent reads its own errors back and repairs, or rolls back to
     the git snapshot.
   </Card>
+  <Card title="Hosted, when you want it" icon="rocket">
+    The optional cloud console at app.copperhead.sh runs `copperhead check`
+    on a connected repository and streams the transcript to your browser.
+    It stores run metadata, never your KiCad files or model keys.
+  </Card>
   <Card title="Docs as memory" icon="open-book">
     Design docs are the agent's memory and its output. Decisions land in an
     append-only DECISIONS.md, and every run writes a human-readable summary


### PR DESCRIPTION
Adds a **Cloud console** section to docs.copperhead.sh (Starlight sidebar group under Reference): Overview, Sign in and organizations, Connect a repository, Hosted check runs, Troubleshooting. Plus a card on the docs index and one line in the llms.txt details.

Documentation only. The CLI gains no code, no cloud dependency, and still needs no account (invariant 1 of the cloud spec). Content matches what app.copperhead.sh does after copperheadhq/copperhead-cloud#18: sign in, orgs, GitHub App installation, hosted `copperhead check` with a streamed transcript, history, cancel, verdicts, and per-org limits.

`npm run build` in `docs/` builds 22 pages including the five new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the optional Copperhead Cloud hosted console.
  * Documented sign-in, organization access, repository connections, hosted checks, limits, run history, data handling, and troubleshooting.
  * Added navigation links and a homepage card introducing the hosted console and its capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->