### PR TITLE
fix(agent): guard restore() on the refuse and dry-run exit paths too

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -613,7 +613,17 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
       const { outcome, summary } = ctx.finishRequest;
       const files = [...ctx.filesTouched];
       if (outcome === 'refuse') {
-        await restore(repoRoot, snap);
+        // The rollback itself can fail (git in a bad state, or — as issue #107
+        // found — the snapshot's stash object already collected by a gc that ran
+        // between snapshot() and here). Same guard as fail(): that must not become
+        // an unhandled throw that skips run-end and summary.md.
+        let restoreError: string | null = null;
+        try {
+          await restore(repoRoot, snap);
+        } catch (err) {
+          restoreError = (err as Error).message;
+          await transcript.event('restore-failed', { error: restoreError });
+        }
         await transcript.event('run-refused', { summary });
         const runStats = stats('refused');
         await transcript.event('run-end', runStats);
@@ -629,11 +639,16 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
           tokensOut,
           outcome: 'aborted',
           openObligations: null,
-          detail: `REFUSED: ${summary}`,
+          detail: restoreError
+            ? `REFUSED: ${summary}\n\nROLLBACK FAILED: ${restoreError} — the working tree may be in a partial state; inspect it with git status/git diff before rerunning`
+            : `REFUSED: ${summary}`,
           env: meta,
           stats: runStats,
         });
         log(`refused: ${summary}`);
+        if (restoreError) {
+          log(`WARNING: rollback failed (${restoreError}); the working tree may be in a partial state`);
+        }
         r.finish(outcomeLine(runStats));
         return {
           outcome: 'refused',
@@ -662,7 +677,15 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
         log('--- dry run: proposed diff ---');
         log(diff || '(no diff)');
         if (untracked) log(`new files:\n${untracked}`);
-        await restore(repoRoot, snap);
+        // Same guard as fail(): a rollback failure here must not become an
+        // unhandled throw that skips run-end and summary.md (issue #107).
+        let restoreError: string | null = null;
+        try {
+          await restore(repoRoot, snap);
+        } catch (err) {
+          restoreError = (err as Error).message;
+          await transcript.event('restore-failed', { error: restoreError });
+        }
         const runStats = stats('done');
         await transcript.event('run-end', runStats);
         await transcript.writeSummary({
@@ -677,11 +700,16 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
           tokensOut,
           outcome: 'success',
           openObligations: null,
-          detail: 'dry run: changes reverted',
+          detail: restoreError
+            ? `dry run: ROLLBACK FAILED: ${restoreError} — the working tree may be in a partial state; inspect it with git status/git diff before rerunning`
+            : 'dry run: changes reverted',
           env: meta,
           stats: runStats,
         });
-        r.finish(outcomeLine(runStats, 'dry run: changes reverted'));
+        if (restoreError) {
+          log(`WARNING: rollback failed (${restoreError}); the working tree may be in a partial state`);
+        }
+        r.finish(outcomeLine(runStats, restoreError ? 'dry run: rollback failed' : 'dry run: changes reverted'));
         return {
           outcome: 'success',
           exitPath: 'done',

--- a/test/observability.test.ts
+++ b/test/observability.test.ts
@@ -195,6 +195,83 @@ describe('exit paths and run-end addenda (task 4.6)', () => {
       await cleanup();
     }
   });
+
+  it('a failed rollback on the refuse path still writes run-end and summary.md (issue #107)', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const lines: string[] = [];
+      // Same shape as fail()'s case above, but the refuse branch used to call
+      // restore() unguarded: an unhandled throw there escaped runAgentLoop
+      // entirely and skipped run-end and summary.md, which the issue reported
+      // for a snapshot's stash object collected by a gc that ran mid-session —
+      // deleting .git reproduces the same "restore() throws" shape without
+      // depending on gc timing.
+      const provider: Provider = {
+        name: 'scripted',
+        chat: async () => {
+          await rm(path.join(repo, '.git'), { recursive: true, force: true });
+          return { text: null, toolCalls: [{ id: 'fin', name: 'finish', args: { outcome: 'refuse', summary: 'violates budget' } }], usage: { inputTokens: 500, outputTokens: 100 } };
+        },
+      };
+      const res = await runAgentLoop(loopOpts(repo, provider, lines, { maxTurns: 2 }));
+      expect(res.outcome).toBe('refused');
+      expect(res.exitPath).toBe('refused');
+
+      const events = await transcriptEvents(res.transcriptDir);
+      expect(events.some((e) => e.type === 'restore-failed')).toBe(true);
+      expect(events.some((e) => e.type === 'run-end')).toBe(true);
+
+      const summary = await readFile(path.join(res.transcriptDir, 'summary.md'), 'utf8');
+      expect(summary).toContain('ROLLBACK FAILED');
+      expect(lines.join('\n')).toContain('rollback failed');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a failed rollback on the dry-run path still writes run-end and summary.md (issue #107)', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      // The dry-run branch runs `git diff`/`git ls-files` before restore(), so
+      // deleting .git (as the two tests above do) breaks those first instead of
+      // exercising the guard around restore() itself. This instead reproduces
+      // the issue's actual mechanism: snapshot() at run start records an
+      // unreferenced `git stash create` object (never `stash store`d, so
+      // nothing points at it), and a gc that runs before restore() collects it,
+      // exactly as issue #107's repro showed. Only the stash object goes
+      // missing — plain reads like diff/ls-files are unaffected — so this
+      // fails restore()'s `git stash apply` specifically, at the same point a
+      // real concurrent gc would. Must dirty a *tracked* file: `git stash
+      // create` only captures tracked changes, so an untracked-only dirty tree
+      // never produces a stash object to collect in the first place.
+      await writeFile(
+        path.join(repo, 'hardware', 'open-key.kicad_pro'),
+        (await readFile(path.join(repo, 'hardware', 'open-key.kicad_pro'), 'utf8')) + '\n',
+        'utf8',
+      );
+      const lines: string[] = [];
+      const provider: Provider = {
+        name: 'scripted',
+        chat: async () => {
+          await execa('git', ['gc', '--prune=now'], { cwd: repo });
+          return { text: null, toolCalls: [{ id: 'fin', name: 'finish', args: { outcome: 'done', summary: 'all good' } }], usage: { inputTokens: 500, outputTokens: 100 } };
+        },
+      };
+      const res = await runAgentLoop(loopOpts(repo, provider, lines, { maxTurns: 2, allowDirty: true, dryRun: true }));
+      expect(res.outcome).toBe('success');
+      expect(res.exitPath).toBe('done');
+
+      const events = await transcriptEvents(res.transcriptDir);
+      expect(events.some((e) => e.type === 'restore-failed')).toBe(true);
+      expect(events.some((e) => e.type === 'run-end')).toBe(true);
+
+      const summary = await readFile(path.join(res.transcriptDir, 'summary.md'), 'utf8');
+      expect(summary).toContain('ROLLBACK FAILED');
+      expect(lines.join('\n')).toContain('rollback failed');
+    } finally {
+      await cleanup();
+    }
+  });
 });
 
 describe('redaction of metadata surfaces (task 6.1)', () => {


### PR DESCRIPTION
## What

A rollback failure on the refuse or dry-run exit paths crashed `runAgentLoop` with an unhandled throw instead of reporting it, exactly when the working tree is in an unknown state and the report matters most.

## Why

Closes #107. `fail()` already guards its `restore()` call: if the rollback throws, it catches the error, records it on the transcript and in `summary.md`, and still finishes the run. The refuse and dry-run paths call `restore()` unguarded, so the identical failure there escapes `runAgentLoop` entirely.

@DPS0340 found and diagnosed this (with the original fix in the now-withdrawn #108): [snapshot()](src/util/git.ts) records an unreferenced `git stash create` object (never `stash store`d, so nothing points at it), and a routine `gc` that runs between the snapshot and the rollback collects it, making the later `git stash apply` fatal. They withdrew #108 for queue reasons unrelated to the fix, and didn't respond when I asked on the issue whether they wanted to reclaim it, so sending it now rather than leaving the gap open, with full credit for the diagnosis.

## Design

Both paths now wrap `restore()` in the same try/catch `fail()` uses: catch the error, emit a `restore-failed` transcript event, and fold it into `summary.md`'s `detail` field with the same "working tree may be in a partial state" wording, before still calling `run-end`/`writeSummary`/returning. Neither path's own outcome classification changes on a rollback failure, matching how `fail()` treats it as an orthogonal, logged condition rather than a new exit path.

## Spec / OpenSpec

Not spec-level: `fail()`'s own restore-guard was never encoded as a numbered AC either, so this extends existing implementation-level defensive behavior to the two paths that lacked it rather than changing anything SPEC.md documents.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | 787 passed, 25 failed, 21 skipped |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` | not run (no key in this environment) |

Two new tests in [test/observability.test.ts](test/observability.test.ts), alongside the existing coverage for `fail()`'s identical guard: one for the refuse path, one for the dry-run path. Per DPS0340's own warning on the issue that a naive regression test can pass against the unfixed code for the wrong reason, both reproduce the actual mechanism rather than a shortcut: dirtying only an untracked file never produces a stash object to begin with, since `git stash create` captures tracked changes only, so the dry-run test specifically dirties a tracked fixture file, then runs `git gc --prune=now` mid-run to collect the resulting unreferenced stash object, exactly reproducing the issue's repro. Verified both fail against unfixed `loop.ts` (temporarily reverted) with the exact uncaught errors the issue describes (`fatal: not a git repository` / `fatal: '...' is not a stash-like commit`), and pass clean against the fix.

All 25 pre-existing failures are unrelated to this change: `kicad-cli` not installed and two Windows-only `chmod` semantics assertions, in this environment. Diffed the full failure set against a clean `main` worktree in the same environment: identical set, zero failures introduced by this branch.

### Manual test log (required)

n/a: this environment has neither `kicad-cli` on PATH nor a live LLM API key, so the CLI sandboxes in `manual-tests/` (which need both) aren't runnable here. The regression tests above exercise the actual failure mechanism directly at the git level rather than through a mock, which is arguably a more reliable reproduction of this specific bug than a manual run would be, since the underlying trigger is a `gc` timing race the manual sandbox wouldn't deterministically hit either. Flagging the gap rather than skipping it silently.

## Docs

None needed: no user-facing behavior changes (a rollback failure was always reported by two of the three paths; this makes it uniform), and no spec artifacts to keep in sync per above.

---

## Invariant checklist

- [ ] Spec-gated in: N/A, does not touch the agent tool list.
- [ ] Verification-gated out: N/A, does not touch ERC/DRC gating.
- [ ] `check`/`verify` stays LLM-free and network-free: N/A, this PR does not touch `src/commands/check`.
- [ ] No sexp serialization: N/A, does not touch `src/kicad/`.
- [ ] Sync-obligations ledger: N/A, does not touch the ledger.
- [ ] Secrets: N/A, no new transcript/summary fields carry anything but the existing `restoreError` message, which was already surfaced by `fail()`'s identical path.
- [ ] Spec coherence: N/A per the Spec/OpenSpec section above.
