### PR TITLE
feat(kicad): discover kicad-cli from standard Windows installation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The script is conservative by design: it never runs `sudo` and never edits shell
 ### Requirements
 
 - Node.js ≥ 20
-- [KiCad](https://www.kicad.org/) ≥ 8 with `kicad-cli` on PATH
+- [KiCad](https://www.kicad.org/) ≥ 8 with `kicad-cli` on PATH (on Windows and macOS, copperhead also searches standard installation directories automatically; override with `COPPERHEAD_KICAD_CLI`)
 - One model backend: a locally installed, ChatGPT-authenticated [Codex CLI](https://learn.chatgpt.com/docs/codex/cli), a logged-in [Cursor Agent CLI](#saved-login-cursor-agent) (`agent login`), logged-in Claude Code (see [Saved login](#saved-login-claude-code)), or `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` in the environment. `check` never calls an LLM.
 
 ## Quick start

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -93,7 +93,7 @@ async function kicadCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
       name: 'kicad-cli',
       status: 'fail',
       detail: 'not found on PATH',
-      hint: 'install KiCad >= 9 (bundles kicad-cli); ERC/DRC gates need it.',
+      hint: 'install KiCad >= 8 (bundles kicad-cli); ERC/DRC gates need it.',
     };
   }
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -13,7 +13,7 @@ import {
   type CompatSettings,
   type CopperheadConfig,
 } from '../config.js';
-import { kicadCliVersion } from '../kicad/cli.js';
+import { kicadCliVersion, MIN_KICAD_MAJOR } from '../kicad/cli.js';
 import { redactSecrets } from '../util/redact.js';
 import { isNotFoundError } from '../util/preflight.js';
 
@@ -85,14 +85,13 @@ function nodeCheck(version: string): DoctorCheck {
   };
 }
 
-// MIN_KICAD_MAJOR enforces the minimum supported KiCad version for ERC/DRC.
+// MIN_KICAD_MAJOR (imported from kicad/cli.ts) enforces the minimum supported KiCad version for ERC/DRC.
 // Behaviour note: kicadCheck() returns status: 'fail' (exit non-zero) for any
 // kicad-cli version below this threshold, and for output that contains no
 // parseable N.N version token. This is intentional user-visible behaviour and
 // is NOT a no-op hint correction: users on KiCad 7 will see doctor fail where
 // it previously succeeded. The gate mirrors the README's stated requirement and
 // follows the same pattern as MIN_NODE_MAJOR above.
-const MIN_KICAD_MAJOR = 8;
 
 async function kicadCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
   try {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -85,12 +85,23 @@ function nodeCheck(version: string): DoctorCheck {
   };
 }
 
+// MIN_KICAD_MAJOR enforces the minimum supported KiCad version for ERC/DRC.
+// Behaviour note: kicadCheck() returns status: 'fail' (exit non-zero) for any
+// kicad-cli version below this threshold, and for output that contains no
+// parseable N.N version token. This is intentional user-visible behaviour and
+// is NOT a no-op hint correction: users on KiCad 7 will see doctor fail where
+// it previously succeeded. The gate mirrors the README's stated requirement and
+// follows the same pattern as MIN_NODE_MAJOR above.
 const MIN_KICAD_MAJOR = 8;
 
 async function kicadCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
   try {
     const raw = await probe();
-    const match = raw.match(/(\d+)\.\d+/);
+    // Anchored match: require a version-shaped token at the start of a line so
+    // an incidental N.N elsewhere in stdout (e.g. "OpenGL 3.2 unsupported")
+    // does not shadow the real KiCad version. The `m` flag makes ^ match
+    // line-starts within a multi-line string.
+    const match = raw.match(/(?:^|\n)\s*(?:kicad-cli\s+)?v?(\d+)\.\d+/m);
     const major = match ? Number(match[1]) : NaN;
     if (!Number.isFinite(major)) {
       return {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -85,9 +85,22 @@ function nodeCheck(version: string): DoctorCheck {
   };
 }
 
+const MIN_KICAD_MAJOR = 8;
+
 async function kicadCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
   try {
-    return { name: 'kicad-cli', status: 'ok', detail: await probe() };
+    const raw = await probe();
+    const match = raw.match(/(\d+)\.\d+/);
+    const major = match ? Number(match[1]) : NaN;
+    if (Number.isFinite(major) && major < MIN_KICAD_MAJOR) {
+      return {
+        name: 'kicad-cli',
+        status: 'fail',
+        detail: `${raw} (< ${MIN_KICAD_MAJOR})`,
+        hint: `copperhead needs KiCad >= ${MIN_KICAD_MAJOR}; upgrade KiCad (https://www.kicad.org/download/).`,
+      };
+    }
+    return { name: 'kicad-cli', status: 'ok', detail: raw };
   } catch {
     return {
       name: 'kicad-cli',

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -92,7 +92,15 @@ async function kicadCheck(probe: () => Promise<string>): Promise<DoctorCheck> {
     const raw = await probe();
     const match = raw.match(/(\d+)\.\d+/);
     const major = match ? Number(match[1]) : NaN;
-    if (Number.isFinite(major) && major < MIN_KICAD_MAJOR) {
+    if (!Number.isFinite(major)) {
+      return {
+        name: 'kicad-cli',
+        status: 'fail',
+        detail: raw || 'could not parse version',
+        hint: `copperhead needs KiCad >= ${MIN_KICAD_MAJOR}; install or configure a compatible kicad-cli.`,
+      };
+    }
+    if (major < MIN_KICAD_MAJOR) {
       return {
         name: 'kicad-cli',
         status: 'fail',

--- a/src/kicad/cli.ts
+++ b/src/kicad/cli.ts
@@ -83,6 +83,14 @@ const MACOS_FALLBACK_BINARIES = [
   '/Applications/KiCad-8.0/KiCad.app/Contents/MacOS/kicad-cli',
 ];
 
+/**
+ * Minimum KiCad major version accepted for ERC/DRC. Mirrors doctor.ts's
+ * MIN_KICAD_MAJOR: both constants must stay in sync. Duplicated here (rather
+ * than imported) so this module does not take a dependency on the doctor
+ * command, which is LLM-free but higher-level.
+ */
+export const MIN_KICAD_MAJOR = 8;
+
 const DEFAULT_WIN_ROOTS = [
   process.env.ProgramFiles ? path.join(process.env.ProgramFiles, 'KiCad') : 'C:/Program Files/KiCad',
   'C:/Program Files/KiCad',
@@ -109,6 +117,13 @@ export function defaultFallbackBinaries(winRoots: readonly string[] = DEFAULT_WI
       const versions = entries
         .filter((e) => e.isDirectory())
         .map((e) => e.name)
+        // Only include versions that meet the minimum supported KiCad major.
+        // This prevents a stale KiCad 7.x install from silently becoming the
+        // ERC/DRC binary while doctor correctly reports FAIL for it.
+        .filter((name) => {
+          const major = Number(name.split('.')[0]);
+          return Number.isFinite(major) && major >= MIN_KICAD_MAJOR;
+        })
         .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
 
       for (const version of versions) {
@@ -119,15 +134,18 @@ export function defaultFallbackBinaries(winRoots: readonly string[] = DEFAULT_WI
           path.join(winRoot, version, 'bin', 'kicad-cli'),
         );
       }
-      candidates.push(
-        path.join(winRoot, 'bin', 'kicad-cli.exe'),
-        path.join(winRoot, 'bin', 'kicad-cli.cmd'),
-        path.join(winRoot, 'bin', 'kicad-cli.bat'),
-        path.join(winRoot, 'bin', 'kicad-cli'),
-      );
     } catch {
-      // not readable / not a directory; skip
+      // not readable / not a directory; versioned candidates unavailable, but
+      // the unversioned bin/ fallback below is still worth probing.
     }
+    // Unversioned fallback: pushed unconditionally so a readdirSync failure
+    // (e.g. ENOTDIR) on the root itself doesn't also suppress this probe.
+    candidates.push(
+      path.join(winRoot, 'bin', 'kicad-cli.exe'),
+      path.join(winRoot, 'bin', 'kicad-cli.cmd'),
+      path.join(winRoot, 'bin', 'kicad-cli.bat'),
+      path.join(winRoot, 'bin', 'kicad-cli'),
+    );
   }
 
   return candidates;

--- a/src/kicad/cli.ts
+++ b/src/kicad/cli.ts
@@ -84,10 +84,9 @@ const MACOS_FALLBACK_BINARIES = [
 ];
 
 /**
- * Minimum KiCad major version accepted for ERC/DRC. Mirrors doctor.ts's
- * MIN_KICAD_MAJOR: both constants must stay in sync. Duplicated here (rather
- * than imported) so this module does not take a dependency on the doctor
- * command, which is LLM-free but higher-level.
+ * Minimum KiCad major version accepted for ERC/DRC and candidate discovery.
+ * Re-used by doctor.ts to ensure CLI discovery and environment preflight
+ * enforce the same version floor.
  */
 export const MIN_KICAD_MAJOR = 8;
 

--- a/src/kicad/cli.ts
+++ b/src/kicad/cli.ts
@@ -48,7 +48,7 @@ export class KicadCliBadOverrideError extends PreflightError {
     const isMac = platform === 'darwin';
 
     const checkHint = isWin
-      ? `check the path in PowerShell/cmd: Test-Path "${configured}"`
+      ? `check the path in PowerShell: Test-Path "${configured}"`
       : `check the path: ls -l "${configured}"`;
 
     const locationHint = isWin

--- a/src/kicad/cli.ts
+++ b/src/kicad/cli.ts
@@ -1,5 +1,5 @@
 import { execa, ExecaError } from 'execa';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -7,14 +7,29 @@ import { normalizeReport, type CheckReport } from './report.js';
 import { PreflightError, isNotFoundError } from '../util/preflight.js';
 
 export class KicadCliMissingError extends PreflightError {
-  constructor() {
+  constructor(platform = process.platform) {
+    const isWin = platform === 'win32';
+    const isMac = platform === 'darwin';
+
+    const locationHint = isWin
+      ? 'ensure kicad-cli.exe is on PATH (typically in C:\\Program Files\\KiCad\\<version>\\bin)'
+      : isMac
+        ? 'ensure the kicad-cli binary is on PATH (on macOS it ships inside KiCad.app/Contents/MacOS)'
+        : 'ensure the kicad-cli binary is on PATH (typically /usr/bin/kicad-cli)';
+
+    const envHint = isWin
+      ? 'or set COPPERHEAD_KICAD_CLI="C:\\Program Files\\KiCad\\10.0\\bin\\kicad-cli.exe"'
+      : isMac
+        ? 'or set COPPERHEAD_KICAD_CLI=/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli'
+        : 'or set COPPERHEAD_KICAD_CLI=/usr/bin/kicad-cli';
+
     super(
       'kicad-cli not found on PATH',
       'copperhead verifies every mutation with kicad-cli ERC/DRC; without it no edit can be checked, so no run can start',
       [
         'install KiCad ≥ 8: https://www.kicad.org/download/',
-        'ensure the kicad-cli binary is on PATH (on macOS it ships inside KiCad.app/Contents/MacOS)',
-        'or set COPPERHEAD_KICAD_CLI=/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli',
+        locationHint,
+        envHint,
         'confirm with "kicad-cli version", then rerun',
       ],
     );
@@ -28,15 +43,32 @@ export class KicadCliMissingError extends PreflightError {
  * seen and rejected, so telling the user to set it would be nonsense.
  */
 export class KicadCliBadOverrideError extends PreflightError {
-  constructor(configured: string) {
+  constructor(configured: string, platform = process.platform) {
+    const isWin = platform === 'win32';
+    const isMac = platform === 'darwin';
+
+    const checkHint = isWin
+      ? `check the path in PowerShell/cmd: Test-Path "${configured}"`
+      : `check the path: ls -l "${configured}"`;
+
+    const locationHint = isWin
+      ? 'on Windows the binary typically lives at C:\\Program Files\\KiCad\\<version>\\bin\\kicad-cli.exe'
+      : isMac
+        ? 'on macOS the binary lives at /Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli'
+        : 'on Linux the binary typically lives at /usr/bin/kicad-cli';
+
+    const confirmHint = isWin
+      ? 'confirm with "& \'$env:COPPERHEAD_KICAD_CLI\' version", then rerun'
+      : 'confirm with "$COPPERHEAD_KICAD_CLI version", then rerun';
+
     super(
       `COPPERHEAD_KICAD_CLI points to a path that does not exist: ${configured}`,
       'the override wins over PATH, so falling back silently would run a different binary than the one you named and make the failure impossible to diagnose',
       [
-        `check the path: ls -l "${configured}"`,
-        'on macOS the binary lives at /Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli',
+        checkHint,
+        locationHint,
         'or unset COPPERHEAD_KICAD_CLI to fall back to PATH',
-        'confirm with "$COPPERHEAD_KICAD_CLI version", then rerun',
+        confirmHint,
       ],
     );
     this.name = 'KicadCliBadOverrideError';
@@ -44,20 +76,72 @@ export class KicadCliBadOverrideError extends PreflightError {
 }
 
 /** Well-known install locations when `kicad-cli` is not on PATH (macOS app bundle). */
-const FALLBACK_BINARIES = [
+const MACOS_FALLBACK_BINARIES = [
   '/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli',
   '/Applications/KiCad-10.0/KiCad.app/Contents/MacOS/kicad-cli',
   '/Applications/KiCad-9.0/KiCad.app/Contents/MacOS/kicad-cli',
   '/Applications/KiCad-8.0/KiCad.app/Contents/MacOS/kicad-cli',
 ];
 
-let fallbackBinaries: readonly string[] = FALLBACK_BINARIES;
+const DEFAULT_WIN_ROOTS = [
+  process.env.ProgramFiles ? path.join(process.env.ProgramFiles, 'KiCad') : 'C:/Program Files/KiCad',
+  'C:/Program Files/KiCad',
+  'C:/Program Files (x86)/KiCad',
+];
+
+/**
+ * Return default fallback candidate paths for macOS and Windows standard KiCad installations.
+ * On Windows, version-numbered directories (e.g. 10.0, 9.0, 8.0) under the KiCad root
+ * are probed in descending numerical order, mirroring symlib.ts.
+ */
+export function defaultFallbackBinaries(winRoots: readonly string[] = DEFAULT_WIN_ROOTS): string[] {
+  const candidates: string[] = [...MACOS_FALLBACK_BINARIES];
+  const seenRoots = new Set<string>();
+
+  for (const winRoot of winRoots) {
+    const normalized = path.normalize(winRoot).toLowerCase();
+    if (seenRoots.has(normalized)) continue;
+    seenRoots.add(normalized);
+
+    if (!existsSync(winRoot)) continue;
+    try {
+      const entries = readdirSync(winRoot, { withFileTypes: true });
+      const versions = entries
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+        .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+
+      for (const version of versions) {
+        candidates.push(
+          path.join(winRoot, version, 'bin', 'kicad-cli.exe'),
+          path.join(winRoot, version, 'bin', 'kicad-cli.cmd'),
+          path.join(winRoot, version, 'bin', 'kicad-cli.bat'),
+          path.join(winRoot, version, 'bin', 'kicad-cli'),
+        );
+      }
+      candidates.push(
+        path.join(winRoot, 'bin', 'kicad-cli.exe'),
+        path.join(winRoot, 'bin', 'kicad-cli.cmd'),
+        path.join(winRoot, 'bin', 'kicad-cli.bat'),
+        path.join(winRoot, 'bin', 'kicad-cli'),
+      );
+    } catch {
+      // not readable / not a directory; skip
+    }
+  }
+
+  return candidates;
+}
+
+let fallbackBinariesOverride: readonly string[] | null = null;
+let fallbackWinRootsOverride: readonly string[] | null = null;
 
 let cachedBinary: string | null | undefined;
 
 /**
  * Resolve the kicad-cli executable: `COPPERHEAD_KICAD_CLI` > PATH name
- * (`kicad-cli`). On PATH miss, `runKicad` falls back to macOS KiCad.app paths.
+ * (`kicad-cli`). On PATH miss, `runKicad` falls back to macOS KiCad.app paths
+ * and Windows standard installation paths.
  */
 export function resolveKicadCli(): string {
   if (cachedBinary !== undefined) {
@@ -88,7 +172,7 @@ function envOverride(): string | null {
 }
 
 /**
- * After ENOENT on PATH, retry with a known macOS install path.
+ * After ENOENT on PATH, retry with known install paths (macOS app bundles, Windows standard paths).
  *
  * Deliberately does not re-read `COPPERHEAD_KICAD_CLI`: this is reached only
  * when resolveKicadCli() cached the bare PATH name, which in turn happens only
@@ -96,7 +180,9 @@ function envOverride(): string | null {
  * override re-check here could never fire.
  */
 function fallbackAfterMissing(): string {
-  for (const candidate of fallbackBinaries) {
+  const candidates =
+    fallbackBinariesOverride ?? defaultFallbackBinaries(fallbackWinRootsOverride ?? undefined);
+  for (const candidate of candidates) {
     if (existsSync(candidate)) {
       cachedBinary = candidate;
       return candidate;
@@ -133,13 +219,21 @@ export function resetKicadCliCache(): void {
 }
 
 /**
- * Test helper: point the app-bundle probe at fixture paths, or call with no
- * argument to restore the real list. Without this the fallback branch is only
- * exercisable on a macOS host that happens to have KiCad installed, which
- * makes the outcome depend on the developer's machine.
+ * Test helper: point the app-bundle / binary probe at fixture paths, or call with no
+ * argument to restore the default dynamic list.
  */
 export function setKicadFallbackBinaries(paths?: readonly string[]): void {
-  fallbackBinaries = paths ?? FALLBACK_BINARIES;
+  fallbackBinariesOverride = paths ?? null;
+  fallbackWinRootsOverride = null;
+}
+
+/**
+ * Test helper: point the Windows installation discovery probe at fixture roots, or call
+ * with no argument to restore the default search roots.
+ */
+export function setKicadFallbackWinRoots(roots?: readonly string[]): void {
+  fallbackWinRootsOverride = roots ?? null;
+  fallbackBinariesOverride = null;
 }
 
 export async function kicadCliVersion(): Promise<string> {

--- a/src/kicad/cli.ts
+++ b/src/kicad/cli.ts
@@ -58,8 +58,8 @@ export class KicadCliBadOverrideError extends PreflightError {
         : 'on Linux the binary typically lives at /usr/bin/kicad-cli';
 
     const confirmHint = isWin
-      ? 'confirm with "& \'$env:COPPERHEAD_KICAD_CLI\' version", then rerun'
-      : 'confirm with "$COPPERHEAD_KICAD_CLI version", then rerun';
+      ? 'confirm with "& $env:COPPERHEAD_KICAD_CLI version", then rerun'
+      : 'confirm with "$COPPERHEAD_KICAD_CLI" version, then rerun';
 
     super(
       `COPPERHEAD_KICAD_CLI points to a path that does not exist: ${configured}`,

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -124,6 +124,41 @@ describe('copperhead doctor', () => {
     }
   });
 
+  it('fails when KiCad version response is empty or unparseable', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const rEmpty = await runDoctor({
+        repoRoot: repo,
+        model: 'gpt-5',
+        deps: deps({
+          kicadVersion: async () => '',
+          env: { OPENAI_API_KEY: 'sk-x' },
+        }),
+      });
+      expect(rEmpty.ok).toBe(false);
+      const kicadEmpty = rEmpty.checks.find((c) => c.name === 'kicad-cli')!;
+      expect(kicadEmpty.status).toBe('fail');
+      expect(kicadEmpty.detail).toBe('could not parse version');
+      expect(kicadEmpty.hint).toContain('copperhead needs KiCad >= 8');
+
+      const rGarbage = await runDoctor({
+        repoRoot: repo,
+        model: 'gpt-5',
+        deps: deps({
+          kicadVersion: async () => 'unknown version string',
+          env: { OPENAI_API_KEY: 'sk-x' },
+        }),
+      });
+      expect(rGarbage.ok).toBe(false);
+      const kicadGarbage = rGarbage.checks.find((c) => c.name === 'kicad-cli')!;
+      expect(kicadGarbage.status).toBe('fail');
+      expect(kicadGarbage.detail).toBe('unknown version string');
+      expect(kicadGarbage.hint).toContain('copperhead needs KiCad >= 8');
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('a corrupted .copperhead/config.json fails the project check, not the whole command', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -70,6 +70,60 @@ describe('copperhead doctor', () => {
     }
   });
 
+  it('fails when KiCad version is below 8 (e.g. KiCad 7.x)', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const r = await runDoctor({
+        repoRoot: repo,
+        model: 'gpt-5',
+        deps: deps({
+          kicadVersion: async () => 'kicad-cli 7.0.10',
+          env: { OPENAI_API_KEY: 'sk-x' },
+        }),
+      });
+      expect(r.ok).toBe(false);
+      const kicad = r.checks.find((c) => c.name === 'kicad-cli')!;
+      expect(kicad.status).toBe('fail');
+      expect(kicad.detail).toContain('(< 8)');
+      expect(kicad.hint).toContain('copperhead needs KiCad >= 8');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('passes when KiCad version is >= 8', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const r8 = await runDoctor({
+        repoRoot: repo,
+        model: 'gpt-5',
+        deps: deps({
+          kicadVersion: async () => '8.0.4',
+          env: { OPENAI_API_KEY: 'sk-x' },
+        }),
+      });
+      expect(r8.ok).toBe(true);
+      const kicad8 = r8.checks.find((c) => c.name === 'kicad-cli')!;
+      expect(kicad8.status).toBe('ok');
+      expect(kicad8.detail).toBe('8.0.4');
+
+      const r10 = await runDoctor({
+        repoRoot: repo,
+        model: 'gpt-5',
+        deps: deps({
+          kicadVersion: async () => 'kicad-cli 10.0.5',
+          env: { OPENAI_API_KEY: 'sk-x' },
+        }),
+      });
+      expect(r10.ok).toBe(true);
+      const kicad10 = r10.checks.find((c) => c.name === 'kicad-cli')!;
+      expect(kicad10.status).toBe('ok');
+      expect(kicad10.detail).toBe('kicad-cli 10.0.5');
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('a corrupted .copperhead/config.json fails the project check, not the whole command', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -124,6 +124,31 @@ describe('copperhead doctor', () => {
     }
   });
 
+  it('resolves the correct major when stdout contains a spurious N.N before the real version (Finding 4 regression)', async () => {
+    // An unanchored regex would match "OpenGL 3.2" and yield major 3, causing
+    // doctor to report "KiCad 3 is too old" for a perfectly good KiCad 9.
+    // The anchored regex must skip prefix noise on earlier lines.
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const r = await runDoctor({
+        repoRoot: repo,
+        model: 'gpt-5',
+        deps: deps({
+          // Simulate a kicad-cli that emits a warning line before its version.
+          kicadVersion: async () => 'OpenGL 3.2 unsupported\n9.0.1',
+          env: { OPENAI_API_KEY: 'sk-x' },
+        }),
+      });
+      const kicad = r.checks.find((c) => c.name === 'kicad-cli')!;
+      expect(kicad.status).toBe('ok');
+      // The detail must carry the full raw string, not just the match.
+      expect(kicad.detail).toContain('9.0.1');
+      expect(r.ok).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('fails when KiCad version response is empty or unparseable', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -8,6 +8,7 @@ import {
   formatDoctor,
   type DoctorDeps,
 } from '../src/commands/doctor.js';
+import { MIN_KICAD_MAJOR } from '../src/kicad/cli.js';
 import { tempFixtureRepo } from './helpers.js';
 
 // Deps that make every host-dependent probe deterministic.
@@ -119,6 +120,38 @@ describe('copperhead doctor', () => {
       const kicad10 = r10.checks.find((c) => c.name === 'kicad-cli')!;
       expect(kicad10.status).toBe('ok');
       expect(kicad10.detail).toBe('kicad-cli 10.0.5');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('enforces the MIN_KICAD_MAJOR floor exported from kicad/cli', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const below = await runDoctor({
+        repoRoot: repo,
+        model: 'gpt-5',
+        deps: deps({
+          kicadVersion: async () => `kicad-cli ${MIN_KICAD_MAJOR - 1}.99.0`,
+          env: { OPENAI_API_KEY: 'sk-x' },
+        }),
+      });
+      expect(below.ok).toBe(false);
+      const kicadBelow = below.checks.find((c) => c.name === 'kicad-cli')!;
+      expect(kicadBelow.status).toBe('fail');
+      expect(kicadBelow.detail).toContain(`(< ${MIN_KICAD_MAJOR})`);
+
+      const at = await runDoctor({
+        repoRoot: repo,
+        model: 'gpt-5',
+        deps: deps({
+          kicadVersion: async () => `kicad-cli ${MIN_KICAD_MAJOR}.0.0`,
+          env: { OPENAI_API_KEY: 'sk-x' },
+        }),
+      });
+      expect(at.ok).toBe(true);
+      const kicadAt = at.checks.find((c) => c.name === 'kicad-cli')!;
+      expect(kicadAt.status).toBe('ok');
     } finally {
       await cleanup();
     }

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -6,6 +6,8 @@ import {
   resolveKicadCli,
   resetKicadCliCache,
   setKicadFallbackBinaries,
+  setKicadFallbackWinRoots,
+  defaultFallbackBinaries,
   kicadCliVersion,
   KicadCliBadOverrideError,
   KicadCliMissingError,
@@ -16,6 +18,20 @@ import {
  * so it is testable without KiCad installed. `check` depends on it, and check
  * is contractually LLM-free and network-free: nothing here reaches out.
  */
+async function writeMockExecutable(binPath: string, output = '9.0.1'): Promise<string> {
+  await mkdir(path.dirname(binPath), { recursive: true });
+  if (process.platform === 'win32') {
+    const isBat = binPath.endsWith('.bat') || binPath.endsWith('.cmd');
+    const target = isBat ? binPath : `${binPath}.cmd`;
+    await writeFile(target, `@echo ${output}\r\n`, 'utf8');
+    return target;
+  } else {
+    await writeFile(binPath, `#!/bin/sh\necho "${output}"\n`, 'utf8');
+    await chmod(binPath, 0o755);
+    return binPath;
+  }
+}
+
 describe('kicad-cli binary resolution', () => {
   const saved = process.env.COPPERHEAD_KICAD_CLI;
   let dir: string;
@@ -30,6 +46,7 @@ describe('kicad-cli binary resolution', () => {
     else process.env.COPPERHEAD_KICAD_CLI = saved;
     resetKicadCliCache();
     setKicadFallbackBinaries();
+    setKicadFallbackWinRoots();
     await rm(dir, { recursive: true, force: true });
   });
 
@@ -77,12 +94,11 @@ describe('kicad-cli binary resolution', () => {
 
   it('reports the binary as missing when PATH has no kicad-cli and no bundle matches', async () => {
     // Drives the real ENOENT chain: PATH lookup fails, fallbackAfterMissing
-    // finds no macOS app bundle, and the run is refused with the install
-    // instructions rather than a raw spawn error.
+    // finds no macOS app bundle or Windows install, and the run is refused
+    // with install instructions rather than a raw spawn error.
     delete process.env.COPPERHEAD_KICAD_CLI;
     // The probe list is emptied rather than left to the host: with the real
-    // list, this assertion would fail on any macOS machine that has KiCad in
-    // /Applications, because the fallback would resolve and the run succeed.
+    // list, this assertion would fail on any machine that has KiCad installed.
     setKicadFallbackBinaries([]);
     const savedPath = process.env.PATH;
     process.env.PATH = dir; // an empty directory: nothing resolvable on it
@@ -98,10 +114,8 @@ describe('kicad-cli binary resolution', () => {
     // probe at a fixture. Covers the retry: the first spawn ENOENTs on the
     // bare PATH name, the second runs the resolved bundle binary.
     delete process.env.COPPERHEAD_KICAD_CLI;
-    const bundle = path.join(dir, 'KiCad.app', 'Contents', 'MacOS', 'kicad-cli');
-    await mkdir(path.dirname(bundle), { recursive: true });
-    await writeFile(bundle, '#!/bin/sh\necho "9.0.1"\n', 'utf8');
-    await chmod(bundle, 0o755);
+    const bundleBase = path.join(dir, 'KiCad.app', 'Contents', 'MacOS', 'kicad-cli');
+    const bundle = await writeMockExecutable(bundleBase, '9.0.1');
     setKicadFallbackBinaries([path.join(dir, 'absent', 'kicad-cli'), bundle]);
     const savedPath = process.env.PATH;
     process.env.PATH = dir;
@@ -121,14 +135,11 @@ describe('kicad-cli binary resolution', () => {
     // that could still succeed. Reaching KicadCliMissingError therefore proves
     // the fallback was never attempted, rather than attempted and also empty.
     const onPath = path.join(dir, 'path-bin');
-    await mkdir(onPath, { recursive: true });
-    const pathBinary = path.join(onPath, 'kicad-cli');
-    await writeFile(pathBinary, '#!/bin/sh\necho "8.0.4"\n', 'utf8');
-    await chmod(pathBinary, 0o755);
+    const pathBinaryBase = path.join(onPath, 'kicad-cli');
+    await writeMockExecutable(pathBinaryBase, '8.0.4');
 
-    const override = path.join(dir, 'custom-kicad'); // deliberately not "kicad-cli"
-    await writeFile(override, '#!/bin/sh\necho "9.9.9"\n', 'utf8');
-    await chmod(override, 0o755);
+    const overrideBase = path.join(dir, 'custom-kicad'); // deliberately not "kicad-cli"
+    const override = await writeMockExecutable(overrideBase, '9.9.9');
 
     setKicadFallbackBinaries([]);
     const savedPath = process.env.PATH;
@@ -163,5 +174,88 @@ describe('kicad-cli binary resolution', () => {
     expect(resolveKicadCli()).toBe('kicad-cli');
     resetKicadCliCache();
     expect(resolveKicadCli()).toBe(bin);
+  });
+
+  it('discovers kicad-cli from standard Windows versioned installation paths', async () => {
+    delete process.env.COPPERHEAD_KICAD_CLI;
+    const winRoot = path.join(dir, 'KiCad');
+    const binBase = path.join(winRoot, '10.0', 'bin', 'kicad-cli');
+    const bin = await writeMockExecutable(binBase, '10.0.5');
+
+    setKicadFallbackWinRoots([winRoot]);
+    const savedPath = process.env.PATH;
+    process.env.PATH = dir;
+    try {
+      expect(await kicadCliVersion()).toBe('10.0.5');
+      expect(resolveKicadCli()).toBe(bin);
+    } finally {
+      process.env.PATH = savedPath;
+    }
+  });
+
+  it('prefers the newest version when multiple Windows versions are installed', async () => {
+    delete process.env.COPPERHEAD_KICAD_CLI;
+    const winRoot = path.join(dir, 'KiCad');
+    const bin8 = path.join(winRoot, '8.0', 'bin', 'kicad-cli.exe');
+    const bin9 = path.join(winRoot, '9.0', 'bin', 'kicad-cli.exe');
+    const bin10 = path.join(winRoot, '10.0', 'bin', 'kicad-cli.exe');
+
+    for (const b of [bin8, bin9, bin10]) {
+      await mkdir(path.dirname(b), { recursive: true });
+      await writeFile(b, '#!/bin/sh\nexit 0\n', 'utf8');
+      await chmod(b, 0o755);
+    }
+
+    setKicadFallbackWinRoots([winRoot]);
+    const candidates = defaultFallbackBinaries([winRoot]);
+    const winCandidates = candidates.filter((c) => c.startsWith(winRoot));
+
+    expect(winCandidates[0]).toBe(bin10);
+    expect(winCandidates[4]).toBe(bin9);
+    expect(winCandidates[8]).toBe(bin8);
+  });
+
+  it('falls back to unversioned Windows installation path (bin/kicad-cli.exe)', async () => {
+    delete process.env.COPPERHEAD_KICAD_CLI;
+    const winRoot = path.join(dir, 'KiCad');
+    const binBase = path.join(winRoot, 'bin', 'kicad-cli');
+    const bin = await writeMockExecutable(binBase, '8.0.0');
+
+    setKicadFallbackWinRoots([winRoot]);
+    const savedPath = process.env.PATH;
+    process.env.PATH = dir;
+    try {
+      expect(await kicadCliVersion()).toBe('8.0.0');
+      expect(resolveKicadCli()).toBe(bin);
+    } finally {
+      process.env.PATH = savedPath;
+    }
+  });
+
+  it('formats platform-specific hints in KicadCliMissingError', () => {
+    const winErr = new KicadCliMissingError('win32');
+    expect(winErr.remedy.some((h) => h.includes('kicad-cli.exe') && h.includes('Program Files'))).toBe(true);
+
+    const macErr = new KicadCliMissingError('darwin');
+    expect(macErr.remedy.some((h) => h.includes('KiCad.app'))).toBe(true);
+
+    const linuxErr = new KicadCliMissingError('linux');
+    expect(linuxErr.remedy.some((h) => h.includes('/usr/bin/kicad-cli'))).toBe(true);
+  });
+
+  it('formats platform-specific hints in KicadCliBadOverrideError', () => {
+    const badPath = 'C:\\bad\\path\\kicad-cli.exe';
+    const winErr = new KicadCliBadOverrideError(badPath, 'win32');
+    expect(winErr.message).toContain(badPath);
+    expect(winErr.remedy.some((h) => h.includes('Test-Path'))).toBe(true);
+    expect(winErr.remedy.some((h) => h.includes('Program Files'))).toBe(true);
+
+    const macErr = new KicadCliBadOverrideError('/bad/path', 'darwin');
+    expect(macErr.remedy.some((h) => h.includes('ls -l'))).toBe(true);
+    expect(macErr.remedy.some((h) => h.includes('KiCad.app'))).toBe(true);
+
+    const linuxErr = new KicadCliBadOverrideError('/bad/path', 'linux');
+    expect(linuxErr.remedy.some((h) => h.includes('ls -l'))).toBe(true);
+    expect(linuxErr.remedy.some((h) => h.includes('/usr/bin'))).toBe(true);
   });
 });

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -11,6 +11,7 @@ import {
   kicadCliVersion,
   KicadCliBadOverrideError,
   KicadCliMissingError,
+  MIN_KICAD_MAJOR,
 } from '../src/kicad/cli.js';
 
 /**
@@ -194,25 +195,31 @@ describe('kicad-cli binary resolution', () => {
   });
 
   it('prefers the newest version when multiple Windows versions are installed', async () => {
+    // Regression for Finding 5: previously this test asserted array indices on
+    // defaultFallbackBinaries() directly, which verified ordering in isolation
+    // but never exercised actual resolution. This version drives kicadCliVersion()
+    // through the full fallback path so the ordering preference is proven by
+    // the binary that actually runs, not by inspecting the candidate list.
     delete process.env.COPPERHEAD_KICAD_CLI;
     const winRoot = path.join(dir, 'KiCad');
-    const bin8 = path.join(winRoot, '8.0', 'bin', 'kicad-cli.exe');
-    const bin9 = path.join(winRoot, '9.0', 'bin', 'kicad-cli.exe');
-    const bin10 = path.join(winRoot, '10.0', 'bin', 'kicad-cli.exe');
 
-    for (const b of [bin8, bin9, bin10]) {
-      await mkdir(path.dirname(b), { recursive: true });
-      await writeFile(b, '#!/bin/sh\nexit 0\n', 'utf8');
-      await chmod(b, 0o755);
-    }
+    // Create mock executables for 8.0 and 9.0 as well, so there are real
+    // candidates at every version — resolution must still prefer 10.0.
+    const binBase8 = path.join(winRoot, '8.0', 'bin', 'kicad-cli');
+    const binBase9 = path.join(winRoot, '9.0', 'bin', 'kicad-cli');
+    const binBase10 = path.join(winRoot, '10.0', 'bin', 'kicad-cli');
+    await writeMockExecutable(binBase8, '8.0.0');
+    await writeMockExecutable(binBase9, '9.0.0');
+    await writeMockExecutable(binBase10, '10.0.5');
 
     setKicadFallbackWinRoots([winRoot]);
-    const candidates = defaultFallbackBinaries([winRoot]);
-    const winCandidates = candidates.filter((c) => c.startsWith(winRoot));
-
-    expect(winCandidates[0]).toBe(bin10);
-    expect(winCandidates[4]).toBe(bin9);
-    expect(winCandidates[8]).toBe(bin8);
+    const savedPath = process.env.PATH;
+    process.env.PATH = dir; // empty dir: PATH has no kicad-cli
+    try {
+      expect(await kicadCliVersion()).toBe('10.0.5');
+    } finally {
+      process.env.PATH = savedPath;
+    }
   });
 
   it('falls back to unversioned Windows installation path (bin/kicad-cli.exe)', async () => {
@@ -260,5 +267,72 @@ describe('kicad-cli binary resolution', () => {
     expect(linuxErr.remedy.some((h) => h.includes('ls -l'))).toBe(true);
     expect(linuxErr.remedy.some((h) => h.includes('/usr/bin'))).toBe(true);
     expect(linuxErr.remedy.some((h) => h.includes('"$COPPERHEAD_KICAD_CLI" version'))).toBe(true);
+  });
+
+  // Finding 1: a root containing only a sub-minimum version (7.x) must not be resolved.
+  it('does not resolve a KiCad version below the minimum (7.x root is silently skipped)', async () => {
+    delete process.env.COPPERHEAD_KICAD_CLI;
+    const winRoot = path.join(dir, 'KiCad');
+    // Only a 7.0 binary exists under this root.
+    const binBase = path.join(winRoot, '7.0', 'bin', 'kicad-cli');
+    await writeMockExecutable(binBase, '7.0.11');
+
+    setKicadFallbackWinRoots([winRoot]);
+    const savedPath = process.env.PATH;
+    process.env.PATH = dir; // empty dir: PATH has no kicad-cli
+    try {
+      // The 7.0 binary must be filtered out; nothing else is available.
+      await expect(kicadCliVersion()).rejects.toBeInstanceOf(KicadCliMissingError);
+    } finally {
+      process.env.PATH = savedPath;
+    }
+  });
+
+  // Finding 3 / coverage: a root that points at a file (ENOTDIR) must still
+  // probe the unversioned bin/ path, because it is pushed outside the try/catch.
+  it('probes unversioned bin/ path even when the root itself is unlistable (ENOTDIR)', async () => {
+    delete process.env.COPPERHEAD_KICAD_CLI;
+    // Create a regular file at the "root" path so readdirSync throws ENOTDIR.
+    const fakeRoot = path.join(dir, 'not-a-dir');
+    await writeFile(fakeRoot, 'not a directory', 'utf8');
+
+    // Create the unversioned binary under a parallel real root so we can
+    // prove it is reached. We use the same fakeRoot path as the root but
+    // the unversioned probe target is bin/kicad-cli inside it — which would
+    // never exist because fakeRoot is a file. Instead, construct a wrapper:
+    // use a sibling dir that acts as the real installation root so the
+    // unversioned probe can actually resolve.
+    const realRoot = path.join(dir, 'KiCad-real');
+    const binBase = path.join(realRoot, 'bin', 'kicad-cli');
+    await writeMockExecutable(binBase, '9.0.1');
+
+    // Pass both roots: fakeRoot (unlistable) first, then realRoot.
+    // The fakeRoot unversioned probe will miss (nothing at fakeRoot/bin/),
+    // but realRoot unversioned probe must succeed.
+    setKicadFallbackWinRoots([fakeRoot, realRoot]);
+    const savedPath = process.env.PATH;
+    process.env.PATH = dir;
+    try {
+      expect(await kicadCliVersion()).toBe('9.0.1');
+    } finally {
+      process.env.PATH = savedPath;
+    }
+  });
+
+  // Coverage gap: duplicate roots must not double the candidate list.
+  it('deduplicates roots so a repeated root does not double the candidate list', () => {
+    const winRoot = path.join(dir, 'KiCad');
+    // Pass the same root twice (matching what DEFAULT_WIN_ROOTS does for
+    // process.env.ProgramFiles vs the hardcoded C:/Program Files/KiCad).
+    const once = defaultFallbackBinaries([winRoot]);
+    const twice = defaultFallbackBinaries([winRoot, winRoot]);
+    // A duplicate must be skipped: the lists must be identical.
+    expect(twice).toEqual(once);
+  });
+
+  // Minimum-version constant sanity check: ensures MIN_KICAD_MAJOR is exported
+  // and matches the intended floor so a refactor cannot silently misalign it.
+  it(`MIN_KICAD_MAJOR is ${MIN_KICAD_MAJOR} (the documented KiCad minimum for ERC/DRC)`, () => {
+    expect(MIN_KICAD_MAJOR).toBe(8);
   });
 });

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -254,7 +254,9 @@ describe('kicad-cli binary resolution', () => {
     const badPath = 'C:\\bad\\path\\kicad-cli.exe';
     const winErr = new KicadCliBadOverrideError(badPath, 'win32');
     expect(winErr.message).toContain(badPath);
-    expect(winErr.remedy.some((h) => h.includes('Test-Path'))).toBe(true);
+    // Test-Path is a PowerShell cmdlet; the hint must say "PowerShell", not "PowerShell/cmd".
+    expect(winErr.remedy.some((h) => h.includes('PowerShell') && h.includes('Test-Path'))).toBe(true);
+    expect(winErr.remedy.some((h) => !h.includes('PowerShell/cmd'))).toBe(true);
     expect(winErr.remedy.some((h) => h.includes('Program Files'))).toBe(true);
     expect(winErr.remedy.some((h) => h.includes('& $env:COPPERHEAD_KICAD_CLI version'))).toBe(true);
 
@@ -296,12 +298,15 @@ describe('kicad-cli binary resolution', () => {
     const fakeRoot = path.join(dir, 'not-a-dir');
     await writeFile(fakeRoot, 'not a directory', 'utf8');
 
-    // Create the unversioned binary under a parallel real root so we can
-    // prove it is reached. We use the same fakeRoot path as the root but
-    // the unversioned probe target is bin/kicad-cli inside it — which would
-    // never exist because fakeRoot is a file. Instead, construct a wrapper:
-    // use a sibling dir that acts as the real installation root so the
-    // unversioned probe can actually resolve.
+    // Direct candidate-generation assertion: even though readdirSync(fakeRoot)
+    // throws ENOTDIR, the unversioned bin/kicad-cli.exe must still be generated
+    // in the candidate list because the push is outside the try/catch.
+    const fakeCandidates = defaultFallbackBinaries([fakeRoot]);
+    expect(fakeCandidates).toContain(path.join(fakeRoot, 'bin', 'kicad-cli.exe'));
+
+    // Resolution assertion: prove scanning continues to later valid roots.
+    // Create a binary under a parallel real root; it must be found despite
+    // the fakeRoot appearing first in the list.
     const realRoot = path.join(dir, 'KiCad-real');
     const binBase = path.join(realRoot, 'bin', 'kicad-cli');
     await writeMockExecutable(binBase, '9.0.1');

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -249,13 +249,16 @@ describe('kicad-cli binary resolution', () => {
     expect(winErr.message).toContain(badPath);
     expect(winErr.remedy.some((h) => h.includes('Test-Path'))).toBe(true);
     expect(winErr.remedy.some((h) => h.includes('Program Files'))).toBe(true);
+    expect(winErr.remedy.some((h) => h.includes('& $env:COPPERHEAD_KICAD_CLI version'))).toBe(true);
 
     const macErr = new KicadCliBadOverrideError('/bad/path', 'darwin');
     expect(macErr.remedy.some((h) => h.includes('ls -l'))).toBe(true);
     expect(macErr.remedy.some((h) => h.includes('KiCad.app'))).toBe(true);
+    expect(macErr.remedy.some((h) => h.includes('"$COPPERHEAD_KICAD_CLI" version'))).toBe(true);
 
     const linuxErr = new KicadCliBadOverrideError('/bad/path', 'linux');
     expect(linuxErr.remedy.some((h) => h.includes('ls -l'))).toBe(true);
     expect(linuxErr.remedy.some((h) => h.includes('/usr/bin'))).toBe(true);
+    expect(linuxErr.remedy.some((h) => h.includes('"$COPPERHEAD_KICAD_CLI" version'))).toBe(true);
   });
 });

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -325,8 +325,9 @@ describe('kicad-cli binary resolution', () => {
   });
 
   // Coverage gap: duplicate roots must not double the candidate list.
-  it('deduplicates roots so a repeated root does not double the candidate list', () => {
+  it('deduplicates roots so a repeated root does not double the candidate list', async () => {
     const winRoot = path.join(dir, 'KiCad');
+    await mkdir(path.join(winRoot, '9.0', 'bin'), { recursive: true });
     // Pass the same root twice (matching what DEFAULT_WIN_ROOTS does for
     // process.env.ProgramFiles vs the hardcoded C:/Program Files/KiCad).
     const once = defaultFallbackBinaries([winRoot]);

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -256,7 +256,7 @@ describe('kicad-cli binary resolution', () => {
     expect(winErr.message).toContain(badPath);
     // Test-Path is a PowerShell cmdlet; the hint must say "PowerShell", not "PowerShell/cmd".
     expect(winErr.remedy.some((h) => h.includes('PowerShell') && h.includes('Test-Path'))).toBe(true);
-    expect(winErr.remedy.some((h) => !h.includes('PowerShell/cmd'))).toBe(true);
+    expect(winErr.remedy.every((h) => !h.includes('PowerShell/cmd'))).toBe(true);
     expect(winErr.remedy.some((h) => h.includes('Program Files'))).toBe(true);
     expect(winErr.remedy.some((h) => h.includes('& $env:COPPERHEAD_KICAD_CLI version'))).toBe(true);
 


### PR DESCRIPTION
## What

Adds automatic discovery of `kicad-cli` on Windows by probing standard installation roots (`C:\Program Files\KiCad`, `C:\Program Files (x86)\KiCad`), preferring the newest installed version that meets the project's minimum supported KiCad version, and makes the missing/bad-override error hints platform-aware (Windows, macOS, Linux) instead of macOS-only.

## Why

Closes #242. On Windows, `kicad-cli` is not reliably on PATH after a default KiCad install, so `resolveKicadCli()` would fail even when KiCad was installed correctly. The existing fallback list only covered macOS app-bundle paths, and the error hints assumed a macOS install (`KiCad.app/Contents/MacOS`), which gave Windows users incorrect remediation guidance.

## Design

Resolution precedence is unchanged and still deterministic:

1. `COPPERHEAD_KICAD_CLI` explicit override (fails fast with `KicadCliBadOverrideError` naming the invalid path if it does not exist).
2. `kicad-cli` bare lookup on PATH.
3. Fallback discovery (macOS app bundles, now also Windows installation roots).

Windows fallback discovery, in [src/kicad/cli.ts](src/kicad/cli.ts):

- `defaultFallbackBinaries()` lists version subdirectories under each configured Windows root (e.g. `10.0`, `9.0`, `8.0`), filters them to major version `>= MIN_KICAD_MAJOR` before building candidates, sorts the remainder in descending numeric order (mirroring the ordering used in `src/kicad/symlib.ts`), and probes `bin/kicad-cli.exe`, `bin/kicad-cli.cmd`, `bin/kicad-cli.bat`, `bin/kicad-cli` for each qualifying version.
- The four unversioned `bin/` fallback candidates are pushed **after** the try/catch around the versioned-subdirectory listing, so they are still probed even when enumerating version subdirectories for a root fails (unreadable or virtualized directory); only the versioned candidates are lost in that case.
- Duplicate Windows roots (e.g. `ProgramFiles` resolving to the same path as the hardcoded default) are deduplicated via `seenRoots`, so the same root is never scanned twice. Verified with a regression test against a root that actually exists on disk, so the assertion is meaningful with or without the dedup logic.
- `setKicadFallbackWinRoots()` is added as a test seam alongside the existing `setKicadFallbackBinaries()`, so tests can point discovery at a temp directory without touching real Windows paths. Setting one override clears the other to avoid stale state between tests.

`KicadCliMissingError` and `KicadCliBadOverrideError` now take an optional `platform` parameter (defaulting to `process.platform`) and branch their remedy hints for Windows (`Test-Path`, PowerShell command syntax, `Program Files\KiCad\<version>\bin\kicad-cli.exe`), macOS (unchanged `KiCad.app/Contents/MacOS`), and Linux (`/usr/bin/kicad-cli`, `ls -l`).

**`doctor.ts` enforces a hard minimum-version gate, not just a hint correction.** `MIN_KICAD_MAJOR = 8` is defined once in `src/kicad/cli.ts` and imported by `doctor.ts` (no duplicate constant, verified by test). The doctor KiCad check returns `status: 'fail'`, flipping `runDoctor().ok` to `false` and the CLI's exit code to non-zero, for two cases that previously passed with only a hint: a detected KiCad version below 8, and a `kicad-cli` version string that fails to parse. **This is a genuine user-visible behavior change**: a user on KiCad 7 will see `copperhead doctor` exit non-zero where it previously exited zero. The version-parsing regex used by this check is anchored to a version-shaped token at the start of a line, so it does not misread an incidental `N.N` appearing elsewhere in probe output (e.g. an OpenGL version string) as the KiCad major version.

The same `MIN_KICAD_MAJOR` floor is enforced in Windows discovery itself (see above), so a Windows machine whose only KiCad install is below the minimum is no longer silently resolved as the ERC/DRC binary; discovery and `doctor` now agree, and both read the constant from the same source.

**Known limitation:** discovery only covers the default installation roots (`ProgramFiles`, `ProgramFiles(x86)`, `C:\Program Files\KiCad`). A custom install location (e.g. `D:\KiCad`) still requires `COPPERHEAD_KICAD_CLI` or adding the bin directory to PATH; the error hints now point the user at both options. The unversioned `bin/` fallback carries no version floor (there is no version segment in that path to filter on), so a KiCad install below 8 placed in an unversioned layout is still discoverable there; this is an accepted residual scope gap, not an oversight.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | PASS (0 errors) |
| Build | `npm run build` | PASS |
| Unit + offline | `npx vitest run test/kicad-cli-resolve.test.ts test/doctor.test.ts` | PASS (61/61) |
| Docs lint | `npm run lint:md` | PASS (164 files, 0 issues) |
| Live-LLM (opt-in) | n/a | not applicable, this change has no LLM/network surface |

Regression tests added across this PR's revisions in [test/kicad-cli-resolve.test.ts](test/kicad-cli-resolve.test.ts) and [test/doctor.test.ts](test/doctor.test.ts) cover: versioned Windows directory discovery, version-sort preference (newest first, verified through actual resolution via `kicadCliVersion()` rather than array indices), unversioned Windows directory fallback (including when versioned-subdirectory enumeration throws `ENOTDIR`), platform-tailored hint formatting for both `KicadCliMissingError` and `KicadCliBadOverrideError` across Windows, macOS, and Linux, rejection of a Windows root whose only install is below `MIN_KICAD_MAJOR`, deduplication of a repeated Windows root asserted against a root that actually exists on disk, a shared-constant check that `doctor.ts`'s version gate imports the same `MIN_KICAD_MAJOR` exported from `cli.ts` rather than redefining it, and a polluted-stdout input for the doctor version regex that must still resolve to the correct major version. No pre-existing failures were introduced by this PR; on a host without KiCad installed, a fixed set of pre-existing suites (draft-*, init-check, golden-corpus, gating-sync, repl, safety) fail at the merge base for unrelated environmental reasons and are unaffected by this change.

### Manual test log (required)

n/a: this change is confined to `kicad-cli` binary resolution and the `doctor` version-gate logic. It is exercised end to end by the automated regression tests, which build real mock executables (`writeMockExecutable`) under a temp directory and drive `resolveKicadCli()` / `kicadCliVersion()` against them for each platform branch. There is no Windows or macOS machine available in this environment to additionally hand-test against a real KiCad install; the mock-executable tests are the closest available substitute and cover the same code paths a manual run would exercise.

## Docs

[README.md](README.md) updated to document automatic fallback discovery on Windows and macOS, the `MIN_KICAD_MAJOR` (KiCad 8+) requirement enforced by both discovery and `doctor`, and the `COPPERHEAD_KICAD_CLI` override.

---

## Invariant checklist

- [x] **Spec-gated in**: N/A, does not touch the agent tool list or `edit_file`/`write_file` gating.
- [x] **Verification-gated out**: N/A, does not touch the ERC/DRC mutation/repair/rollback flow. The minimum-version floor affects *which* `kicad-cli` binary the gate runs against, not whether the gate itself runs.
- [x] **`check`/`verify` stays LLM-free and network-free**: N/A, this PR only changes how the `kicad-cli` binary is located and validated; no provider, API key, or network access is introduced.
- [x] **No sexp serialization**: N/A, `src/kicad/cli.ts` resolves a binary path only and does not touch the sexp parser.
- [x] **Sync-obligations ledger**: N/A, no post-tool-call hooks or ledger state touched.
- [x] **Secrets**: N/A, no `sk-`-style credentials involved; the only externally configurable value (`COPPERHEAD_KICAD_CLI`) is a filesystem path, not a secret.
- [x] **Spec coherence**: No delta specs changed; `SPEC.md` has no acceptance criterion covering the doctor `kicad-cli` check or the discovery minimum-version floor, so nothing in `SPEC.md` diverges. **Note that this PR does introduce a user-visible behavior change**: `copperhead doctor` now exits non-zero for KiCad installs below version 8 (previously it passed with only a hint), and Windows discovery now refuses to resolve a below-minimum KiCad install rather than silently accepting it. `nodeCheck` already gates on a minimum Node version with no corresponding spec entry, so this follows established unspecified-but-intentional practice, flagged here for reviewer visibility rather than left implicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - KiCad CLI discovery now searches standard installation locations on Windows and macOS.
  - Windows installations are selected by version, including versioned and unversioned setups.
  - Added `COPPERHEAD_KICAD_CLI` for custom CLI locations.
  - Error messages provide platform-specific guidance for missing or invalid CLI paths.

- **Bug Fixes**
  - KiCad version checks now require KiCad 8 or newer.
  - Unrecognized version output now produces actionable guidance.
  - Version detection avoids unrelated numbers in diagnostic output.

- **Documentation**
  - Updated requirements to state the KiCad 8+ requirement and automatic installation discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->