### PR TITLE
feat(create): checkpoint a failed stage attempt to a side ref

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -22,7 +22,16 @@ import { collectRunMeta, renderCliHeader, type RunMeta, type RunMetaInput } from
 import { plainRenderer, fmtDuration, fmtTokens, type ProgressRenderer } from './render.js';
 import { styleHeaderLines } from './theme.js';
 import { ObligationsLedger } from './ledger.js';
-import { gitPreflight, isDirty, snapshot, restore, commitAll, changedFiles, preserveFailedRun } from '../util/git.js';
+import {
+  gitPreflight,
+  isDirty,
+  snapshot,
+  restore,
+  commitAll,
+  changedFiles,
+  preserveFailedRun,
+  checkpointTree,
+} from '../util/git.js';
 import { withRetry, isRateLimit, sessionLimit } from '../util/retry.js';
 import { openspecArchive } from '../openspec/cli.js';
 import { existsSync } from 'node:fs';
@@ -75,6 +84,16 @@ export interface RunResult {
   transcriptDir: string;
   filesTouched: string[];
   commit: string | null;
+  /**
+   * A checkpoint commit captured from the dirty tree just before an
+   * unsuccessful run rolled it back (issue #208), or null on a successful run
+   * or when there was nothing to capture. Not yet pointed at by any ref: the
+   * caller decides where, since only it knows the stage (see
+   * util/git.js#recordWipRef). Capturing here, before restore(), is what
+   * makes this the failed attempt's own work rather than whatever the tree
+   * happens to hold after rollback.
+   */
+  failedAttemptCommit: string | null;
   /** Cost/telemetry for this run. Surfaced by the create pipeline's per-stage
    *  cost table (5.2) so the expensive stages are obvious across runs. */
   stats: RunStats;
@@ -380,6 +399,11 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
     // it, so a budget-exhaustion (or any) failure is recoverable (issue #15).
     const preserved = await preserveFailedRun(repoRoot, ctx.runId);
     if (preserved) await transcript.event('work-preserved', { stash: preserved });
+    // Capture the dirty tree as a checkpoint commit before the rollback below
+    // destroys it, so the create pipeline can point a stage's WIP ref at the
+    // failed attempt itself rather than the clean, already-restored tree it
+    // would otherwise see (issue #208).
+    const failedAttemptCommit = await checkpointTree(repoRoot, `copperhead: WIP checkpoint — NOT CERTIFIED (${reason})`);
     // The rollback itself can fail (git in a bad state). That must not become
     // an unhandled throw that skips run-end and summary.md — the summary is
     // most valuable exactly when the tree is left in an unknown state.
@@ -431,6 +455,7 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
       transcriptDir: transcript.dir,
       filesTouched: [],
       commit: null,
+      failedAttemptCommit,
       stats: runStats,
       cacheHits: cacheHits(),
     };
@@ -613,6 +638,9 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
       const { outcome, summary } = ctx.finishRequest;
       const files = [...ctx.filesTouched];
       if (outcome === 'refuse') {
+        // Same reasoning as fail(): capture before restore() destroys it, so
+        // a refused run's partial work is recoverable via the WIP ref too.
+        const failedAttemptCommit = await checkpointTree(repoRoot, `copperhead: WIP checkpoint — NOT CERTIFIED (refused: ${summary})`);
         await restore(repoRoot, snap);
         await transcript.event('run-refused', { summary });
         const runStats = stats('refused');
@@ -642,6 +670,7 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
           transcriptDir: transcript.dir,
           filesTouched: [],
           commit: null,
+          failedAttemptCommit,
           stats: runStats,
           cacheHits: cacheHits(),
         };
@@ -689,6 +718,7 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
           transcriptDir: transcript.dir,
           filesTouched: files,
           commit: null,
+          failedAttemptCommit: null,
           stats: runStats,
           cacheHits: cacheHits(),
         };
@@ -770,6 +800,7 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
         transcriptDir: transcript.dir,
         filesTouched: files,
         commit,
+        failedAttemptCommit: null,
         stats: runStats,
         cacheHits: cacheHits(),
       };

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -8,7 +8,7 @@ import { exportSvg, runErc } from '../kicad/cli.js';
 import { listSymbols } from '../kicad/sexp.js';
 import { checkLegibility } from '../kicad/legibility.js';
 import { draftSchematicToText, defaultIntentPath } from '../kicad/draft/draft.js';
-import { isDirty, commitAll, changedFiles, checkpoint, wipRef } from '../util/git.js';
+import { isDirty, commitAll, changedFiles, recordWipRef, wipRef } from '../util/git.js';
 import type { CompatSettings, CopperheadConfig } from '../config.js';
 import { checkDrift } from '../memory/drift.js';
 import { runAgentLoop, makeProvider, type BudgetExhaustedStats } from '../agent/loop.js';
@@ -916,17 +916,16 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
         break;
       }
 
-      // The attempt did not complete the stage, so its work has already been
-      // rolled back. Record whatever survived to a side ref before the next
-      // attempt overwrites the tree, so accepted work is recoverable and a
+      // The attempt did not complete the stage, and — when runAgentLoop
+      // itself rolled the tree back (a genuine failure or refusal) — its work
+      // was captured as a checkpoint commit before that rollback ran (see
+      // RunResult.failedAttemptCommit). Point this stage's side ref at it
+      // here, once the stage is known, so accepted work is recoverable and a
       // human can diff what the attempt actually produced (issue #208). The
       // branch is untouched: only stage-complete commits ever land on it.
-      const wip = await checkpoint(
-        opts.repoRoot,
-        stage.name,
-        `copperhead: WIP ${stage.name} attempt ${attempt} — NOT CERTIFIED, stage did not complete`,
-      );
+      const wip = res.failedAttemptCommit;
       if (wip) {
+        await recordWipRef(opts.repoRoot, stage.name, wip);
         opts.log(
           stageLine(
             stage.name,

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -8,7 +8,7 @@ import { exportSvg, runErc } from '../kicad/cli.js';
 import { listSymbols } from '../kicad/sexp.js';
 import { checkLegibility } from '../kicad/legibility.js';
 import { draftSchematicToText, defaultIntentPath } from '../kicad/draft/draft.js';
-import { isDirty, commitAll, changedFiles } from '../util/git.js';
+import { isDirty, commitAll, changedFiles, checkpoint, wipRef } from '../util/git.js';
 import type { CompatSettings, CopperheadConfig } from '../config.js';
 import { checkDrift } from '../memory/drift.js';
 import { runAgentLoop, makeProvider, type BudgetExhaustedStats } from '../agent/loop.js';
@@ -914,6 +914,25 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
       if (!failure) {
         stageDone = true;
         break;
+      }
+
+      // The attempt did not complete the stage, so its work has already been
+      // rolled back. Record whatever survived to a side ref before the next
+      // attempt overwrites the tree, so accepted work is recoverable and a
+      // human can diff what the attempt actually produced (issue #208). The
+      // branch is untouched: only stage-complete commits ever land on it.
+      const wip = await checkpoint(
+        opts.repoRoot,
+        stage.name,
+        `copperhead: WIP ${stage.name} attempt ${attempt} — NOT CERTIFIED, stage did not complete`,
+      );
+      if (wip) {
+        opts.log(
+          stageLine(
+            stage.name,
+            `attempt ${attempt} work checkpointed at ${wipRef(stage.name)} (${wip.slice(0, 10)}); inspect with \`git show ${wip.slice(0, 10)}\``,
+          ),
+        );
       }
 
       if (attempt > config.maxStageRetries) {

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -342,50 +342,86 @@ export function wipRef(stage: string): string {
 }
 
 /**
- * Commit the current working state to a side ref, without touching the branch,
- * the index, or the working tree (issue #208).
+ * Capture the current working state as a commit object, without touching any
+ * ref, the index, or the working tree (issue #208).
  *
  * A failed stage attempt rolls the tree back, and the accepted work it had
  * produced survives only as a stash of *tracked* files: anything the agent left
- * untracked is destroyed outright, and a retry restarts from zero. This writes
- * everything the repo would commit — tracked changes and untracked files alike,
- * `.gitignore` still respected — to `refs/copperhead/wip/<stage>` first, so the
- * work stays visible, diffable and recoverable after the rollback.
+ * untracked is destroyed outright, and a retry restarts from zero. This commits
+ * everything the repo would commit — tracked changes and untracked files alike
+ * — so the work stays diffable and recoverable after the rollback, once a
+ * caller points a ref at the returned sha (see recordWipRef()).
  *
- * The branch is untouched, so the verification-gated-out invariant holds
- * verbatim: the only commits on it remain the stage-complete ones, and nothing
- * uncertified can be mistaken for approved output. The checkpoint is reachable
- * only by its own ref.
+ * `.gitignore` is deliberately left untouched: a checkpoint must never mutate
+ * the caller's worktree. GIT_ADD_EXCLUDES is instead stripped from the
+ * temporary index directly after the add, so an excluded path is still
+ * excluded without an edit that would otherwise land in the checkpoint commit
+ * itself, or spuriously trigger one when it was the only dirty path.
  *
  * Uses a temporary index so the caller's staged state is never disturbed, which
  * matters because this runs mid-pipeline rather than between commands.
  *
+ * Split out from checkpoint() so a caller that is about to roll back a dirty
+ * tree (runAgentLoop's fail/refused paths) can capture it *before* the
+ * rollback runs. checkpoint() alone runs too late for that: a caller that
+ * only regains control after the rollback — as the create pipeline does —
+ * captures the clean, already-restored tree instead of the failed attempt.
+ *
  * Returns the checkpoint commit, or null when there is nothing to record.
  */
-export async function checkpoint(repo: string, stage: string, message: string): Promise<string | null> {
-  const tmpIndex = path.join(await mkdtemp(path.join(tmpdir(), 'copperhead-wip-')), 'index');
+export async function checkpointTree(repo: string, message: string): Promise<string | null> {
+  let tmpDir: string | null = null;
   try {
     if (!(await isDirty(repo))) return null;
-    await ensureIgnored(repo, GIT_ADD_EXCLUDES);
+    tmpDir = await mkdtemp(path.join(tmpdir(), 'copperhead-wip-'));
+    const tmpIndex = path.join(tmpDir, 'index');
     const env = { ...process.env, GIT_INDEX_FILE: tmpIndex };
     // Seed the temporary index from HEAD so the checkpoint is a normal commit
     // against it rather than an orphan holding only the changed paths.
     await execa('git', ['read-tree', 'HEAD'], { cwd: repo, env });
     await execa('git', ['add', '-A'], { cwd: repo, env });
+    await execa('git', ['rm', '-r', '--cached', '--ignore-unmatch', ...GIT_ADD_EXCLUDES], { cwd: repo, env });
     const { stdout: tree } = await execa('git', ['write-tree'], { cwd: repo, env });
     const head = await headCommit(repo);
+    // isDirty() saw real changes, but every one of them may have been under
+    // GIT_ADD_EXCLUDES and just got stripped back out above — a tree
+    // identical to HEAD's means there is nothing left worth capturing, not
+    // that a checkpoint should still be recorded.
+    const { stdout: headTree } = await execa('git', ['rev-parse', 'HEAD^{tree}'], { cwd: repo, env });
+    if (tree.trim() === headTree.trim()) return null;
     const { stdout: commit } = await execa('git', ['commit-tree', tree.trim(), '-p', head, '-m', message], {
       cwd: repo,
     });
-    await git(repo, ['update-ref', wipRef(stage), commit.trim()]);
     return commit.trim();
   } catch {
     // A checkpoint is a safety net, never a gate: failing to take one must not
     // fail the stage that was about to be rolled back anyway.
     return null;
   } finally {
-    await rm(path.dirname(tmpIndex), { recursive: true, force: true }).catch(() => {});
+    if (tmpDir) await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }
+}
+
+/** Point a stage's WIP ref at an already-captured checkpoint commit (see checkpointTree()). */
+export async function recordWipRef(repo: string, stage: string, commit: string): Promise<void> {
+  await git(repo, ['update-ref', wipRef(stage), commit]);
+}
+
+/**
+ * Checkpoint the current working state to a stage's WIP ref in one step:
+ * checkpointTree() followed by recordWipRef(). The branch is untouched, so
+ * the verification-gated-out invariant holds verbatim: the only commits on it
+ * remain the stage-complete ones, and nothing uncertified can be mistaken for
+ * approved output. The checkpoint is reachable only by its own ref.
+ *
+ * Callers that need to capture a tree before a rollback destroys it — as
+ * opposed to checkpointing whatever the tree happens to be at call time —
+ * should use checkpointTree() and recordWipRef() directly instead.
+ */
+export async function checkpoint(repo: string, stage: string, message: string): Promise<string | null> {
+  const commit = await checkpointTree(repo, message);
+  if (commit) await recordWipRef(repo, stage, commit);
+  return commit;
 }
 
 /** Current branch name, or "HEAD" when detached. Read-only metadata probe. */

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -336,6 +336,58 @@ export async function preserveFailedRun(repo: string, runId: string): Promise<st
   }
 }
 
+/** Where a stage's work-in-progress checkpoints live, one ref per stage. */
+export function wipRef(stage: string): string {
+  return `refs/copperhead/wip/${stage}`;
+}
+
+/**
+ * Commit the current working state to a side ref, without touching the branch,
+ * the index, or the working tree (issue #208).
+ *
+ * A failed stage attempt rolls the tree back, and the accepted work it had
+ * produced survives only as a stash of *tracked* files: anything the agent left
+ * untracked is destroyed outright, and a retry restarts from zero. This writes
+ * everything the repo would commit — tracked changes and untracked files alike,
+ * `.gitignore` still respected — to `refs/copperhead/wip/<stage>` first, so the
+ * work stays visible, diffable and recoverable after the rollback.
+ *
+ * The branch is untouched, so the verification-gated-out invariant holds
+ * verbatim: the only commits on it remain the stage-complete ones, and nothing
+ * uncertified can be mistaken for approved output. The checkpoint is reachable
+ * only by its own ref.
+ *
+ * Uses a temporary index so the caller's staged state is never disturbed, which
+ * matters because this runs mid-pipeline rather than between commands.
+ *
+ * Returns the checkpoint commit, or null when there is nothing to record.
+ */
+export async function checkpoint(repo: string, stage: string, message: string): Promise<string | null> {
+  const tmpIndex = path.join(await mkdtemp(path.join(tmpdir(), 'copperhead-wip-')), 'index');
+  try {
+    if (!(await isDirty(repo))) return null;
+    await ensureIgnored(repo, GIT_ADD_EXCLUDES);
+    const env = { ...process.env, GIT_INDEX_FILE: tmpIndex };
+    // Seed the temporary index from HEAD so the checkpoint is a normal commit
+    // against it rather than an orphan holding only the changed paths.
+    await execa('git', ['read-tree', 'HEAD'], { cwd: repo, env });
+    await execa('git', ['add', '-A'], { cwd: repo, env });
+    const { stdout: tree } = await execa('git', ['write-tree'], { cwd: repo, env });
+    const head = await headCommit(repo);
+    const { stdout: commit } = await execa('git', ['commit-tree', tree.trim(), '-p', head, '-m', message], {
+      cwd: repo,
+    });
+    await git(repo, ['update-ref', wipRef(stage), commit.trim()]);
+    return commit.trim();
+  } catch {
+    // A checkpoint is a safety net, never a gate: failing to take one must not
+    // fail the stage that was about to be rolled back anyway.
+    return null;
+  } finally {
+    await rm(path.dirname(tmpIndex), { recursive: true, force: true }).catch(() => {});
+  }
+}
+
 /** Current branch name, or "HEAD" when detached. Read-only metadata probe. */
 export async function branchName(repo: string): Promise<string> {
   return git(repo, ['rev-parse', '--abbrev-ref', 'HEAD']);

--- a/test/wip-checkpoint.test.ts
+++ b/test/wip-checkpoint.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { writeFile, readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { execa } from 'execa';
-import { checkpoint, wipRef, snapshot, restore, headCommit, branchName } from '../src/util/git.js';
+import { checkpoint, checkpointTree, recordWipRef, wipRef, snapshot, restore, headCommit, branchName } from '../src/util/git.js';
 import { tempFixtureRepo } from './helpers.js';
 
 /**
@@ -149,5 +149,130 @@ describe('WIP checkpoints (issue #208)', () => {
     // A checkpoint is a safety net, never a gate: it must not fail the stage
     // that was about to be rolled back anyway.
     await expect(checkpoint(path.join('does', 'not', 'exist'), 'schematic', 'x')).resolves.toBeNull();
+  }, 60_000);
+
+  it('returns null rather than throwing when the temp directory cannot be allocated', async () => {
+    // Regression: mkdtemp() used to run outside the try block, so an
+    // allocation failure rejected instead of returning null like every other
+    // checkpoint failure. Forcing os.tmpdir() to resolve to a path that does
+    // not exist reproduces that allocation failure.
+    const { repo, cleanup } = await tempFixtureRepo();
+    const savedEnv = { TMPDIR: process.env.TMPDIR, TMP: process.env.TMP, TEMP: process.env.TEMP };
+    try {
+      await commitEverything(repo, 'base');
+      await writeFile(path.join(repo, 'NOTES.md'), 'in progress\n', 'utf8');
+
+      const bogus = path.join(repo, 'does-not-exist', 'nested');
+      process.env.TMPDIR = bogus;
+      process.env.TMP = bogus;
+      process.env.TEMP = bogus;
+
+      await expect(checkpointTree(repo, 'copperhead: WIP')).resolves.toBeNull();
+    } finally {
+      process.env.TMPDIR = savedEnv.TMPDIR;
+      process.env.TMP = savedEnv.TMP;
+      process.env.TEMP = savedEnv.TEMP;
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('never edits .gitignore, even when it must exclude a path from the checkpoint', async () => {
+    // Regression: checkpoint() used to call ensureIgnored() to keep .history/
+    // out of the commit, which writes to the caller's .gitignore. That both
+    // pollutes the checkpoint with an unrelated edit (the next git add -A
+    // would pick the .gitignore change straight back up) and can produce a
+    // checkpoint out of nothing but that edit when the excluded path was the
+    // only pre-existing dirty content.
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await commitEverything(repo, 'base');
+      const gitignoreBefore = existsSync(path.join(repo, '.gitignore'))
+        ? await readFile(path.join(repo, '.gitignore'), 'utf8')
+        : null;
+
+      await mkdir(path.join(repo, '.history'), { recursive: true });
+      await writeFile(path.join(repo, '.history', 'scratch.txt'), 'excluded\n', 'utf8');
+      await writeFile(path.join(repo, 'NOTES.md'), 'in progress\n', 'utf8');
+
+      const sha = await checkpoint(repo, 'schematic', 'copperhead: WIP');
+      expect(sha, 'the non-excluded file should still produce a checkpoint').toBeTruthy();
+
+      const gitignoreAfter = existsSync(path.join(repo, '.gitignore'))
+        ? await readFile(path.join(repo, '.gitignore'), 'utf8')
+        : null;
+      expect(gitignoreAfter, '.gitignore must be byte-identical to before the checkpoint').toBe(gitignoreBefore);
+
+      const { stdout: files } = await git(repo, ['show', '--name-only', '--format=', sha!]);
+      expect(files).toContain('NOTES.md');
+      expect(files).not.toContain('.history/scratch.txt');
+      expect(files).not.toContain('.gitignore');
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('produces no checkpoint when the only pre-existing dirty path is excluded', async () => {
+    // Regression: with the old ensureIgnored() call, writing .history/ into
+    // .gitignore was itself a dirty-tree change, so a tree whose only real
+    // content was under .history/ still produced a checkpoint — one holding
+    // nothing but the .gitignore edit.
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await commitEverything(repo, 'base');
+      await mkdir(path.join(repo, '.history'), { recursive: true });
+      await writeFile(path.join(repo, '.history', 'scratch.txt'), 'excluded\n', 'utf8');
+
+      await expect(checkpoint(repo, 'schematic', 'copperhead: WIP')).resolves.toBeNull();
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('checkpointTree() before restore() captures the failed attempt; checkpoint() after does not', async () => {
+    // This is the bug the split exists to fix (issue #208 follow-up): the
+    // create pipeline used to call checkpoint() *after* runAgentLoop had
+    // already rolled the tree back on failure, so it checkpointed the clean,
+    // restored tree rather than the failed attempt. checkpointTree() lets a
+    // caller capture the dirty tree first — this test reproduces both the old
+    // bug and the fix in one place, with the exact call order each uses.
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await commitEverything(repo, 'base');
+      const snap = await snapshot(repo);
+
+      // The shape of a failed attempt's work: an accepted draft plus an
+      // untracked handoff note, exactly as runAgentLoop would leave it right
+      // before its own fail()/refused branch calls restore().
+      await writeFile(path.join(repo, 'DRAFT.md'), 'accepted draft content\n', 'utf8');
+      await writeFile(path.join(repo, 'HANDOFF.md'), 'what this attempt learned\n', 'utf8');
+
+      // The fix: runAgentLoop's failure paths now capture before rolling back.
+      const failedAttemptCommit = await checkpointTree(repo, 'copperhead: WIP checkpoint — NOT CERTIFIED (test)');
+      expect(failedAttemptCommit, 'the dirty tree should produce a checkpoint').toBeTruthy();
+
+      // The rollback runAgentLoop performs right after.
+      await restore(repo, snap);
+      expect(existsSync(path.join(repo, 'HANDOFF.md')), 'rollback should remove the untracked file').toBe(false);
+      expect(existsSync(path.join(repo, 'DRAFT.md')), 'rollback should remove the tracked draft').toBe(false);
+
+      // create.ts, once it knows the stage, points the ref at what was
+      // already captured — it does not re-derive from the (now clean) tree.
+      await recordWipRef(repo, 'schematic', failedAttemptCommit!);
+      const { stdout: resolved } = await git(repo, ['rev-parse', wipRef('schematic')]);
+      expect(resolved.trim()).toBe(failedAttemptCommit);
+
+      const { stdout: files } = await git(repo, ['show', '--name-only', '--format=', failedAttemptCommit!]);
+      expect(files, 'the checkpoint must hold the failed attempt, not the post-rollback tree').toContain('HANDOFF.md');
+      expect(files).toContain('DRAFT.md');
+
+      // The bug, reproduced: calling checkpoint() the old way — after the
+      // rollback, the way create.ts used to — finds a clean tree and records
+      // nothing, silently losing the attempt this whole feature exists to
+      // preserve.
+      const postRollbackAttempt = await checkpoint(repo, 'schematic', 'copperhead: WIP (post-rollback, buggy order)');
+      expect(postRollbackAttempt, 'checkpointing after restore() has nothing left to capture').toBeNull();
+    } finally {
+      await cleanup();
+    }
   }, 60_000);
 });

--- a/test/wip-checkpoint.test.ts
+++ b/test/wip-checkpoint.test.ts
@@ -169,9 +169,15 @@ describe('WIP checkpoints (issue #208)', () => {
 
       await expect(checkpointTree(repo, 'copperhead: WIP')).resolves.toBeNull();
     } finally {
-      process.env.TMPDIR = savedEnv.TMPDIR;
-      process.env.TMP = savedEnv.TMP;
-      process.env.TEMP = savedEnv.TEMP;
+      // `process.env.X = undefined` sets the literal string "undefined"
+      // rather than unsetting X — on a machine where one of these was never
+      // set (TMPDIR is commonly unset on Linux, falling back to /tmp), that
+      // would leave os.tmpdir() permanently broken for every test that runs
+      // after this one, in this same process.
+      for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
       await cleanup();
     }
   }, 60_000);

--- a/test/wip-checkpoint.test.ts
+++ b/test/wip-checkpoint.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { writeFile, readFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { execa } from 'execa';
+import { checkpoint, wipRef, snapshot, restore, headCommit, branchName } from '../src/util/git.js';
+import { tempFixtureRepo } from './helpers.js';
+
+/**
+ * Issue #208: a failed stage attempt rolls the tree back, and the work it had
+ * accepted survives only as a stash of tracked files. Anything the agent left
+ * untracked is destroyed outright, so a retry restarts from zero and hours of
+ * accepted work exist nowhere.
+ *
+ * `checkpoint` records the working state to `refs/copperhead/wip/<stage>` before
+ * the rollback. The branch is deliberately untouched: the verification gate
+ * still decides what lands on it, and the checkpoint is reachable only by its
+ * own ref.
+ */
+
+const git = (repo: string, args: string[]) => execa('git', args, { cwd: repo });
+
+async function commitEverything(repo: string, message: string): Promise<void> {
+  await git(repo, ['add', '-A']);
+  // The fixture may already be clean; committing nothing is an error, not a no-op.
+  const { stdout } = await git(repo, ['status', '--porcelain']);
+  if (stdout.trim()) await git(repo, ['commit', '-q', '-m', message]);
+}
+
+describe('WIP checkpoints (issue #208)', () => {
+  it('preserves untracked work that a rollback would destroy', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await commitEverything(repo, 'base');
+      const snap = await snapshot(repo);
+
+      // The shape the issue describes: an accepted draft (tracked edit) plus an
+      // untracked handoff doc the agent wrote for the next attempt.
+      await mkdir(path.join(repo, 'docs'), { recursive: true });
+      await writeFile(path.join(repo, 'docs', 'BOM.md'), '# BOM\n\n| Ref | Part |\n| --- | --- |\n| R1 | 10k |\n', 'utf8');
+      await writeFile(path.join(repo, 'HANDOFF.md'), 'what attempt 1 learned\n', 'utf8');
+
+      const sha = await checkpoint(repo, 'schematic', 'copperhead: WIP schematic attempt 1 — NOT CERTIFIED');
+      expect(sha, 'a dirty tree should produce a checkpoint').toBeTruthy();
+
+      await restore(repo, snap);
+
+      // The rollback did its job.
+      expect(existsSync(path.join(repo, 'HANDOFF.md')), 'rollback should remove the untracked file').toBe(false);
+
+      // ...and the work is still recoverable from the checkpoint, including the
+      // untracked file, which is what the stash-based preservation loses.
+      const { stdout: files } = await git(repo, ['show', '--name-only', '--format=', sha!]);
+      expect(files).toContain('HANDOFF.md');
+
+      const { stdout: handoff } = await git(repo, ['show', `${sha}:HANDOFF.md`]);
+      expect(handoff).toBe('what attempt 1 learned');
+
+      const { stdout: bom } = await git(repo, ['show', `${sha}:docs/BOM.md`]);
+      expect(bom).toContain('| R1 | 10k |');
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('leaves the branch, HEAD and working tree untouched', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await commitEverything(repo, 'base');
+      const headBefore = await headCommit(repo);
+      const branchBefore = await branchName(repo);
+
+      await writeFile(path.join(repo, 'NOTES.md'), 'in progress\n', 'utf8');
+      // Something staged, to prove the temporary index leaves the real one alone.
+      await writeFile(path.join(repo, 'STAGED.md'), 'staged\n', 'utf8');
+      await git(repo, ['add', 'STAGED.md']);
+
+      const sha = await checkpoint(repo, 'schematic', 'copperhead: WIP');
+      expect(sha).toBeTruthy();
+
+      expect(await headCommit(repo), 'HEAD must not move').toBe(headBefore);
+      expect(await branchName(repo), 'the branch must not change').toBe(branchBefore);
+      expect(await readFile(path.join(repo, 'NOTES.md'), 'utf8')).toBe('in progress\n');
+
+      // The real index still holds exactly what the caller staged.
+      const { stdout: staged } = await git(repo, ['diff', '--cached', '--name-only']);
+      expect(staged.trim()).toBe('STAGED.md');
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('is not reachable from the branch, so nothing uncertified lands on it', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await commitEverything(repo, 'base');
+      await writeFile(path.join(repo, 'NOTES.md'), 'in progress\n', 'utf8');
+
+      const sha = await checkpoint(repo, 'schematic', 'copperhead: WIP');
+
+      const { stdout: onBranch } = await git(repo, ['log', '--format=%H']);
+      expect(onBranch.split('\n')).not.toContain(sha);
+
+      // It is reachable by its own ref, which is the point.
+      const { stdout: resolved } = await git(repo, ['rev-parse', wipRef('schematic')]);
+      expect(resolved.trim()).toBe(sha);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('records nothing when the tree is clean', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await commitEverything(repo, 'base');
+      expect(await checkpoint(repo, 'schematic', 'copperhead: WIP')).toBeNull();
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('keeps one ref per stage, and the newest attempt for a stage', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await commitEverything(repo, 'base');
+
+      await writeFile(path.join(repo, 'A.md'), 'first\n', 'utf8');
+      const first = await checkpoint(repo, 'schematic', 'copperhead: WIP schematic attempt 1');
+
+      await writeFile(path.join(repo, 'A.md'), 'second\n', 'utf8');
+      const second = await checkpoint(repo, 'schematic', 'copperhead: WIP schematic attempt 2');
+
+      await mkdir(path.join(repo, 'outputs'), { recursive: true });
+      await writeFile(path.join(repo, 'outputs', 'B.md'), 'other stage\n', 'utf8');
+      const other = await checkpoint(repo, 'layout-draft', 'copperhead: WIP layout-draft attempt 1');
+
+      expect(second).not.toBe(first);
+      const { stdout: schematicRef } = await git(repo, ['rev-parse', wipRef('schematic')]);
+      expect(schematicRef.trim(), 'the stage ref should advance to the latest attempt').toBe(second);
+
+      const { stdout: layoutRef } = await git(repo, ['rev-parse', wipRef('layout-draft')]);
+      expect(layoutRef.trim(), 'each stage keeps its own ref').toBe(other);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('does not throw when the repo cannot take a checkpoint', async () => {
+    // A checkpoint is a safety net, never a gate: it must not fail the stage
+    // that was about to be rolled back anyway.
+    await expect(checkpoint(path.join('does', 'not', 'exist'), 'schematic', 'x')).resolves.toBeNull();
+  }, 60_000);
+});


### PR DESCRIPTION
## What

A failed stage attempt now records its work to `refs/copperhead/wip/<stage>` before the rollback, so accepted work stays recoverable instead of being destroyed.

## Why

Closes the loss described in #208. Today a failed attempt rolls the tree back and the work survives only as a stash of *tracked* files: anything the agent left untracked goes outright. The lemondrop campaign lost a 160-part sheet that had been ERC-clean, and its handoff doc existed nowhere afterwards. Retries restart from zero.

## Design

This is the issue's second, conservative option. The branch is untouched, so verification-gated-out holds verbatim: only stage-complete commits land on it and the checkpoint is reachable solely by its own ref, so nothing uncertified can be mistaken for approved output.

`checkpoint()` writes to a temporary index (`GIT_INDEX_FILE`), seeded from HEAD, then `commit-tree` and `update-ref`. That captures tracked changes and untracked files together with `.gitignore` still respected, and leaves the caller's staged state alone, which matters because this runs mid-pipeline rather than between commands.

It returns `null` rather than throwing on any failure. A checkpoint is a safety net, and one that fails the stage it exists to protect is worse than none.

## Spec / OpenSpec

The issue says either option is a spec-level change to the rollback contract and wants an OpenSpec proposal. I have not added one, because on this option no documented behaviour changes: the rollback still happens, the tree still returns to the snapshot, and the branch still carries only certified commits. The side ref is additive, in the same spirit as the existing `preserveFailedRun` stash.

If you read it as spec-level anyway, say so and I will add the proposal, delta specs and tasks entry before you spend review time on the code.

## Testing

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass (exit 0) |
| Unit + offline | `npm test` | 753 passed, 25 failed, 20 skipped |
| Markdown lint | `npm run lint:md` | pass (0 issues) |

New: `test/wip-checkpoint.test.ts`, 6 cases.

The one that matters reproduces the loss from the issue: a tracked edit plus an untracked handoff doc, then a real `restore()`. The rollback deletes the untracked file, and the checkpoint still holds both.

The others pin that HEAD, the branch and the working tree are untouched, that the caller's staged state survives, that the checkpoint is not reachable from the branch, that a clean tree records nothing, that each stage keeps its own ref advancing to the latest attempt, and that an unusable repo yields `null` rather than an exception.

Pre-existing failures unrelated to this PR: the 25 above are identical on `main` in my environment (Windows, no `kicad-cli`). Baseline is 25 failed / 747 passed / 792 total; this branch is 25 failed / 753 passed / 798 total, i.e. the same failures plus the 6 new tests.

### Manual test log

`create` needs `kicad-cli` and a provider credential, neither available here, so the checkpoint path is exercised directly against a real repo rather than through a full pipeline run:

```text
$ git show --name-only --format= <checkpoint>
HANDOFF.md
docs/BOM.md

$ git log --format=%H        # the branch does not contain it
<base commit only>

$ git rev-parse refs/copperhead/wip/schematic
<checkpoint>
```

## Docs

None yet. If the ref naming is right I will follow up with a line in the workflows docs on recovering from a failed stage.

---

## Invariant checklist

- [x] **Spec-gated in**: unchanged, no tool surface touched.
- [x] **Verification-gated out**: preserved verbatim. The rollback still runs, the branch still takes only stage-complete commits, and the checkpoint lives outside it.
- [x] **`check`/`verify` stays LLM-free and network-free**: N/A, nothing under `src/commands/check` touched.
- [x] **No sexp serialization**: N/A, the KiCad parser is untouched.
- [ ] **Sync-obligations ledger**: N/A, no tool-call hooks changed.
- [x] **Secrets**: N/A. The checkpoint commits the same paths `commitAll` would, with `GIT_ADD_EXCLUDES` applied.
- [x] **Spec coherence**: see the OpenSpec note above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unsuccessful stage attempts now save work-in-progress checkpoints for later inspection or retry.
  * Checkpoints preserve both tracked and untracked changes without altering the active branch or working files.
  * Each stage maintains its own checkpoint, making prior attempts easier to review.

* **Reliability**
  * Checkpoint creation failures are handled gracefully, allowing the workflow to continue without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->