### PR TITLE
fix(create): name the tool that produces the outputs stage's artifacts

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -266,7 +266,12 @@ export const STAGES: Stage[] = [
       return dirHasFiles(path.join(root, 'outputs'), ['.gbr', '.gtl', '.gbl', '.gbs', '.gbo', '.gbp', '.gbd', '.gto', '.gts', '.gml']);
     },
     prompt: () =>
-      'Stage 6: outputs package. Export into outputs/: gerbers+drill (JLC profile), DXF and STEP outline, SVG renders (export_svg), and an ordering BOM.csv generated from BOM.md (refdes, MPN, qty). Every export must succeed.',
+      // `export_outputs` is what actually produces the gerbers, drill, DXF and
+      // STEP this stage asks for; `export_svg` only renders. Naming just the
+      // renderer left the stage asking for a fab package while pointing at the
+      // one tool that cannot make one. `export_outputs` is an edit tool, so it
+      // stays hidden until a proposal validates — hence the explicit order.
+      'Stage 6: outputs package. Export into outputs/: gerbers+drill (JLC profile), DXF and STEP outline, SVG renders, and an ordering BOM.csv generated from BOM.md (refdes, MPN, qty). Propose and validate a change first, then call export_outputs for the fabrication package (gerbers+drill, DXF, STEP) and export_svg for the renders. Every export must succeed.',
   },
   {
     name: 'firmware',

--- a/test/outputs-stage-tooling.test.ts
+++ b/test/outputs-stage-tooling.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { STAGES } from '../src/commands/create.js';
+import { TOOLS } from '../src/agent/tools.js';
+
+/**
+ * Issue #228: the outputs stage asked for a fabrication package while naming
+ * only `export_svg`, which renders and cannot produce gerbers, drill, DXF or
+ * STEP. `export_outputs` does exist and wraps `exportFab`, but it is an edit
+ * tool, so it stays out of the advertised list until a proposal validates —
+ * the stage never mentioned it, so nothing told the agent it was reachable.
+ *
+ * These pin the contract rather than the wording: whatever artifacts the stage
+ * demands, it must name a tool that can actually produce them.
+ */
+
+const outputsStage = STAGES.find((s) => s.name === 'outputs');
+
+describe('outputs stage tooling (issue #228)', () => {
+  it('the stage exists and asks for a fabrication package', () => {
+    expect(outputsStage, 'the outputs stage should exist').toBeDefined();
+    const prompt = outputsStage!.prompt();
+    expect(prompt).toMatch(/gerber/i);
+    expect(prompt).toMatch(/drill/i);
+  });
+
+  it('names a tool that can produce the artifacts it demands', () => {
+    const prompt = outputsStage!.prompt();
+    // export_svg renders only; the fab package comes from export_outputs.
+    expect(prompt).toContain('export_outputs');
+  });
+
+  it('export_outputs is a real registered tool', () => {
+    const tool = TOOLS.find((t) => t.schema.name === 'export_outputs');
+    expect(tool, 'export_outputs should be registered').toBeDefined();
+    expect(tool!.schema.description).toMatch(/gerber/i);
+  });
+
+  it('tells the agent how to reach an unlock-gated export tool', () => {
+    const tool = TOOLS.find((t) => t.schema.name === 'export_outputs');
+    // If the tool is unlock-gated, the prompt has to say how to unlock it,
+    // otherwise naming it is not enough to make it reachable.
+    if (tool!.requiresUnlock) {
+      expect(outputsStage!.prompt()).toMatch(/validate/i);
+    }
+  });
+});


### PR DESCRIPTION
## What

Stage 6 of the create pipeline now names `export_outputs` as the tool that produces the fabrication package, and says how to reach it. Previously it asked for gerbers, drill, DXF and STEP while naming only `export_svg`.

## Why

Refs #228, though the diagnosis there turns out to be off in a way worth recording.

The issue says the stage is unsatisfiable because "the agent tool surface exposes only `export_svg`". `export_outputs` does exist: [tools.ts](src/agent/tools.ts) registers it, and it wraps `exportFab` in [cli.ts](src/kicad/cli.ts), which emits gerbers, drill, `outline.dxf` and `board.step`. It was present at `4998f54`, the commit the report was filed against.

The real problem is that the stage never told the agent about it. Two things combine:

1. `export_outputs` is `requiresUnlock: true`, and `availableTools()` filters unlock-gated tools out of the advertised list until a proposal validates. `editsUnlocked` starts `false`.
2. The stage prompt named `export_svg` and nothing else.

So the agent was asked for a fab package while pointed at the one export tool that cannot produce one, with no indication that another existed or how to reach it. That matches the transcript in the issue: it exports SVGs, cannot satisfy "gerbers+drill", and burns the stage.

## Design

The fix is prompt-side only, because the tooling is already correct. Naming the tool alone would not be enough while it is unlock-gated, so the prompt also states the order: propose and validate first, then export.

I deliberately did not change the `requiresUnlock` policy. `export_outputs` writes into `outputs/` and adds to `filesTouched`, so it is an edit tool by the same rule as the rest, and relaxing that is a safety decision rather than a stage-prompt one. The spec-gated-in invariant is untouched: nothing about which tools are structurally absent before validation has changed.

The tests pin the contract rather than the wording, so a future rewrite of the prompt cannot quietly reintroduce the gap: whatever artifacts the stage demands, it must name a tool that can produce them, and while that tool is unlock-gated it must also say how to unlock it.

## Spec / OpenSpec

No spec-level behavior changes. The stage's contract (SPEC 2.5 outputs) is unchanged; this makes the stage able to meet the contract it already had. Pure prompt and test change, so no delta specs or `tasks.md` entries.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass (exit 0) |
| Build | `npm run build` | pass (exit 0) |
| Unit + offline | `npm test` | 751 passed, 25 failed, 20 skipped |
| Markdown lint | `npm run lint:md` | pass (0 issues, 164 files) |
| Live-LLM (opt-in) | not run | n/a |

New tests: `test/outputs-stage-tooling.test.ts`, 4 cases. Two of them fail on `main` and pass here:

```text
main:      2 failed | 2 passed (4)
  x names a tool that can produce the artifacts it demands
      AssertionError: expected 'Stage 6: outputs package. Export into...' to contain 'export_outputs'
  x tells the agent how to reach an unlock-gated export tool
      AssertionError: expected 'Stage 6: outputs package. Export into...' to match /validate/i

this branch: 4 passed (4)
```

The other two pass on both by design: they assert the stage exists and asks for gerbers, and that `export_outputs` is registered, which are the premises the first two rest on.

Pre-existing failures unrelated to this PR: the 25 failures above are identical on `main` in my environment (Windows, no `kicad-cli`). Baseline was 25 failed / 747 passed / 792 total; this branch is 25 failed / 751 passed / 796 total, i.e. the same failures plus the 4 new tests. The one failure inside `test/stage-completion.test.ts` (`schematic isComplete: legibility gate`) also reproduces unchanged on `main`.

### Manual test log (required)

The stage prompt is a pure function, so it can be exercised directly against the built output rather than through a full pipeline run (which needs `kicad-cli` and a key, neither available here).

```text
$ npm run build
$ node -e "const {STAGES}=require('./dist/commands/create.js'); const s=STAGES.find(x=>x.name==='outputs'); console.log(s.prompt(''));"

Stage 6: outputs package. Export into outputs/: gerbers+drill (JLC profile), DXF and
STEP outline, SVG renders, and an ordering BOM.csv generated from BOM.md (refdes, MPN,
qty). Propose and validate a change first, then call export_outputs for the fabrication
package (gerbers+drill, DXF, STEP) and export_svg for the renders. Every export must
succeed.
```

On `main` the same command prints the old text, naming `export_svg` only.

## Docs

None. The change is inside a stage prompt string, not user-facing documentation.

---

## Invariant checklist

- [x] **Spec-gated in**: unchanged. `export_outputs` stays `requiresUnlock: true` and structurally absent from the advertised list until a proposal validates. The prompt describes that ordering rather than bypassing it.
- [ ] **Verification-gated out**: N/A, no mutation path changed.
- [x] **`check`/`verify` stays LLM-free and network-free**: N/A in effect, nothing under `src/commands/check` is touched.
- [x] **No sexp serialization**: N/A, the KiCad parser is untouched.
- [ ] **Sync-obligations ledger**: N/A, no tool-call hooks changed.
- [x] **Secrets**: N/A, no transcript, summary or env handling touched.
- [x] **Spec coherence**: no spec-level behavior changed, so SPEC.md and the change artifacts stay as they are.

## One thing worth a separate decision

While confirming the above I found that the stage's completion gate is weaker than its contract:

```ts
return dirHasFiles(path.join(root, 'outputs'), ['.gbr', '.gtl', ...]);
```

A single gerber file marks the whole stage complete, so a package missing drill, DXF, STEP or `BOM.csv` still passes, and a `resume` builds on it. That is the same class of problem as the one this PR fixes.

I have left it alone here because `test/stage-completion.test.ts` currently asserts that behavior (`returns true when outputs/ contains at least one Gerber file (.gbr)`), so tightening it is a deliberate contract change rather than a bug fix, and it belongs in its own PR with your call on how strict the gate should be. Happy to send that if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved fabrication export guidance to generate Gerber and drill files before render previews.
  * Added proposal validation before edit-producing exports.
  * Added unlock instructions when required.

* **Tests**
  * Added coverage to verify fabrication output requests, export tooling, descriptions, and required instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->