### PR TITLE
feat(cli): add skill commands for listing and running registered skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Spec-gated in, verification-gated out: the design can't drift from its requireme
 ```text
 copperhead init [--path hardware/]   # scaffold docs/ from an existing schematic; idempotent
 copperhead do "<change request>"     # the core loop: propose, edit, verify, propagate, commit
+copperhead skill list                # registered skills (no LLM)
+copperhead skill run generate-report # read-only design report (needs a model)
 copperhead check                     # ERC + DRC + doc-drift + spec validation; no LLM calls (alias: verify)
 copperhead doctor                    # env preflight: node, kicad-cli, git, openspec, provider credential; no LLM/network
 copperhead sync [--dry-run]          # verify the whole design state, resolve drift
@@ -122,7 +124,9 @@ copperhead create --brief brief.md   # brief → full output package
 copperhead export bom --supplier jlcpcb   # supplier-ready ordering file from docs/BOM.md
 ```
 
-Global flags: `--repo <path>` (default: cwd) and `--json` for machine-readable output. `--model` is available on `do`, `sync`, `create`, and `doctor`; `--interactive` only on `do` and `create`; `do` also takes `--dry-run`, `--max-turns`, and `--allow-dirty`.
+Global flags: `--repo <path>` (default: cwd) and `--json` for machine-readable output. `--model` is available on `do`, `sync`, `create`, `skill run`, and `doctor`; `--interactive` only on `do` and `create`; `do` also takes `--dry-run`, `--max-turns`, and `--allow-dirty`.
+
+`copperhead create` still uses its own hardcoded stages; those are not yet skills.
 
 `--model` accepts `gpt-5` (OpenAI), `claude` / `claude-<id>` (Anthropic API), `claude-code` / `claude-code:<id>` (Claude Code, saved login), `cursor` / `cursor:<id>` (Cursor Agent CLI, saved login), and `codex` / `codex:<id>` (Codex CLI, saved login). Routing is by prefix; `claude-code` is matched before the `claude` prefix. `compat:<id>` targets any OpenAI-compatible endpoint (Groq, OpenRouter, Gemini, or a local Ollama) via `COPPERHEAD_BASE_URL` and `COPPERHEAD_API_KEY_ENV` - worked examples for each in [`.env.example`](.env.example) and the [configuration reference](https://docs.copperhead.sh/reference/configuration/#model-selection).
 

--- a/openspec/changes/formalize-tool-registry/.openspec.yaml
+++ b/openspec/changes/formalize-tool-registry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/formalize-tool-registry/design.md
+++ b/openspec/changes/formalize-tool-registry/design.md
@@ -1,0 +1,167 @@
+# formalize-tool-registry: Design
+
+## Context
+
+Today there are two capability systems that do not know about each other. `TOOLS: ToolDef[]` in `src/agent/tools.ts` is 23 entries, `requiresUnlock: boolean`, handlers returning `Promise<string>`. `STAGES` in `src/commands/create.ts` is a skill registry under another name: each stage has `name`, `isComplete`, and `prompt`, and `create` executes one by calling `runAgentLoop`. The model sees only the flat tool list. `theme.ts` classifies a tool result by regex on its first line. There is no schema version, no structured envelope, and no `gate()` predicate — so the research tools' condition (`research.enabled` AND keys present) and any future skill would each grow a second gating path.
+
+Issue #246 owns this stream. This change is Phase 0, option 2: framework plus one proof skill. Part-research (#41), MCP (#40), and migrating `STAGES` are out of scope.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One catalog the model sees; dispatch picks atomic tool vs skill.
+- `gate()` as the single gating mechanism; spec-gating of `edit_file`/`write_file` stays an absence-from-list invariant, proven by test.
+- Structured `ToolResult` envelopes; renderer reads `ok` / `viewHint`.
+- Envelope `data` redacted at construction; render/dock never see a raw secret-shaped payload.
+- Proof skill `generate_report` plus nested sub-run, with CLI `copperhead skill run generate-report`.
+- `check`/`verify` remain LLM-free and network-free (AC-2.1).
+
+**Non-Goals:**
+
+- Migrating `STAGES` onto the skill registry (follow-up; `stage-completion.test.ts` and the `create-*.test.ts` files stay put).
+- Part-research tools, MCP server, Claude Code / Codex companion skills.
+- Changing provider wire formats beyond flattening the envelope to today's string `Msg` tool content.
+- A new network surface, a new LLM SDK, or any change to the `check` module graph.
+
+## Decisions
+
+### D1. One catalog, two tiers; dispatch picks the tier
+
+```
+catalog:  [read_file, edit_file, run_erc, ..., generate_report]
+             |______ tier 1: atomic ______|   |____ tier 2 ____|
+```
+
+`registry.list(ctx)` returns every entry whose `gate(ctx)` is true. Names are unique across both tiers. A skill presents as a tool in the provider's schema list (name, description, parameters). `dispatch(name)` looks up the entry: tier 1 runs `handler`; tier 2 runs the nested sub-run (D6) and returns one envelope.
+
+Alternative considered: keep skills out of the model catalog and inject their prompts into the current loop. Rejected — that forfeits budget isolation and a real completion contract, which is exactly what makes create stages recoverable today.
+
+### D2. `gate()` predicate replaces `requiresUnlock`
+
+```ts
+gate: (ctx: RunContext) => boolean
+```
+
+Edit tools: `gate: (ctx) => ctx.editsUnlocked`. Research tools (later): `gate: (ctx) => enabled && keysPresent`. A boolean cannot express the second without a parallel filter. One predicate is the project's established "absent, not discouraged" idiom.
+
+`availableTools(ctx)` becomes `registry.list(ctx)` filtered to the requested tier, or the combined catalog. Off-catalog rejection in `parseToolCalls` is unchanged: it still takes a `Set` of names from `list(ctx)`.
+
+### D3. A skill's default gate is the conjunction of its tools' gates
+
+```ts
+gate?: (ctx) => boolean  // default: every declared tool's gate(ctx) is true
+```
+
+Load-bearing. A skill that lists `edit_file` is structurally absent from `list(ctx)` until the proposal validates, by construction. Without this default the skill tier is the hole in invariant 1. A skill MAY supply a stricter `gate`; it MUST NOT supply a weaker one. The conformance test (D8) asserts the effective gate is at least as strict as every declared tool.
+
+Worked example: `generate_report` declares `[read_file, search, list_nets, run_erc, run_drc, export_svg, check_drift]` — no mutation tools — therefore always available and provably unable to write.
+
+### D4. Envelope at the handler boundary; flatten for providers
+
+```ts
+interface ToolResult {
+  ok: boolean;
+  summary: string;     // one line the renderer shows
+  detail?: string;     // what the model reads (flattened)
+  data?: unknown;      // structured payload, redacted at construction
+  error?: { kind: 'unavailable' | 'validation' | 'refusal' | 'exception'; message: string };
+  viewHint?: 'diagnostic' | 'mutation' | 'query' | 'export';
+}
+```
+
+Handlers return `ToolResult`. `dispatchTool` returns the envelope to the loop. The loop (1) records the envelope on the transcript, (2) flattens `summary` + `detail` (or `error.message`) into the string `Msg` tool content providers already consume, (3) hands the envelope to the renderer.
+
+Flattening preserves today's gating-sync substrings: an unavailable edit tool's `error.message` still contains `"not available"` and `"unlock"`. The absence assertion `expect(registry.list(ctx).map(e => e.name)).not.toContain('edit_file')` is the invariant; the envelope `kind === 'unavailable'` assertion is additive, never a replacement.
+
+`data` is passed through `redactSecrets` (and the `*_KEY`/`*_SECRET`/`*_TOKEN` value set) at envelope construction. Renderers receive the already-redacted envelope. They never call `JSON.stringify` on unredacted handler output.
+
+Alternative: keep handlers returning strings and wrap at dispatch. Rejected — view hints and typed errors would be reconstructed from prose, which is the regex heuristic this change deletes.
+
+### D5. Schema version on each entry; protocol version on the registry
+
+Each tool and skill carries `version: number` (schema of its parameters + result). The registry exposes a protocol version for the envelope shape. Provider adapters keep sending `{ name, description, parameters }` over the wire; `version` stays in our catalog so MCP hosts can cache a tool list later without this change taking a dependency on MCP.
+
+### D6. Nested sub-run, not a second `do`
+
+A skill call is **not** `runAgentLoop` as `do`/`create` call it. The outer loop owns git preflight, snapshot, commit, and OpenSpec archive. A nested skill that went through that path would snapshot mid-run, commit out from under the parent, or archive a change the parent still holds.
+
+The nested path is a turn-loop extract:
+
+- Shares the parent's `RunContext` ledger, transcript, and `editsUnlocked`.
+- Own messages, own `maxTurns` (skill default or arg), own tool subset (`skill.tools` resolved against the registry).
+- No git snapshot, no commit, no `openspec archive`.
+- Completes when `isComplete(ctx, args)` is true or the turn budget is exhausted; the parent receives one envelope.
+- `finish` is forbidden in a skill's `tools` array (conformance test). The nested loop does not put `finish` in the child catalog. Even if a future caller forced it, `finishRequest` on the shared ctx MUST NOT trigger the parent's commit; the nested path never reads it for that purpose.
+
+Verification-gating stays with the parent: a skill that somehow mutated would open obligations on the shared ledger, and the parent's `finish` would still refuse. `generate_report` cannot mutate, so this is a structural backstop for later skills, not a generate_report concern.
+
+Alternative: inject skill instructions into the current loop. Rejected (D1). Alternative: spawn a full `runAgentLoop`. Rejected because of snapshot/commit.
+
+### D7. `generate_report` is the proof skill; `STAGES` stay put
+
+Read-only report of the current design state. Parameters: `{ scope: 'power' | 'all' }` (default `all`). The nested loop uses the declared tools and returns `summary` + `detail` as the report (ERC/DRC/drift status, net count, SVG path if exported). It does not call `write_file`; the report is the envelope. The CLI prints that envelope; the parent transcript records it.
+
+`STAGES` remain hardcoded in `create.ts`. Migrating them is a later change so this one does not move `stage-completion.test.ts` and the six `create-*.test.ts` files in the same diff as the registry.
+
+### D8. Handlers table + skill modules, identity `defineTool`/`defineSkill`, barrel + conformance
+
+```
+src/capabilities/
+  handlers.ts                atomic tools (schema + string handler + requiresUnlock)
+  index.ts                   wrap HANDLERS via defineTool; import each skill
+  skills/generate-report.ts  export default defineSkill({ ... })
+```
+
+Atomic tools stay one table so a new tool is one `HANDLERS` entry, not a stub file plus a barrel line. Skills remain one module each — they have a prompt, tool subset, and completion contract that a table row cannot hold. `defineTool` / `defineSkill` are identity functions for inference and defaults (`gate` conjunction, `version` required). `src/agent/tools.ts` keeps `RunContext`, dispatch, and the nested skill sub-run.
+
+Conformance test over every registered entry:
+
+- names unique across both tiers
+- `version` and `viewHint` set
+- catalog tool names match `HANDLERS` 1:1
+- every skill `tools` name resolves
+- a skill's effective gate is at least as strict as each declared tool
+- every file under `src/capabilities/skills/` is imported by the barrel (an unregistered skill file fails CI)
+
+Existing tools keep their current names, schemas, and observable string summaries after flattening, so provider integration tests and `gating-sync` stay green.
+
+### D9. CLI form is the same definition
+
+```
+copperhead skill list
+copperhead skill run generate-report [--scope power|all]
+```
+
+`skill list` is LLM-free and network-free: it prints registered skills and whether `gate(ctx)` would include them. `skill run` invokes D6's nested sub-run (it needs a model, same as `do`) and prints the envelope. Tests call the exported runner with a `ScriptedProvider` (already used in `test/observability.test.ts`) so the suite stays offline. Missing key on `skill run` is a typed error naming the env var, not a stack trace.
+
+`check`/`verify` do not import `src/capabilities/`. The module-graph guard in `test/init-check.test.ts` keeps scanning outward from `src/commands/check.ts`.
+
+### D10. Renderer reads `ok` / `viewHint`; retry maps from error kind
+
+`toolLine` uses `result.ok` for the glyph, not `/\b(clean|ok|pass(?:ed)?|success|done)\b/i`. `viewHint` selects layout (diagnostic vs mutation vs query vs export). `validation` and `refusal` are not retried; `exception` uses `src/util/retry.ts` the way provider 429s already do; `unavailable` is not retried (the catalog did not contain the tool).
+
+## Risks / Trade-offs
+
+- [Envelope refactor weakens `gating-sync`] → keep `expect(registry.list(ctx).map(e => e.name)).not.toContain('edit_file')`; keep `"not available"` / `"unlock"` in the unavailable message; add `error.kind === 'unavailable'` alongside, never instead.
+- [Nested `runAgentLoop` snapshots or commits] → D6 is a turn-loop extract, not `do`. Tests assert a skill call does not create a git snapshot, a commit, or an OpenSpec archive.
+- [Skill lists `finish` and launders an unverified mutation] → conformance forbids `finish` in `tools`; nested path never consults `finishRequest` for commit; parent ledger still blocks.
+- [File split of `tools.ts` is a large mechanical diff] → one commit-worth of moves with behavior-preserving flatten; existing handler strings become `summary`/`detail` so golden tests that match result text stay stable.
+- [Third-party bytes on the render path in later phases] → redaction at envelope construction now, with a test that a key-shaped token in `data` never reaches the renderer verbatim. Phase 2 rides this.
+- [`check` accidentally imports the registry] → module-graph guard stays pointed at `src/commands/check.ts`; `src/capabilities/` is not on that graph.
+
+## Migration Plan
+
+1. Land types, envelope helpers (including redaction-at-construction), and `ToolRegistry` wrapping the current `TOOLS` array with `gate: (ctx) => !requiresUnlock || ctx.editsUnlocked`. No behavior change.
+2. Wrap `HANDLERS` into the catalog, add `skills/*`, barrel + conformance. Flattened strings stay identical.
+3. Nested sub-run + `generate_report` + `copperhead skill list`/`run`.
+4. Renderer switches from regex to `ok`/`viewHint`.
+5. On archive: SPEC.md §4.2 documents the catalog (tools + skills) and §3 gains `skill`.
+
+Rollback: revert the change. No config flag — this is the new tool frame, not an opt-in. Existing `do`/`create`/`check` contracts are preserved by flattening and by leaving `STAGES` in place.
+
+## Open Questions
+
+- Skill names in the model catalog: `generate_report` (underscore, matches tools) vs `generate-report` (CLI kebab). Leaning underscore in the catalog and kebab in the CLI, mapped by the skill command, so the model sees one naming convention.
+- Whether inner skill turns share the parent's JSONL transcript as nested events or write a sibling `skill-<name>.jsonl`. Leaning nested events in the same transcript so one run dir stays the audit trail.
+- Default `maxTurns` for `generate_report`. Leaning 8 — enough for ERC+DRC+drift+a handful of reads, far under `do`'s 40.

--- a/openspec/changes/formalize-tool-registry/design.md
+++ b/openspec/changes/formalize-tool-registry/design.md
@@ -70,13 +70,13 @@ interface ToolResult {
 }
 ```
 
-Handlers return `ToolResult`. `dispatchTool` returns the envelope to the loop. The loop (1) records the envelope on the transcript, (2) flattens `summary` + `detail` (or `error.message`) into the string `Msg` tool content providers already consume, (3) hands the envelope to the renderer.
+Catalog handlers return `ToolResult`. The legacy `HANDLERS` table may return prose for operations whose outcome is the operation itself, or `{ ok, text }` when the handler already knows a separate domain outcome (ERC/DRC/drift/symbol/legibility diagnostics and multi-artifact exports). The barrel converts either form to one envelope before dispatch returns it. This prevents a known failing diagnostic from being re-inferred from prose. The loop (1) records the envelope on the transcript, (2) flattens `summary` + `detail` (or `error.message`) into the string `Msg` tool content providers already consume, (3) hands the envelope to the renderer.
 
 Flattening preserves today's gating-sync substrings: an unavailable edit tool's `error.message` still contains `"not available"` and `"unlock"`. The absence assertion `expect(registry.list(ctx).map(e => e.name)).not.toContain('edit_file')` is the invariant; the envelope `kind === 'unavailable'` assertion is additive, never a replacement.
 
 `data` is passed through `redactSecrets` (and the `*_KEY`/`*_SECRET`/`*_TOKEN` value set) at envelope construction. Renderers receive the already-redacted envelope. They never call `JSON.stringify` on unredacted handler output.
 
-Alternative: keep handlers returning strings and wrap at dispatch. Rejected — view hints and typed errors would be reconstructed from prose, which is the regex heuristic this change deletes.
+Unsuccessful domain outcomes without an invocation error keep their `detail` when flattened. Typed invocation errors still flatten to `error.message`.
 
 ### D5. Schema version on each entry; protocol version on the registry
 
@@ -92,6 +92,8 @@ The nested path is a turn-loop extract:
 - Own messages, own `maxTurns` (skill default or arg), own tool subset (`skill.tools` resolved against the registry).
 - No git snapshot, no commit, no `openspec archive`.
 - Completes when `isComplete(ctx, args)` is true or the turn budget is exhausted; the parent receives one envelope.
+- Provider turns inherit the main loop's bounded turn timeout and 429 retry policy. An exhausted timeout, rate limit, or other provider exception is converted by dispatch into a failed `exception` envelope; it never escapes the parent loop.
+- Inner tool results are retained in call order, including repeated calls to the same tool. An incomplete skill returns every partial result it gathered.
 - `finish` is forbidden in a skill's `tools` array (conformance test). The nested loop does not put `finish` in the child catalog. Even if a future caller forced it, `finishRequest` on the shared ctx MUST NOT trigger the parent's commit; the nested path never reads it for that purpose.
 
 Verification-gating stays with the parent: a skill that somehow mutated would open obligations on the shared ledger, and the parent's `finish` would still refuse. `generate_report` cannot mutate, so this is a structural backstop for later skills, not a generate_report concern.
@@ -133,13 +135,13 @@ copperhead skill list
 copperhead skill run generate-report [--scope power|all]
 ```
 
-`skill list` is LLM-free and network-free: it prints registered skills and whether `gate(ctx)` would include them. `skill run` invokes D6's nested sub-run (it needs a model, same as `do`) and prints the envelope. Tests call the exported runner with a `ScriptedProvider` (already used in `test/observability.test.ts`) so the suite stays offline. Missing key on `skill run` is a typed error naming the env var, not a stack trace.
+`skill list` is LLM-free, network-free, and filesystem-side-effect-free: it prints registered skills and whether `gate(ctx)` would include them without initializing a transcript. `skill run` invokes D6's nested sub-run (it needs a model, same as `do`) and prints the envelope. Tests call the exported runner with a `ScriptedProvider` (already used in `test/observability.test.ts`) so the suite stays offline. Missing key on `skill run` is a typed error naming the env var, not a stack trace.
 
 `check`/`verify` do not import `src/capabilities/`. The module-graph guard in `test/init-check.test.ts` keeps scanning outward from `src/commands/check.ts`.
 
 ### D10. Renderer reads `ok` / `viewHint`; retry maps from error kind
 
-`toolLine` uses `result.ok` for the glyph, not `/\b(clean|ok|pass(?:ed)?|success|done)\b/i`. `viewHint` selects layout (diagnostic vs mutation vs query vs export). `validation` and `refusal` are not retried; `exception` uses `src/util/retry.ts` the way provider 429s already do; `unavailable` is not retried (the catalog did not contain the tool).
+`toolLine` uses `result.ok` for the glyph, not `/\b(clean|ok|pass(?:ed)?|success|done)\b/i`. Diagnostics that already have a structured result set `ok` from that result (for example `CheckReport.ok`), never from a prefix in formatted prose. `viewHint` selects layout (diagnostic vs mutation vs query vs export). `validation` and `refusal` are not retried; thrown 429s use `src/util/retry.ts`; `unavailable` is not retried.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/formalize-tool-registry/proposal.md
+++ b/openspec/changes/formalize-tool-registry/proposal.md
@@ -1,0 +1,36 @@
+# formalize-tool-registry: Proposal
+
+## Why
+
+The tool system is a flat `TOOLS` array with boolean gating and plain-string results. Skills already exist as `STAGES` in `create`, but they are a second, hardcoded registry the model cannot see. Issue #246's later phases (part-research, MCP, host skills) need one catalog, versioned schemas, structured results, and a `gate()` predicate — none of which exist yet. Formalizing that frame now is what those surfaces reuse; building them against the flat list would freeze the wrong shape.
+
+## What Changes
+
+- **One two-tier catalog.** Atomic tools (tier 1) and composed skills (tier 2) register through the same path and appear as one tool list to the model. Dispatch picks the tier: a tool runs its handler; a skill runs a nested `runAgentLoop` and returns one envelope to the parent.
+- **`ToolRegistry` replaces the flat array.** Lookup by name, `list(ctx)` applying each entry's `gate()`, schema `version`, and a registry protocol version. `requiresUnlock: boolean` becomes `gate: (ctx) => boolean`.
+- **Structured `ToolResult` envelope** `{ ok, summary, detail?, data?, error?, viewHint? }`. Providers still receive a flattened string (backward compatible). The renderer reads `ok` / `viewHint` instead of regex-guessing pass/fail from prose.
+- **Typed error kinds** `unavailable` / `validation` / `refusal` / `exception`, with envelope construction as the redaction boundary (`data` never carries a secret-shaped payload to render or dock).
+- **Skill contract.** A skill declares its tool subset, prompt, completion gate, and optional turn budget. Its default `gate` is the conjunction of those tools' gates, so a skill that lists `edit_file` is structurally absent until the proposal validates — by construction.
+- **Proof skill `generate_report`.** Read-only (`read_file`, `search`, `list_nets`, `run_erc`, `run_drc`, `export_svg`, `check_drift`). Always available; cannot write. Nested loop returns the report as the envelope. `create`'s `STAGES` are **not** migrated in this change.
+- **CLI form** `copperhead skill run generate-report`, the same definition as the model-facing tool, so the skill is testable without a provider key.
+
+## Capabilities
+
+### New Capabilities
+
+- `tool-registry`: the two-tier catalog, versioned schemas, `ToolResult` envelope, `gate()` predicates, skill sub-run contract, `generate_report` as the proof skill, and the `copperhead skill run` CLI.
+
+### Modified Capabilities
+
+- `agent-core`: the loop consumes the registry; dispatch returns envelopes that flatten to today's string for providers; a skill call is a nested `runAgentLoop` whose parent sees one result, not the inner transcript.
+- `cli-surface`: the CLI gains `skill run <name>`.
+- `spec-gating`: gating is a `gate()` predicate on each catalog entry; a skill's effective gate is at least as strict as every tool it declares; the structural test remains absence from `list(ctx)`, not a dispatch-time `unavailable` error.
+- `safety-rails`: envelope `data` is redacted at construction; the render/dock path never receives a raw secret-shaped payload. `check`/`verify` stay LLM-free and network-free (AC-2.1).
+
+## Impact
+
+- **Code:** new `src/capabilities/` (`HANDLERS` table wrapped by `defineTool`, one file per skill, barrel); `src/agent/tools.ts` is registry + dispatch + skill sub-run; loop, providers, `render.ts` / `dock-renderer.ts` / `theme.ts` consume envelopes; `src/commands/skill.ts` for the CLI form.
+- **Tests:** `gating-sync` keeps the absence assertion (`edit_file` not in `list(ctx)`); envelope assertions are additive; conformance test over every registered entry; offline `skill run` via stub provider; redaction test that a key-shaped token never reaches the renderer.
+- **Docs:** SPEC.md §4.2 tool table becomes the catalog (tools + skills); skill CLI lands in §3.
+- **Unchanged contracts:** spec-gated edit tools remain structurally absent until a proposal validates; verification-gated completion is unchanged; a skill sub-run cannot clear parent obligations via `finish`; `check` imports no capability module; `STAGES` stay in `create.ts`.
+- **Out of scope:** part-research tools (#41 / `add-part-research-tools`), MCP server and host skills (#40 / `add-mcp-server`), migrating `create` stages onto the skill registry.

--- a/openspec/changes/formalize-tool-registry/specs/agent-core/spec.md
+++ b/openspec/changes/formalize-tool-registry/specs/agent-core/spec.md
@@ -3,7 +3,7 @@
 ## ADDED Requirements
 
 ### Requirement: Loop consumes the registry and flattens envelopes
-The agent loop SHALL obtain the per-turn tool list from `registry.list(ctx)` and SHALL dispatch through the registry. Handler and skill results SHALL be `ToolResult` envelopes. The loop SHALL flatten each envelope into the string `content` of the provider-facing tool `Msg` (summary plus detail on success; `error.message` on failure) so existing provider adapters keep their current wire format.
+The agent loop SHALL obtain the per-turn tool list from `registry.list(ctx)` and SHALL dispatch through the registry. Handler and skill results SHALL be `ToolResult` envelopes. The loop SHALL flatten each envelope into the string `content` of the provider-facing tool `Msg` (summary plus detail for domain results, including unsuccessful partial results; `error.message` for typed invocation errors) so existing provider adapters keep their current wire format.
 
 #### Scenario: Provider still sees strings
 - **WHEN** a turn's tool call completes

--- a/openspec/changes/formalize-tool-registry/specs/agent-core/spec.md
+++ b/openspec/changes/formalize-tool-registry/specs/agent-core/spec.md
@@ -1,0 +1,25 @@
+# agent-core — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Loop consumes the registry and flattens envelopes
+The agent loop SHALL obtain the per-turn tool list from `registry.list(ctx)` and SHALL dispatch through the registry. Handler and skill results SHALL be `ToolResult` envelopes. The loop SHALL flatten each envelope into the string `content` of the provider-facing tool `Msg` (summary plus detail on success; `error.message` on failure) so existing provider adapters keep their current wire format.
+
+#### Scenario: Provider still sees strings
+- **WHEN** a turn's tool call completes
+- **THEN** the `Msg` appended with `role: 'tool'` has string `content` derived from the envelope, and the transcript event stores the envelope
+
+#### Scenario: Off-catalog names stay prose
+- **WHEN** `parseToolCalls` is given a catalog `Set` from `registry.list(ctx)` and the model emits a name not in that set
+- **THEN** that emission is left as prose and is not dispatched
+
+### Requirement: Skill dispatch is a nested turn loop
+When the dispatched name is a skill, the loop SHALL run the nested sub-run specified by the tool-registry capability (shared ledger and transcript, restricted tool subset, no snapshot/commit/archive) and SHALL continue the parent turn with that one envelope. The parent loop SHALL remain the only path that snapshots, commits, or archives.
+
+#### Scenario: Inner turns do not commit
+- **WHEN** a parent `do` run calls `generate_report` mid-loop
+- **THEN** after the skill returns, the working tree has no extra commit attributable to the skill, and the parent loop is still in progress
+
+#### Scenario: Nested finish cannot satisfy the parent
+- **WHEN** a nested sub-run ends
+- **THEN** the parent's `finishRequest` is unchanged from before the skill call, and commit still requires the parent to call `finish` with obligations clear

--- a/openspec/changes/formalize-tool-registry/specs/cli-surface/spec.md
+++ b/openspec/changes/formalize-tool-registry/specs/cli-surface/spec.md
@@ -1,0 +1,26 @@
+# cli-surface — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: `skill` command
+The CLI SHALL provide `copperhead skill list` and `copperhead skill run <name>`. `skill list` SHALL print registered skills and whether each would be present in `registry.list(ctx)` for the current repo, make zero LLM calls, and make zero network calls. `skill run <name>` SHALL invoke that skill's nested sub-run with the same definition the model catalog uses and print the resulting envelope. A missing API key on `skill run` SHALL exit non-zero with a message naming the missing env var and without a stack trace. An unknown skill name SHALL exit non-zero naming the name.
+
+#### Scenario: Help lists skill
+- **WHEN** `copperhead --help` is run
+- **THEN** the output lists `skill` with a one-line description
+
+#### Scenario: list is LLM-free
+- **WHEN** `copperhead skill list` runs on the fixture repo with no API keys in the environment
+- **THEN** it exits 0, prints `generate_report`, and makes no network calls to any api.* host
+
+#### Scenario: run generate-report
+- **WHEN** `copperhead skill run generate-report` completes with a provider available
+- **THEN** stdout contains the report summary and ERC/DRC/drift results, and no new repo file was created solely to hold that report
+
+#### Scenario: run without a key fails clearly
+- **WHEN** `copperhead skill run generate-report` is invoked with no model API key and no saved-login provider configured
+- **THEN** the process exits non-zero, names the missing env var or login, and prints no stack trace
+
+#### Scenario: unknown skill
+- **WHEN** `copperhead skill run does-not-exist` is invoked
+- **THEN** the process exits non-zero and the message contains `does-not-exist`

--- a/openspec/changes/formalize-tool-registry/specs/cli-surface/spec.md
+++ b/openspec/changes/formalize-tool-registry/specs/cli-surface/spec.md
@@ -3,7 +3,7 @@
 ## ADDED Requirements
 
 ### Requirement: `skill` command
-The CLI SHALL provide `copperhead skill list` and `copperhead skill run <name>`. `skill list` SHALL print registered skills and whether each would be present in `registry.list(ctx)` for the current repo, make zero LLM calls, and make zero network calls. `skill run <name>` SHALL invoke that skill's nested sub-run with the same definition the model catalog uses and print the resulting envelope. A missing API key on `skill run` SHALL exit non-zero with a message naming the missing env var and without a stack trace. An unknown skill name SHALL exit non-zero naming the name.
+The CLI SHALL provide `copperhead skill list` and `copperhead skill run <name>`. `skill list` SHALL print registered skills and whether each would be present in `registry.list(ctx)` for the current repo, make zero LLM calls, make zero network calls, and create no transcript or run directory. `skill run <name>` SHALL invoke that skill's nested sub-run with the same definition the model catalog uses and print the resulting envelope. A missing API key on `skill run` SHALL exit non-zero with a message naming the missing env var and without a stack trace. An unknown skill name SHALL exit non-zero naming the name.
 
 #### Scenario: Help lists skill
 - **WHEN** `copperhead --help` is run
@@ -11,7 +11,7 @@ The CLI SHALL provide `copperhead skill list` and `copperhead skill run <name>`.
 
 #### Scenario: list is LLM-free
 - **WHEN** `copperhead skill list` runs on the fixture repo with no API keys in the environment
-- **THEN** it exits 0, prints `generate_report`, and makes no network calls to any api.* host
+- **THEN** it exits 0, prints `generate_report`, makes no network calls to any api.* host, and does not create `.copperhead/runs/`
 
 #### Scenario: run generate-report
 - **WHEN** `copperhead skill run generate-report` completes with a provider available

--- a/openspec/changes/formalize-tool-registry/specs/safety-rails/spec.md
+++ b/openspec/changes/formalize-tool-registry/specs/safety-rails/spec.md
@@ -1,0 +1,21 @@
+# safety-rails — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Envelope construction is the render redaction boundary
+`ToolResult.data` and any other structured envelope field that may hold tool output SHALL be redacted with the same secret patterns as transcripts (including `sk-[A-Za-z0-9_-]+` and the values of environment variables named `*_KEY`, `*_SECRET`, or `*_TOKEN`) at envelope construction, before the envelope is handed to `render.ts`, `dock-renderer.ts`, or `theme.ts`. Those render paths SHALL NOT stringify or print unredacted handler output.
+
+#### Scenario: Key-shaped token never reaches the renderer
+- **WHEN** a tool handler's raw output contains a value matching `sk-[A-Za-z0-9_-]{20,}` or an env value of a `*_KEY`/`*_SECRET`/`*_TOKEN` variable
+- **THEN** the envelope given to the renderer does not contain that value verbatim, and the on-screen tool line does not contain it
+
+#### Scenario: Transcript still redacts
+- **WHEN** the same invocation is recorded on the transcript
+- **THEN** the JSONL event is also redacted (AC-4.1 unchanged)
+
+### Requirement: check does not import the capability catalog
+The `check`/`verify` command path SHALL NOT import `src/capabilities/` or any module that loads the tool/skill registry. AC-2.1 remains in force: `check` is LLM-free and network-free.
+
+#### Scenario: Module-graph guard
+- **WHEN** the static import check scans outward from `src/commands/check.ts`
+- **THEN** the graph contains neither `src/capabilities/` nor any provider SDK

--- a/openspec/changes/formalize-tool-registry/specs/spec-gating/spec.md
+++ b/openspec/changes/formalize-tool-registry/specs/spec-gating/spec.md
@@ -1,0 +1,31 @@
+# spec-gating — Delta Spec
+
+## MODIFIED Requirements
+
+### Requirement: Edit tools locked until proposal validates
+The agent SHALL NOT have `edit_file` or `write_file` in its tool list until an OpenSpec change proposal for the current request exists and `openspec validate --change <id>` passes. The lock is structural (tools absent from `registry.list(ctx)`), not prompt-based and not a dispatch-time refusal of a still-listed tool. Any skill whose declared `tools` include `edit_file`, `write_file`, or another entry that is itself gated on the unlock SHALL likewise be absent from `registry.list(ctx)` until that validation passes.
+
+#### Scenario: Pre-validation tool list
+- **WHEN** a `do` run is in its plan step, before validation passes
+- **THEN** the tool list sent to the provider contains no `edit_file` or `write_file`
+
+#### Scenario: Unlock after validation
+- **WHEN** `openspec validate --change <id>` exits 0
+- **THEN** subsequent turns include the edit tools, and the transcript records the unlock event
+
+#### Scenario: Absence is the invariant
+- **WHEN** edits are locked
+- **THEN** `registry.list(ctx).map(e => e.name)` does not contain `edit_file` or `write_file`, even if a subsequent `dispatchTool(ctx, 'edit_file', …)` would also return `error.kind` `unavailable`
+
+#### Scenario: Skill cannot smuggle an edit tool
+- **WHEN** edits are locked and a skill lists `edit_file` in its `tools`
+- **THEN** that skill is absent from the tool list sent to the provider
+
+## ADDED Requirements
+
+### Requirement: Gating-sync absence assertion is not replaced by envelope kind
+The structural spec-gating test SHALL assert absence from `registry.list(ctx)` (or the equivalent catalog the provider receives). An assertion that `dispatchTool` returned `error.kind === 'unavailable'` MAY exist in addition, and MUST NOT be the sole proof that an edit tool was locked.
+
+#### Scenario: Both assertions on a locked dispatch
+- **WHEN** the gating-sync test runs with edits locked
+- **THEN** it asserts `edit_file` is not in `list(ctx)` and, if it also dispatches `edit_file`, treats the `unavailable` envelope as a secondary check

--- a/openspec/changes/formalize-tool-registry/specs/tool-registry/spec.md
+++ b/openspec/changes/formalize-tool-registry/specs/tool-registry/spec.md
@@ -1,0 +1,111 @@
+# tool-registry — Spec
+
+## ADDED Requirements
+
+### Requirement: Two-tier catalog
+The agent SHALL expose a single catalog of named entries in two tiers: atomic tools (tier 1) and skills (tier 2). Names SHALL be unique across both tiers. The catalog presented to the provider SHALL be exactly `registry.list(ctx)`: every entry whose `gate(ctx)` is true, and no other. Dispatch SHALL select the tier by name: a tool runs its handler; a skill runs the nested sub-run defined by this capability and returns one `ToolResult` to the caller.
+
+#### Scenario: Combined catalog
+- **WHEN** `registry.list(ctx)` is computed with edits locked
+- **THEN** the returned names include `read_file` and `generate_report`, and include neither `edit_file` nor `write_file`
+
+#### Scenario: Dispatch picks the tier
+- **WHEN** the model calls `generate_report`
+- **THEN** dispatch runs the skill sub-run rather than a tier-1 handler, and the parent receives a single `ToolResult` envelope
+
+#### Scenario: Unknown name is not dispatched
+- **WHEN** `dispatchTool` is called with a name that is not in `registry.list(ctx)`
+- **THEN** it returns an envelope with `ok: false` and `error.kind` `unavailable`, and no handler runs
+
+### Requirement: Versioned schemas
+Every catalog entry SHALL carry a positive integer `version` for its parameter/result schema. The registry SHALL expose a protocol version for the `ToolResult` envelope shape. Provider adapters SHALL continue to send `{ name, description, parameters }` on the wire; they MUST NOT drop an entry because it has a `version`.
+
+#### Scenario: Every registered entry is versioned
+- **WHEN** the conformance test enumerates the registry
+- **THEN** every tool and skill has a `version >= 1`
+
+### Requirement: ToolResult envelope
+Every tool and skill invocation SHALL return a `ToolResult` of the form `{ ok, summary, detail?, data?, error?, viewHint? }`. `error.kind`, when present, SHALL be one of `unavailable`, `validation`, `refusal`, `exception`. The loop SHALL flatten `summary` plus `detail` (or `error.message` on failure) into the string tool-result content providers already consume. `viewHint` SHALL be one of `diagnostic`, `mutation`, `query`, `export`.
+
+#### Scenario: Successful flatten
+- **WHEN** a tool returns `{ ok: true, summary: "ERC clean", detail: "0 violations" }`
+- **THEN** the provider-facing tool message contains `ERC clean` and `0 violations`, and the renderer is given the envelope (not a reconstructed string)
+
+#### Scenario: Unavailable flatten preserves the lock phrasing
+- **WHEN** `edit_file` is dispatched while edits are locked
+- **THEN** the envelope has `ok: false`, `error.kind` `unavailable`, and `error.message` contains both `not available` and `unlock`
+
+#### Scenario: Typed validation error is not retried
+- **WHEN** a handler returns `error.kind` `validation` or `refusal`
+- **THEN** the loop does not retry that call
+
+### Requirement: Predicate gating
+Each catalog entry SHALL declare `gate: (ctx) => boolean`. An entry whose gate returns false SHALL be absent from `registry.list(ctx)` and SHALL NOT appear in the tool list sent to the provider. A boolean `requiresUnlock` field SHALL NOT exist on the catalog type.
+
+#### Scenario: Locked edit tools are absent from the list
+- **WHEN** `ctx.editsUnlocked` is false
+- **THEN** `registry.list(ctx).map(e => e.name)` does not contain `edit_file` or `write_file`
+
+#### Scenario: Unlock is presence, not a dispatch warning
+- **WHEN** `ctx.editsUnlocked` becomes true after a validated proposal
+- **THEN** subsequent `registry.list(ctx)` includes `edit_file` and `write_file`
+
+### Requirement: Skill contract
+A skill SHALL declare `name`, `version`, `description`, `parameters`, `tools` (a list of catalog names), `prompt(ctx, args)`, and `isComplete(ctx, args)`. It MAY declare `maxTurns` and `gate`. When `gate` is omitted, the skill SHALL be available only if every declared tool's `gate(ctx)` is true. A supplied `gate` MUST NOT be weaker than that conjunction. A skill's `tools` array SHALL NOT include `finish`.
+
+#### Scenario: Default gate hides locked skills
+- **WHEN** a skill declares `edit_file` in `tools` and edits are locked
+- **THEN** that skill is absent from `registry.list(ctx)`
+
+#### Scenario: Read-only skill stays present
+- **WHEN** `generate_report` is registered with only read-only tools and edits are locked
+- **THEN** `generate_report` is present in `registry.list(ctx)`
+
+#### Scenario: Weaker gate is rejected
+- **WHEN** the conformance test inspects a skill whose declared `gate` would return true while one of its tools' gates returns false
+- **THEN** the test fails
+
+#### Scenario: finish is not a skill tool
+- **WHEN** the conformance test inspects every skill's `tools` array
+- **THEN** none contains `finish`
+
+### Requirement: Nested skill sub-run
+A skill invocation SHALL run a nested turn loop that shares the parent's ledger, transcript, and `editsUnlocked`; uses only the skill's declared tool subset; applies the skill's `maxTurns` (or the skill's default); and does not take a git snapshot, commit, or OpenSpec archive. The sub-run SHALL end when `isComplete` is true or the turn budget is exhausted, and SHALL return one `ToolResult` to the parent. The nested path SHALL NOT treat `finishRequest` as a signal to commit.
+
+#### Scenario: Parent sees one envelope
+- **WHEN** the parent loop dispatches `generate_report`
+- **THEN** the parent records one tool result for that call, not one result per inner turn
+
+#### Scenario: Nested run is not a do
+- **WHEN** `generate_report` completes inside a parent `do` run
+- **THEN** git history gains no extra commit from the skill, and `openspec/` is not archived by the skill
+
+#### Scenario: Shared ledger keeps obligations
+- **WHEN** a nested skill (in a future mutation skill) would open a sync obligation
+- **THEN** that obligation remains on the parent's ledger after the skill returns
+
+### Requirement: generate_report proof skill
+The catalog SHALL include a skill `generate_report` with parameters `{ scope: "power" | "all" }` (default `"all"`), tools `read_file`, `search`, `list_nets`, `run_erc`, `run_drc`, `export_svg`, and `check_drift`, and a default `maxTurns` of 8. It SHALL NOT declare any mutation tool (`edit_file`, `write_file`, or any other `gate` that requires `editsUnlocked`). The report SHALL be the returned envelope (`summary` + `detail`); the skill SHALL NOT write a repo file to hold the report.
+
+#### Scenario: Always available
+- **WHEN** edits are locked and no OpenSpec change is in flight
+- **THEN** `generate_report` is in `registry.list(ctx)`
+
+#### Scenario: Cannot write
+- **WHEN** `generate_report`'s declared `tools` are resolved
+- **THEN** the set contains none of `edit_file`, `write_file`, `propose_change`, or `finish`
+
+#### Scenario: Report is the envelope
+- **WHEN** `generate_report` completes with `scope: "all"`
+- **THEN** the envelope `ok` reflects whether ERC, DRC (if a board exists), and drift were obtained, `summary` is one line, `detail` contains those results, and no new repo file was created to hold the report
+
+### Requirement: Capability layout and conformance
+Atomic tools SHALL be declared in `src/capabilities/handlers.ts` and wrapped into the catalog through `defineTool` in the barrel. Each skill SHALL live in its own module under `src/capabilities/skills/`, imported by that barrel. `defineTool` and `defineSkill` SHALL apply defaults (including the skill gate conjunction). A conformance test SHALL fail if a skill file is not imported by the barrel, if catalog tool names do not match `HANDLERS` 1:1, if two entries share a name, if `version` or `viewHint` is missing, if a skill names an unknown tool, or if a skill's effective gate is weaker than any of its tools.
+
+#### Scenario: Unregistered skill file fails CI
+- **WHEN** a file exists under `src/capabilities/skills/` that the barrel does not import
+- **THEN** the conformance test fails
+
+#### Scenario: Unique names
+- **WHEN** the conformance test enumerates the registry
+- **THEN** no two entries share a `name`

--- a/openspec/changes/formalize-tool-registry/specs/tool-registry/spec.md
+++ b/openspec/changes/formalize-tool-registry/specs/tool-registry/spec.md
@@ -39,6 +39,14 @@ Every tool and skill invocation SHALL return a `ToolResult` of the form `{ ok, s
 - **WHEN** a handler returns `error.kind` `validation` or `refusal`
 - **THEN** the loop does not retry that call
 
+#### Scenario: Diagnostic outcome is not inferred from prose
+- **WHEN** ERC returns a report with `ok: false` formatted as `ERC: 3 violation(s)`
+- **THEN** the tool envelope has `ok: false`, the renderer does not show the success glyph, and the provider-facing text still contains the violation detail
+
+#### Scenario: Unsuccessful detail is preserved
+- **WHEN** an unsuccessful domain-result envelope has `detail` but no typed invocation `error`
+- **THEN** flattening includes both its summary and detail
+
 ### Requirement: Predicate gating
 Each catalog entry SHALL declare `gate: (ctx) => boolean`. An entry whose gate returns false SHALL be absent from `registry.list(ctx)` and SHALL NOT appear in the tool list sent to the provider. A boolean `requiresUnlock` field SHALL NOT exist on the catalog type.
 
@@ -84,6 +92,18 @@ A skill invocation SHALL run a nested turn loop that shares the parent's ledger,
 - **WHEN** a nested skill (in a future mutation skill) would open a sync obligation
 - **THEN** that obligation remains on the parent's ledger after the skill returns
 
+#### Scenario: Provider error is contained
+- **WHEN** a provider throws inside a nested skill turn
+- **THEN** dispatch returns an envelope with `ok: false` and `error.kind: exception`, rather than letting the rejection escape the parent loop
+
+#### Scenario: Nested provider recovery is bounded
+- **WHEN** a nested provider turn returns 429 or exceeds `turnTimeoutMs`
+- **THEN** the sub-run applies bounded backoff or timeout retries using the main loop policy and eventually returns or fails as one envelope
+
+#### Scenario: Partial and repeated results survive
+- **WHEN** a skill exhausts its turn budget after calling the same tool more than once
+- **THEN** its unsuccessful envelope retains every gathered result in call order, including repeated calls
+
 ### Requirement: generate_report proof skill
 The catalog SHALL include a skill `generate_report` with parameters `{ scope: "power" | "all" }` (default `"all"`), tools `read_file`, `search`, `list_nets`, `run_erc`, `run_drc`, `export_svg`, and `check_drift`, and a default `maxTurns` of 8. It SHALL NOT declare any mutation tool (`edit_file`, `write_file`, or any other `gate` that requires `editsUnlocked`). The report SHALL be the returned envelope (`summary` + `detail`); the skill SHALL NOT write a repo file to hold the report.
 
@@ -109,3 +129,7 @@ Atomic tools SHALL be declared in `src/capabilities/handlers.ts` and wrapped int
 #### Scenario: Unique names
 - **WHEN** the conformance test enumerates the registry
 - **THEN** no two entries share a `name`
+
+#### Scenario: Isolated registry construction is isolated
+- **WHEN** a second `ToolRegistry` is constructed from entries returned by the singleton registry
+- **THEN** binding default skill gates in the second registry does not mutate the singleton's entries

--- a/openspec/changes/formalize-tool-registry/tasks.md
+++ b/openspec/changes/formalize-tool-registry/tasks.md
@@ -1,0 +1,55 @@
+# formalize-tool-registry: Tasks
+
+## 1. Envelope and registry (no behavior change)
+
+- [x] 1.1 Add `ToolResult`, `ViewHint`, `ToolErrorKind`, `gate()`, and schema `version` types; add identity `defineTool` / `defineSkill` with skill default-gate conjunction
+- [x] 1.2 Implement envelope helpers: `ok`/`fail` constructors, flatten-to-string for provider `Msg` content, redaction of `data`/`summary`/`detail`/`error.message` at construction via existing `redactSecrets`
+- [x] 1.3 Implement `ToolRegistry` (`get`, `list(ctx)`, protocol version) wrapping the current `TOOLS` array with `gate: (ctx) => !requiresUnlock || ctx.editsUnlocked`
+- [x] 1.4 Point `availableTools` / `dispatchTool` at the registry; preserve today's flattened strings including `"not available"` / `"unlock"` on a locked `edit_file` dispatch
+- [x] 1.5 Unit tests: flatten, typed error kinds, redaction-at-construction (key-shaped token stripped before the object is returned)
+
+## 2. Capability files and conformance
+
+- [x] 2.1 Wrap existing handlers via `defineTool` in the barrel (`version`, `viewHint`, same handler behavior); skills stay one file each under `src/capabilities/skills/`
+- [x] 2.2 Barrel `src/capabilities/index.ts`; `src/agent/tools.ts` keeps `RunContext`, dispatch, and the nested skill sub-run
+- [x] 2.3 Conformance test: unique names, `version`/`viewHint` set, catalog tools match `HANDLERS`, barrel imports every `skills/` file, skill `tools` resolve, skill effective gate at least as strict as each declared tool, no skill lists `finish`
+- [x] 2.4 `gating-sync` keeps `expect(list(ctx).map(e => e.name)).not.toContain('edit_file')` (and `write_file`); envelope `unavailable` assertion is additive; `"not available"` / `"unlock"` substrings still pass
+
+## 3. Loop, providers, renderer
+
+- [x] 3.1 Loop obtains the per-turn catalog from `registry.list(ctx)`, records the envelope on the transcript, flattens for the provider `Msg`
+- [x] 3.2 Providers keep sending `{ name, description, parameters }`; `parseToolCalls` catalog `Set` still comes from `list(ctx)` (off-catalog stays prose)
+- [x] 3.3 `theme.ts` / `render.ts` / `dock-renderer.ts` read `result.ok` and `viewHint`; delete the pass/fail regex heuristic in `toolLine`
+- [x] 3.4 Retry: `validation`/`refusal`/`unavailable` are not retried; `exception` uses `src/util/retry.ts`
+- [x] 3.5 Render-path redaction test: a handler payload containing `sk-` or a `*_KEY` env value never appears in the renderer input or the printed tool line
+
+## 4. Nested sub-run
+
+- [x] 4.1 Extract a nested turn-loop path that shares parent ledger/transcript/`editsUnlocked`, applies a tool-name subset and `maxTurns`, and does not git-snapshot, commit, or `openspec archive`
+- [x] 4.2 Nested path never consults `finishRequest` for commit; `finish` is not placed in a skill child catalog
+- [x] 4.3 Dispatch of a skill name runs the nested path and returns one envelope to the parent
+- [x] 4.4 Tests: parent records one tool result per skill call; no extra commit / archive; parent `finishRequest` unchanged after the skill returns
+
+## 5. generate_report and CLI
+
+- [x] 5.1 Register skill `generate_report` (`scope: power|all`, default `all`, `maxTurns` 8, tools `read_file`/`search`/`list_nets`/`run_erc`/`run_drc`/`export_svg`/`check_drift`, no mutation tools); report is the envelope, no report file written
+- [x] 5.2 CLI `copperhead skill list` (LLM-free, network-free) and `copperhead skill run <name>` (kebab CLI name maps to underscore catalog name)
+- [x] 5.3 `skill run` missing-key path: non-zero exit, env var or login named, no stack trace; unknown name: non-zero, name in the message
+- [x] 5.4 Export a runner that tests invoke with a `ScriptedProvider` so `skill run generate-report` is covered offline
+- [x] 5.5 `copperhead --help` lists `skill`
+
+## 6. Scenario tests (map 1:1 to delta specs)
+
+- [x] 6.1 tool-registry: combined catalog; dispatch picks skill tier; unknown name → `unavailable`; every entry versioned; successful flatten; locked `edit_file` flatten; validation not retried
+- [x] 6.2 tool-registry: locked list omits edit tools; unlock is presence; default skill gate hides locked skills; `generate_report` present while locked; weaker skill gate fails conformance; no skill lists `finish`
+- [x] 6.3 tool-registry: parent sees one envelope; nested run is not a `do`; always-available / cannot-write / report-is-envelope for `generate_report`; unregistered file fails CI; unique names
+- [x] 6.4 spec-gating: pre-validation list; unlock after validate; absence-from-list is the invariant; skill cannot smuggle `edit_file`; gating-sync has both assertions
+- [x] 6.5 agent-core: provider still sees strings; off-catalog stays prose; inner turns do not commit; nested finish cannot satisfy the parent
+- [x] 6.6 cli-surface: help lists `skill`; `skill list` LLM-free on the fixture; `skill run generate-report` with ScriptedProvider; run without a key; unknown skill
+- [x] 6.7 safety-rails: key-shaped token never reaches the renderer; transcript still redacted; `check` module-graph guard excludes `src/capabilities/` and provider SDKs (AC-2.1)
+
+## 7. Docs and archive prep
+
+- [x] 7.1 Draft SPEC.md edits for archive time: §4.2 becomes the two-tier catalog (existing tools + `generate_report`); §3 gains `skill list` / `skill run`
+- [x] 7.2 README: document `copperhead skill list` / `skill run generate-report` and that `create` stages are not yet skills
+- [x] 7.3 Confirm `STAGES` in `src/commands/create.ts` is untouched; `npm run typecheck && npm test` green; `npm run build` for the CLI command

--- a/openspec/changes/formalize-tool-registry/tasks.md
+++ b/openspec/changes/formalize-tool-registry/tasks.md
@@ -52,4 +52,13 @@
 
 - [x] 7.1 Draft SPEC.md edits for archive time: §4.2 becomes the two-tier catalog (existing tools + `generate_report`); §3 gains `skill list` / `skill run`
 - [x] 7.2 README: document `copperhead skill list` / `skill run generate-report` and that `create` stages are not yet skills
-- [x] 7.3 Confirm `STAGES` in `src/commands/create.ts` is untouched; `npm run typecheck && npm test` green; `npm run build` for the CLI command
+- [x] 7.3 Confirm `STAGES` in `src/commands/create.ts` is untouched; run typecheck, build, and the offline suite; document environment-only failures honestly
+
+## 8. PR #255 review fixes
+
+- [x] 8.1 Contain skill-provider exceptions inside dispatch and apply bounded timeout plus 429 recovery to nested provider turns
+- [x] 8.2 Give diagnostics handler-owned outcomes so failing ERC/DRC/drift/symbol/legibility results cannot render a success glyph
+- [x] 8.3 Preserve partial unsuccessful report detail and every repeated inner tool call in call order
+- [x] 8.4 Keep `skill list` filesystem-side-effect-free and give off-list skill calls an accurate unavailable reason
+- [x] 8.5 Clone registry entries before binding default gates; cover weak gates, singleton isolation, refusal, JSON, no-provider, nudge, exception, retry, timeout, partial, and repeated-result paths
+- [x] 8.6 Re-run typecheck, focused tests, full offline suite, build, and `openspec validate formalize-tool-registry`; document environment-only failures honestly

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -281,7 +281,8 @@ copperhead do "<change request>" [--model codex|gpt-5|claude] [--max-turns N]
     The core loop. See §4.
 
 copperhead skill list
-    Print registered skills and whether each is available. LLM-free, network-free.
+    Print registered skills and whether each is available. LLM-free, network-free,
+    and does not create a run transcript/directory.
 
 copperhead skill run <name> [--scope power|all] [--model …]
     Run a skill (currently `generate-report`) via the nested sub-run. Needs a
@@ -389,6 +390,7 @@ interface Provider {
 - On turn-budget exhaustion in an attended (TTY) run: print run stats (turns, files touched, open obligations, token usage) and ask whether to continue with more turns; declining, or a non-TTY run, fails as below. The extension can repeat; each is a fresh decision with fresh numbers.
 - On any unrecoverable failure: preserve the touched work as a git stash entry named `copperhead failed run <run-id>`, restore the snapshot, print the stash ref and transcript path, exit 1
 - Rate-limit (429): exponential backoff ×3, then fail over to the other **keyed** provider (`openai` ↔ `anthropic`) if a key exists; saved-login providers (`codex`, `claude-code`, `cursor`) never fail over to a keyed or alternate provider
+- Nested skill provider turns use the same bounded timeout and 429 backoff policy. A provider error inside a skill becomes a failed tool envelope, so it cannot escape the parent loop and bypass its failure/rollback path.
 - The Anthropic provider marks `cache_control` breakpoints (system prompt, last tool, last message block) so the resent conversation prefix is cached; reported input tokens include cache reads/writes
 
 ---

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -280,6 +280,13 @@ copperhead score schematic [--json]
 copperhead do "<change request>" [--model codex|gpt-5|claude] [--max-turns N]
     The core loop. See §4.
 
+copperhead skill list
+    Print registered skills and whether each is available. LLM-free, network-free.
+
+copperhead skill run <name> [--scope power|all] [--model …]
+    Run a skill (currently `generate-report`) via the nested sub-run. Needs a
+    model, same as `do`. Does not snapshot or commit.
+
 copperhead check          (alias: copperhead verify)
     Run ERC + DRC + doc-drift check; exit non-zero on violations.
     No LLM calls. Usable as CI step / pre-commit hook.
@@ -346,6 +353,7 @@ It's a loop, and it looks a lot like pair-programming, except the codebase is a 
 | `run_drc` | () → {violations: [...]} | `kicad-cli pcb drc --format json --exit-code-violations` |
 | `export_svg` | (sch\|pcb) → path | For viewer + before/after diffing |
 | `check_drift` | () → [{doc, claim, actual}] | Compares doc tables (BOM/pinout) against parsed schematic |
+| `generate_report` | (scope?: power\|all) → report | Skill: nested read-only sub-run; ERC/DRC/drift/nets. Always in the catalog. |
 
 ### 4.3 System prompt — key rules (verbatim requirements)
 

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -1,0 +1,35 @@
+import type { CopperheadConfig } from '../config.js';
+import type { CheckReport } from '../kicad/report.js';
+import type { ObligationsLedger } from './ledger.js';
+import type { Transcript } from './transcript.js';
+
+export interface FinishRequest {
+  outcome: 'done' | 'refuse';
+  summary: string;
+}
+
+/** Mutable state one run threads through every tool call. */
+export interface RunContext {
+  repoRoot: string;
+  config: CopperheadConfig;
+  transcript: Transcript;
+  ledger: ObligationsLedger;
+  runId: string;
+  interactive: boolean;
+  confirm: (question: string) => Promise<boolean>;
+  editsUnlocked: boolean;
+  changeId: string | null;
+  proposalValidated: boolean;
+  filesTouched: Set<string>;
+  decisions: string[];
+  lastErc: CheckReport | null;
+  lastDrc: CheckReport | null;
+  /** Last check_legibility counts; feeds the run summary's verification section. */
+  lastLegibility: { error: number; advisory: number } | null;
+  /** Last score composite (AC-16.21); recorded in the run summary. */
+  lastScore: number | null;
+  /** Last `check_drift` output; used by `generate_report` completion. */
+  lastDrift?: string | null;
+  repairCycles: number;
+  finishRequest: FinishRequest | null;
+}

--- a/src/agent/dock-renderer.ts
+++ b/src/agent/dock-renderer.ts
@@ -10,6 +10,7 @@
 import { rule, statusBar } from './box.js';
 import { copper, dim, styleOutcome, toolLine, warn } from './theme.js';
 import { fmtDuration, fmtTokens, turnMarker, type ProgressRenderer } from './render.js';
+import type { ViewHint } from './envelope.js';
 import type { TerminalDock } from '../util/dock.js';
 
 const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -57,8 +58,8 @@ export class DockRenderer implements ProgressRenderer {
     this.emit(line);
   }
 
-  toolResult(name: string, firstLine: string, ok?: boolean): void {
-    this.emit(toolLine(name, firstLine, ok));
+  toolResult(name: string, firstLine: string, ok?: boolean, viewHint?: ViewHint): void {
+    this.emit(toolLine(name, firstLine, ok, viewHint));
   }
 
   private turnStartMs = Date.now();

--- a/src/agent/dock-renderer.ts
+++ b/src/agent/dock-renderer.ts
@@ -57,8 +57,8 @@ export class DockRenderer implements ProgressRenderer {
     this.emit(line);
   }
 
-  toolResult(name: string, firstLine: string): void {
-    this.emit(toolLine(name, firstLine));
+  toolResult(name: string, firstLine: string, ok?: boolean): void {
+    this.emit(toolLine(name, firstLine, ok));
   }
 
   private turnStartMs = Date.now();

--- a/src/agent/envelope.ts
+++ b/src/agent/envelope.ts
@@ -1,0 +1,112 @@
+import { redactSecrets } from '../util/redact.js';
+
+/** Envelope protocol version for the ToolResult shape (design D5). */
+export const PROTOCOL_VERSION = 1;
+
+export type ViewHint = 'diagnostic' | 'mutation' | 'query' | 'export';
+export type ToolErrorKind = 'unavailable' | 'validation' | 'refusal' | 'exception';
+
+export interface ToolResult {
+  ok: boolean;
+  summary: string;
+  detail?: string;
+  data?: unknown;
+  error?: { kind: ToolErrorKind; message: string };
+  viewHint?: ViewHint;
+}
+
+function redactEnvelopeText(text: string): string {
+  let out = redactSecrets(text);
+  for (const [name, val] of Object.entries(process.env)) {
+    if (!val || val.length < 8) continue;
+    if (!/_(KEY|SECRET|TOKEN)$/.test(name)) continue;
+    if (out.includes(val)) out = out.split(val).join('[REDACTED]');
+  }
+  return out;
+}
+
+function redactDeep(value: unknown): unknown {
+  if (typeof value === 'string') return redactEnvelopeText(value);
+  if (Array.isArray(value)) return value.map(redactDeep);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, redactDeep(v)]));
+  }
+  return value;
+}
+
+/** Redact every string field at construction so render/dock never see secrets. */
+export function seal(partial: ToolResult): ToolResult {
+  return {
+    ok: partial.ok,
+    summary: redactEnvelopeText(partial.summary),
+    ...(partial.detail !== undefined ? { detail: redactEnvelopeText(partial.detail) } : {}),
+    ...(partial.data !== undefined ? { data: redactDeep(partial.data) } : {}),
+    ...(partial.error
+      ? { error: { kind: partial.error.kind, message: redactEnvelopeText(partial.error.message) } }
+      : {}),
+    ...(partial.viewHint ? { viewHint: partial.viewHint } : {}),
+  };
+}
+
+export function okResult(text: string, viewHint?: ViewHint, data?: unknown): ToolResult {
+  const first = text.split('\n')[0] ?? text;
+  return seal({
+    ok: true,
+    summary: first,
+    ...(text !== first ? { detail: text } : {}),
+    ...(data !== undefined ? { data } : {}),
+    ...(viewHint ? { viewHint } : {}),
+  });
+}
+
+export function failResult(kind: ToolErrorKind, message: string, viewHint?: ViewHint): ToolResult {
+  const first = message.split('\n')[0] ?? message;
+  return seal({
+    ok: false,
+    summary: first,
+    error: { kind, message },
+    ...(viewHint ? { viewHint } : {}),
+  });
+}
+
+/** Flatten an envelope to the string providers already consume as tool Msg content. */
+export function flatten(result: ToolResult): string {
+  if (!result.ok) return result.error?.message ?? result.summary;
+  if (result.detail) {
+    return result.detail.startsWith(result.summary) ? result.detail : `${result.summary}\n${result.detail}`;
+  }
+  return result.summary;
+}
+
+/**
+ * Wrap a legacy handler string. Error-shaped prefixes become typed failures so
+ * validation/refusal are not retried; everything else is success. Flattened
+ * text equals the original string.
+ */
+export function textResult(text: string, viewHint: ViewHint): ToolResult {
+  if (
+    /^error:/.test(text) ||
+    text.startsWith('rejected:') ||
+    text.startsWith('edit REVERTED') ||
+    text.startsWith('validation FAILED')
+  ) {
+    return failResult('validation', text, viewHint);
+  }
+  if (
+    text.startsWith('refused:') ||
+    text.startsWith('cannot finish yet') ||
+    text.startsWith('proposal validated but human declined')
+  ) {
+    return failResult('refusal', text, viewHint);
+  }
+  return okResult(text, viewHint);
+}
+
+export function isRetryableToolKind(kind: ToolErrorKind): boolean {
+  return kind === 'exception';
+}
+
+export function unavailable(name: string, editsUnlocked: boolean): ToolResult {
+  const message = `tool "${name}" is not available${editsUnlocked ? '' : ' (edit tools unlock after the proposal validates)'}`;
+  return failResult('unavailable', message);
+}

--- a/src/agent/envelope.ts
+++ b/src/agent/envelope.ts
@@ -71,11 +71,22 @@ export function failResult(kind: ToolErrorKind, message: string, viewHint?: View
 
 /** Flatten an envelope to the string providers already consume as tool Msg content. */
 export function flatten(result: ToolResult): string {
-  if (!result.ok) return result.error?.message ?? result.summary;
+  if (result.error) return result.error.message;
   if (result.detail) {
     return result.detail.startsWith(result.summary) ? result.detail : `${result.summary}\n${result.detail}`;
   }
   return result.summary;
+}
+
+/** Build an envelope from text plus an outcome already known by the handler. */
+export function outcomeResult(text: string, ok: boolean, viewHint?: ViewHint): ToolResult {
+  const first = text.split('\n')[0] ?? text;
+  return seal({
+    ok,
+    summary: first,
+    ...(text !== first ? { detail: text } : {}),
+    ...(viewHint ? { viewHint } : {}),
+  });
 }
 
 /**
@@ -106,7 +117,12 @@ export function isRetryableToolKind(kind: ToolErrorKind): boolean {
   return kind === 'exception';
 }
 
-export function unavailable(name: string, editsUnlocked: boolean): ToolResult {
-  const message = `tool "${name}" is not available${editsUnlocked ? '' : ' (edit tools unlock after the proposal validates)'}`;
+export function unavailable(name: string, editsUnlocked: boolean, reason?: string): ToolResult {
+  const suffix = reason
+    ? ` (${reason})`
+    : editsUnlocked
+      ? ''
+      : ' (edit tools unlock after the proposal validates)';
+  const message = `tool "${name}" is not available${suffix}`;
   return failResult('unavailable', message);
 }

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -2,7 +2,8 @@ import path from 'node:path';
 import { readFile, writeFile } from 'node:fs/promises';
 import { execa } from 'execa';
 import type { Msg, Provider, Turn } from './types.js';
-import { availableTools, dispatchTool, type RunContext } from './tools.js';
+import { availableTools, dispatchToolResult, type RunContext } from './tools.js';
+import { flatten } from './envelope.js';
 import { CachingProvider } from './response-cache.js';
 import { withTimeout, TurnTimeoutError } from './recovery.js';
 import { buildSystemPrompt } from './prompts.js';
@@ -590,9 +591,10 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
     nudges = 0;
 
     for (const call of res.toolCalls) {
-      const result = await dispatchTool(ctx, call.name, call.args);
-      await transcript.event('tool', { name: call.name, args: call.args, result });
-      r.toolResult(call.name, result.split('\n')[0] ?? '');
+      const envelope = await dispatchToolResult(ctx, call.name, call.args, { provider });
+      const result = flatten(envelope);
+      await transcript.event('tool', { name: call.name, args: call.args, result, envelope });
+      r.toolResult(call.name, envelope.summary, envelope.ok);
       messages.push({ role: 'tool', toolCallId: call.id, content: result });
     }
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -594,7 +594,7 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
       const envelope = await dispatchToolResult(ctx, call.name, call.args, { provider });
       const result = flatten(envelope);
       await transcript.event('tool', { name: call.name, args: call.args, result, envelope });
-      r.toolResult(call.name, envelope.summary, envelope.ok);
+      r.toolResult(call.name, envelope.summary, envelope.ok, envelope.viewHint);
       messages.push({ role: 'tool', toolCallId: call.id, content: result });
     }
 

--- a/src/agent/registry.ts
+++ b/src/agent/registry.ts
@@ -9,15 +9,15 @@ export class ToolRegistry {
   private readonly byName = new Map<string, CatalogEntry>();
 
   constructor(entries: CatalogEntry[]) {
-    for (const e of entries) {
+    for (const source of entries) {
+      const e: CatalogEntry = { ...source };
       if (this.byName.has(e.name)) throw new Error(`duplicate catalog name "${e.name}"`);
       this.byName.set(e.name, e);
     }
-    for (const e of entries) {
+    for (const e of this.byName.values()) {
       if (e.kind === 'skill' && !e.gateProvided) {
         const conj = (ctx: RunContext) => this.conjunction(e.tools, ctx);
         e.gate = conj;
-        e.ownGate = conj;
       }
     }
   }

--- a/src/agent/registry.ts
+++ b/src/agent/registry.ts
@@ -1,0 +1,58 @@
+import { catalog } from '../capabilities/index.js';
+import type { CatalogEntry, CatalogSkill } from '../capabilities/define.js';
+import type { RunContext } from './context.js';
+import { PROTOCOL_VERSION } from './envelope.js';
+
+export { PROTOCOL_VERSION };
+
+export class ToolRegistry {
+  private readonly byName = new Map<string, CatalogEntry>();
+
+  constructor(entries: CatalogEntry[]) {
+    for (const e of entries) {
+      if (this.byName.has(e.name)) throw new Error(`duplicate catalog name "${e.name}"`);
+      this.byName.set(e.name, e);
+    }
+    for (const e of entries) {
+      if (e.kind === 'skill' && !e.gateProvided) {
+        const conj = (ctx: RunContext) => this.conjunction(e.tools, ctx);
+        e.gate = conj;
+        e.ownGate = conj;
+      }
+    }
+  }
+
+  get protocolVersion(): number {
+    return PROTOCOL_VERSION;
+  }
+
+  get(name: string): CatalogEntry | undefined {
+    return this.byName.get(name);
+  }
+
+  all(): CatalogEntry[] {
+    return [...this.byName.values()];
+  }
+
+  skills(): CatalogSkill[] {
+    return this.all().filter((e): e is CatalogSkill => e.kind === 'skill');
+  }
+
+  /** True when every named tool exists and its gate is open. */
+  conjunction(toolNames: string[], ctx: RunContext): boolean {
+    return toolNames.every((n) => {
+      const t = this.byName.get(n);
+      return t?.kind === 'tool' && t.gate(ctx);
+    });
+  }
+
+  /** Entries whose gate is open. Skills also require every declared tool's gate (D3). */
+  list(ctx: RunContext): CatalogEntry[] {
+    return this.all().filter((e) => {
+      if (e.kind === 'skill' && (e.tools.includes('finish') || !this.conjunction(e.tools, ctx))) return false;
+      return e.gate(ctx);
+    });
+  }
+}
+
+export const registry = new ToolRegistry(catalog);

--- a/src/agent/render.ts
+++ b/src/agent/render.ts
@@ -14,7 +14,7 @@ export interface ProgressRenderer {
   log(line: string): void;
   /** Called at the start of each turn with cumulative token totals so far. */
   turnStart(turn: number, maxTurns: number, tokensIn: number, tokensOut: number): void;
-  toolResult(name: string, firstLine: string): void;
+  toolResult(name: string, firstLine: string, ok?: boolean): void;
   /** Busy text while a provider call is in flight; null when idle. */
   status(text: string | null): void;
   /**
@@ -175,8 +175,8 @@ export class InteractiveRenderer implements ProgressRenderer {
     this.redraw();
   }
 
-  toolResult(name: string, firstLine: string): void {
-    this.log(toolLine(name, firstLine));
+  toolResult(name: string, firstLine: string, ok?: boolean): void {
+    this.log(toolLine(name, firstLine, ok));
   }
 
   status(text: string | null): void {

--- a/src/agent/render.ts
+++ b/src/agent/render.ts
@@ -9,12 +9,13 @@
  */
 
 import { copper, dim, setColorEnabled, styleOutcome, toolLine, warn } from './theme.js';
+import type { ViewHint } from './envelope.js';
 
 export interface ProgressRenderer {
   log(line: string): void;
   /** Called at the start of each turn with cumulative token totals so far. */
   turnStart(turn: number, maxTurns: number, tokensIn: number, tokensOut: number): void;
-  toolResult(name: string, firstLine: string, ok?: boolean): void;
+  toolResult(name: string, firstLine: string, ok?: boolean, viewHint?: ViewHint): void;
   /** Busy text while a provider call is in flight; null when idle. */
   status(text: string | null): void;
   /**
@@ -175,8 +176,8 @@ export class InteractiveRenderer implements ProgressRenderer {
     this.redraw();
   }
 
-  toolResult(name: string, firstLine: string, ok?: boolean): void {
-    this.log(toolLine(name, firstLine, ok));
+  toolResult(name: string, firstLine: string, ok?: boolean, viewHint?: ViewHint): void {
+    this.log(toolLine(name, firstLine, ok, viewHint));
   }
 
   status(text: string | null): void {

--- a/src/agent/theme.ts
+++ b/src/agent/theme.ts
@@ -59,10 +59,9 @@ export function stageLine(name: string, detail: string, kind: 'info' | 'ok' | 'w
   return `${label} ${body}`;
 }
 
-/** Tool-result scrollback line: short glyph + name + first line of result. */
-export function toolLine(name: string, firstLine: string): string {
-  const clean = /\b(clean|ok|pass(?:ed)?|success|done)\b/i.test(firstLine) && !/\b(fail|error|violat)/i.test(firstLine);
-  const glyph = clean ? ok('✓') : copper('▸');
+/** Tool-result scrollback line: glyph from envelope `ok`, not a regex on prose. */
+export function toolLine(name: string, firstLine: string, succeeded = false): string {
+  const glyph = succeeded ? ok('✓') : copper('▸');
   return `  ${glyph} ${dim(name)}  ${firstLine}`;
 }
 

--- a/src/agent/theme.ts
+++ b/src/agent/theme.ts
@@ -59,10 +59,21 @@ export function stageLine(name: string, detail: string, kind: 'info' | 'ok' | 'w
   return `${label} ${body}`;
 }
 
-/** Tool-result scrollback line: glyph from envelope `ok`, not a regex on prose. */
-export function toolLine(name: string, firstLine: string, succeeded = false): string {
+/**
+ * Tool-result scrollback line: glyph from envelope `ok`, not a regex on prose.
+ * The envelope `viewHint` styles the name: mutations (they changed the repo)
+ * read copper, exports light copper, queries/diagnostics stay dim. Plain mode
+ * is unaffected: every painter no-ops while color is off.
+ */
+export function toolLine(
+  name: string,
+  firstLine: string,
+  succeeded = false,
+  viewHint?: 'diagnostic' | 'mutation' | 'query' | 'export',
+): string {
   const glyph = succeeded ? ok('✓') : copper('▸');
-  return `  ${glyph} ${dim(name)}  ${firstLine}`;
+  const label = viewHint === 'mutation' ? copper(name) : viewHint === 'export' ? copperLight(name) : dim(name);
+  return `  ${glyph} ${label}  ${firstLine}`;
 }
 
 /** Color the final outcome line from its exit-path token. */

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -3,8 +3,9 @@ import { corruptionError } from '../capabilities/helpers.js';
 import { flatten, failResult, seal, unavailable, type ToolResult } from './envelope.js';
 import { registry } from './registry.js';
 import { withRetry, isRateLimit } from '../util/retry.js';
+import { TurnTimeoutError, withTimeout } from './recovery.js';
 import type { RunContext } from './context.js';
-import type { Msg, Provider } from './types.js';
+import type { Msg, Provider, Turn } from './types.js';
 
 export type { RunContext, FinishRequest } from './context.js';
 export type { CatalogEntry, CatalogSkill };
@@ -26,14 +27,14 @@ export async function dispatchToolResult(
   args: Record<string, unknown>,
   opts: DispatchOpts = {},
 ): Promise<ToolResult> {
-  if (opts.only && !opts.only.has(name)) return unavailable(name, ctx.editsUnlocked);
+  if (opts.only && !opts.only.has(name)) return unavailable(name, ctx.editsUnlocked, 'not part of this skill');
   const entry = availableTools(ctx).find((e) => e.name === name);
   if (!entry) return unavailable(name, ctx.editsUnlocked);
-  if (entry.kind === 'skill') {
-    if (!opts.provider) return failResult('validation', `skill "${name}" requires a provider`, 'diagnostic');
-    return runSkillSubRun({ ctx, skill: entry, args, provider: opts.provider });
-  }
   try {
+    if (entry.kind === 'skill') {
+      if (!opts.provider) return failResult('validation', `skill "${name}" requires a provider`, 'diagnostic');
+      return await runSkillSubRun({ ctx, skill: entry, args, provider: opts.provider });
+    }
     // Unified retry policy (design D10): a thrown 429 backs off through the
     // same withRetry/isRateLimit pair the provider path uses. Typed envelope
     // failures (validation/refusal/unavailable) return, so they never retry;
@@ -62,7 +63,7 @@ export async function runSkillSubRun(opts: {
   const { ctx, skill, args, provider } = opts;
   const savedFinish = ctx.finishRequest;
   const only = new Set(skill.tools.filter((n) => n !== 'finish'));
-  const results = new Map<string, ToolResult>();
+  const results: { name: string; result: ToolResult }[] = [];
   const messages: Msg[] = [
     { role: 'system', content: skill.prompt(ctx, args) },
     { role: 'user', content: 'Execute this skill. Use the available tools, then stop when the report is complete.' },
@@ -72,7 +73,27 @@ export async function runSkillSubRun(opts: {
     for (let turn = 0; turn < (skill.maxTurns ?? 8); turn++) {
       if (await skill.isComplete(ctx, args)) break;
       const tools = registry.list(ctx).filter((e) => e.kind === 'tool' && only.has(e.name)).map((e) => e.schema);
-      const res = await provider.chat(messages, tools);
+      let res: Turn;
+      let timeoutRetries = 0;
+      while (true) {
+        try {
+          res = await withRetry(
+            () => withTimeout(() => provider.chat(messages, tools), ctx.config.turnTimeoutMs, () => provider.close?.()),
+            { isRetryable: isRateLimit, baseMs: 250 },
+          );
+          break;
+        } catch (err) {
+          if (err instanceof TurnTimeoutError && timeoutRetries++ < 3) {
+            await ctx.transcript.event('skill-turn-timeout', {
+              skill: skill.name,
+              ms: ctx.config.turnTimeoutMs,
+              attempt: timeoutRetries,
+            });
+            continue;
+          }
+          throw err;
+        }
+      }
       messages.push({ role: 'assistant', content: res.text, toolCalls: res.toolCalls });
       if (!res.toolCalls.length) {
         if (await skill.isComplete(ctx, args)) break;
@@ -81,7 +102,7 @@ export async function runSkillSubRun(opts: {
       }
       for (const call of res.toolCalls) {
         const envelope = await dispatchToolResult(ctx, call.name, call.args, { only });
-        results.set(call.name, envelope);
+        results.push({ name: call.name, result: envelope });
         const flat = flatten(envelope);
         await ctx.transcript.event('skill-tool', {
           skill: skill.name,
@@ -97,11 +118,7 @@ export async function runSkillSubRun(opts: {
     ctx.finishRequest = savedFinish;
   }
 
-  const detail =
-    skill.tools
-      .filter((n) => results.has(n))
-      .map((n) => `${n}:\n${flatten(results.get(n)!)}`)
-      .join('\n\n') || 'no tool results';
+  const detail = results.map(({ name, result }) => `${name}:\n${flatten(result)}`).join('\n\n') || 'no tool results';
   const complete = await skill.isComplete(ctx, args);
   return seal({
     ok: complete,

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -1,831 +1,107 @@
-import path from 'node:path';
-import { writeFile, mkdir, appendFile, readFile } from 'node:fs/promises';
-import type { ToolSchema } from './types.js';
-import { toolReadFile, toolWriteFile, toolEditFile, toolSearch } from './filetools.js';
-import { resolveInRepo, isKicadFile } from '../util/paths.js';
-import { runErc, runDrc, exportSvg, exportFab, kicadLoadError, isProbeableKicadFile } from '../kicad/cli.js';
-import { formatViolations, type CheckReport } from '../kicad/report.js';
-import { listSymbols, listNets } from '../kicad/sexp.js';
-import { checkLegibility, formatLegibility } from '../kicad/legibility.js';
-import { scoreSchematic, formatScore } from '../kicad/score.js';
-import { draftSchematic, defaultIntentPath, formatSchematicDraftReport } from '../kicad/draft/draft.js';
-import { verifySchematicSymbols, searchInstalledSymbols, symbolSearchDirs, resolveLibrarySymbol, comparePinNumbers } from '../kicad/symlib.js';
-import { checkDrift } from '../memory/drift.js';
-import { saveConstraint, classifyAffectsTarget, affectsTargetExists } from '../memory/constraints.js';
-import { openspecValidate } from '../openspec/cli.js';
-import { existsSync } from 'node:fs';
-import type { CopperheadConfig } from '../config.js';
-import { isEngineAuthoredSchematic } from '../kicad/fab.js';
-import { ObligationsLedger } from './ledger.js';
-import type { Transcript } from './transcript.js';
+import type { CatalogEntry, CatalogSkill } from '../capabilities/index.js';
+import { corruptionError } from '../capabilities/helpers.js';
+import { flatten, failResult, seal, unavailable, type ToolResult } from './envelope.js';
+import { registry } from './registry.js';
+import type { RunContext } from './context.js';
+import type { Msg, Provider } from './types.js';
 
-export interface FinishRequest {
-  outcome: 'done' | 'refuse';
-  summary: string;
+export type { RunContext, FinishRequest } from './context.js';
+export type { CatalogEntry, CatalogSkill };
+export { corruptionError, registry };
+
+export function availableTools(ctx: RunContext): CatalogEntry[] {
+  return registry.list(ctx);
 }
 
-/** Mutable state one run threads through every tool call. */
-export interface RunContext {
-  repoRoot: string;
-  config: CopperheadConfig;
-  transcript: Transcript;
-  ledger: ObligationsLedger;
-  runId: string;
-  interactive: boolean;
-  confirm: (question: string) => Promise<boolean>;
-  editsUnlocked: boolean;
-  changeId: string | null;
-  proposalValidated: boolean;
-  filesTouched: Set<string>;
-  decisions: string[];
-  lastErc: CheckReport | null;
-  lastDrc: CheckReport | null;
-  /** Last check_legibility counts; feeds the run summary's verification section. */
-  lastLegibility: { error: number; advisory: number } | null;
-  /** Last score composite (AC-16.21); recorded in the run summary. */
-  lastScore: number | null;
-  repairCycles: number;
-  finishRequest: FinishRequest | null;
+export interface DispatchOpts {
+  provider?: Provider;
+  /** Skill sub-run: only these names may dispatch (never `finish`). */
+  only?: ReadonlySet<string>;
 }
 
-export interface ToolDef {
-  schema: ToolSchema;
-  /** Edit-tier tools are absent from the tool list until the proposal validates. */
-  requiresUnlock: boolean;
-  handler: (ctx: RunContext, args: Record<string, unknown>) => Promise<string>;
-}
-
-const str = (args: Record<string, unknown>, key: string): string => {
-  const v = args[key];
-  if (typeof v !== 'string' || v === '') throw new Error(`missing required string arg "${key}"`);
-  return v;
-};
-
-// U+FFFD (the Unicode replacement character) is what a byte sequence becomes
-// when UTF-8 decoding fails — most often a multibyte glyph (Ω, µ, ±, °) split
-// across a streaming chunk boundary and decoded per-chunk upstream in the
-// provider SDK (I2). It never appears in a legitimately authored PCB doc, so
-// its presence in a content-bearing tool arg means the value arrived corrupted.
-// Reject the call before it lands on disk so the model re-emits; the corruption
-// is nondeterministic (it depends on where a chunk boundary fell), so the retry
-// almost always comes through clean — far cheaper than shipping a mangled value
-// like "5.1kΩ" → "5.1k�" into DECISIONS.md and only noticing on review.
-const REPLACEMENT_CHAR = '�';
-export function corruptionError(fields: Record<string, unknown>): string | null {
-  const bad = Object.entries(fields)
-    .filter(([, v]) => typeof v === 'string' && v.includes(REPLACEMENT_CHAR))
-    .map(([k]) => k);
-  if (!bad.length) return null;
-  return `rejected: the ${bad.join(', ')} value contains U+FFFD (�), the replacement character that signals a UTF-8 decoding error — a special character (e.g. Ω, µ, ±, °) was likely mangled in transit. Re-send this exact call with the intended character written correctly, or spell it in ASCII (e.g. "ohm", "uF", "+/-", "deg").`;
-}
-
-function markTouched(ctx: RunContext, rel: string): void {
-  ctx.filesTouched.add(rel);
-  if (isKicadFile(rel)) {
-    ctx.ledger.onKicadEdit(rel);
-    if (rel.endsWith('.kicad_sch')) ctx.lastErc = null;
-    if (rel.endsWith('.kicad_pcb')) ctx.lastDrc = null;
-  } else if (rel.endsWith('.md')) {
-    ctx.ledger.onDocEdit(rel);
+export async function dispatchToolResult(
+  ctx: RunContext,
+  name: string,
+  args: Record<string, unknown>,
+  opts: DispatchOpts = {},
+): Promise<ToolResult> {
+  if (opts.only && !opts.only.has(name)) return unavailable(name, ctx.editsUnlocked);
+  const entry = availableTools(ctx).find((e) => e.name === name);
+  if (!entry) return unavailable(name, ctx.editsUnlocked);
+  if (entry.kind === 'skill') {
+    if (!opts.provider) return failResult('validation', `skill "${name}" requires a provider`, 'diagnostic');
+    return runSkillSubRun({ ctx, skill: entry, args, provider: opts.provider });
   }
-}
-
-export const TOOLS: ToolDef[] = [
-  {
-    schema: {
-      name: 'read_file',
-      description: 'Read a repo-relative file, optionally a line range. Returns text (line-numbered when ranged).',
-      parameters: {
-        type: 'object',
-        properties: {
-          path: { type: 'string' },
-          start_line: { type: 'number' },
-          end_line: { type: 'number' },
-        },
-        required: ['path'],
-      },
-    },
-    requiresUnlock: false,
-    handler: (ctx, args) =>
-      toolReadFile(
-        ctx.repoRoot,
-        str(args, 'path'),
-        args.start_line as number | undefined,
-        args.end_line as number | undefined,
-      ),
-  },
-  {
-    schema: {
-      name: 'search',
-      description: 'Regex search over the repo (ripgrep-style). Optional glob filter, e.g. "**/*.kicad_sch".',
-      parameters: {
-        type: 'object',
-        properties: { pattern: { type: 'string' }, glob: { type: 'string' } },
-        required: ['pattern'],
-      },
-    },
-    requiresUnlock: false,
-    handler: async (ctx, args) => {
-      const pattern = args.pattern;
-      if (typeof pattern !== 'string' || pattern.trim() === '') {
-        return 'error: search requires a non-empty regex in "pattern" (narrow by file with "glob", e.g. {"pattern": "GPIO", "glob": "**/*.md"}); to list files, use a broad pattern like "." with a glob';
-      }
-      const matches = await toolSearch(ctx.repoRoot, pattern, args.glob as string | undefined);
-      if (!matches.length) return 'no matches';
-      return matches.map((m) => `${m.file}:${m.line}: ${m.text}`).join('\n');
-    },
-  },
-  {
-    schema: {
-      name: 'list_symbols',
-      description: 'List schematic symbols: ref, value, footprint, sheet.',
-      parameters: { type: 'object', properties: {}, required: [] },
-    },
-    requiresUnlock: false,
-    handler: async (ctx) => {
-      if (!ctx.config.schematic) return 'no schematic configured';
-      const syms = await listSymbols(path.join(ctx.repoRoot, ctx.config.schematic));
-      return JSON.stringify(syms.map(({ ref, value, footprint, sheet }) => ({ ref, value, footprint, sheet })), null, 2);
-    },
-  },
-  {
-    schema: {
-      name: 'list_nets',
-      description: 'List net names found in the schematic.',
-      parameters: { type: 'object', properties: {}, required: [] },
-    },
-    requiresUnlock: false,
-    handler: async (ctx) => {
-      if (!ctx.config.schematic) return 'no schematic configured';
-      return JSON.stringify(await listNets(path.join(ctx.repoRoot, ctx.config.schematic)));
-    },
-  },
-  {
-    schema: {
-      name: 'propose_change',
-      description:
-        'Write the OpenSpec change proposal for this run (the plan step). Must be called and validated before edit tools unlock.',
-      parameters: {
-        type: 'object',
-        properties: {
-          id: { type: 'string', description: 'kebab-case change id' },
-          why: { type: 'string' },
-          what_changes: { type: 'string', description: 'markdown bullet list of changes' },
-          tasks: { type: 'string', description: 'markdown checklist of implementation steps' },
-        },
-        required: ['id', 'why', 'what_changes', 'tasks'],
-      },
-    },
-    requiresUnlock: false,
-    handler: async (ctx, args) => {
-      const id = str(args, 'id');
-      const dir = resolveInRepo(ctx.repoRoot, path.join('openspec', 'changes', id));
-      await mkdir(dir, { recursive: true });
-      const auto = ctx.interactive ? '' : '\n> Marker: AUTO (autonomous mode; auto-approved, reviewable after the fact)\n';
-      await writeFile(
-        path.join(dir, 'proposal.md'),
-        `# Proposal: ${id}\n${auto}\n## Why\n\n${str(args, 'why')}\n\n## What Changes\n\n${str(args, 'what_changes')}\n`,
-        'utf8',
-      );
-      await writeFile(path.join(dir, 'tasks.md'), `# Tasks\n\n${str(args, 'tasks')}\n`, 'utf8');
-      ctx.changeId = id;
-      return `proposal written to openspec/changes/${id}/ — now call validate_change`;
-    },
-  },
-  {
-    schema: {
-      name: 'validate_change',
-      description: 'Validate the current change proposal; on success the edit tools unlock.',
-      parameters: { type: 'object', properties: {}, required: [] },
-    },
-    requiresUnlock: false,
-    handler: async (ctx) => {
-      if (!ctx.changeId) return 'no proposal yet: call propose_change first';
-      let ok: boolean;
-      let detail: string;
-      if (existsSync(path.join(ctx.repoRoot, 'openspec', 'config.yaml'))) {
-        const res = await openspecValidate(ctx.repoRoot, ctx.changeId);
-        ok = res.ok;
-        detail = res.output;
-      } else {
-        // No OpenSpec workspace in the target repo: structural validation of the
-        // proposal files themselves (the invariant is the gate, not the CLI).
-        const dir = path.join(ctx.repoRoot, 'openspec', 'changes', ctx.changeId);
-        ok = existsSync(path.join(dir, 'proposal.md')) && existsSync(path.join(dir, 'tasks.md'));
-        detail = ok ? 'structural validation passed (no openspec workspace)' : 'proposal files missing';
-      }
-      if (!ok) return `validation FAILED:\n${detail}`;
-      ctx.proposalValidated = true;
-      if (ctx.interactive) {
-        const approved = await ctx.confirm(`Proposal ${ctx.changeId} validated. Unlock edit tools and proceed?`);
-        if (!approved) return 'proposal validated but human declined; edits remain locked';
-      }
-      ctx.editsUnlocked = true;
-      await ctx.transcript.event('edit-tools-unlocked', { changeId: ctx.changeId });
-      return `validation passed; edit tools are now unlocked`;
-    },
-  },
-  {
-    schema: {
-      name: 'edit_file',
-      description:
-        'Exact-match anchored replace in an existing file. Requires a validated change proposal first (call propose_change then validate_change to unlock edits; both may be in the same reply, before this call). The anchor must be unique; widen it with surrounding lines if not. For renames, pass replace_all: true to replace every occurrence in one call.',
-      parameters: {
-        type: 'object',
-        properties: {
-          path: { type: 'string' },
-          old_string: { type: 'string' },
-          new_string: { type: 'string' },
-          replace_all: { type: 'boolean' },
-        },
-        required: ['path', 'old_string', 'new_string'],
-      },
-    },
-    requiresUnlock: true,
-    handler: async (ctx, args) => {
-      const corrupt = corruptionError({ new_string: args.new_string });
-      if (corrupt) return corrupt;
-      const rel = str(args, 'path');
-      const abs = resolveInRepo(ctx.repoRoot, rel);
-      // Engine-drafted sheets are regenerated wholesale from the IR: a hand
-      // edit would be destroyed by the next re-draft and would break the
-      // byte-identical staleness check. Geometry repairs go through the IR
-      // (design D5). Hand-drawn schematics never carry the draft generator
-      // marker, so `do` on existing repos is untouched by this guard.
-      if (rel.endsWith('.kicad_sch') && existsSync(abs)) {
-        const head = (await readFile(abs, 'utf8')).slice(0, 400);
-        if (isEngineAuthoredSchematic(head)) {
-          return `refused: ${rel} is engine-drafted from ${defaultIntentPath(rel)}. Revise the intent (edit_file on the intent JSON) and call draft_schematic to regenerate the sheet; direct geometry edits would be lost on the next re-draft.`;
-        }
-      }
-      // Text edits can corrupt an s-expression file in ways the editor cannot
-      // see; a corrupted file then fails every later ERC/DRC with an opaque
-      // error. Validate loadability with KiCad itself and roll the edit back
-      // rather than letting the file drift unusable. Only schematics and
-      // boards are probeable; .kicad_pro/.kicad_sym/.kicad_mod edits must not
-      // be probed (a sch/pcb probe rejects them wholesale).
-      const before = isProbeableKicadFile(rel) ? await readFile(abs, 'utf8') : null;
-      const res = await toolEditFile(
-        ctx.repoRoot,
-        rel,
-        str(args, 'old_string'),
-        args.new_string as string,
-        args.replace_all === true,
-      );
-      if (before !== null) {
-        const loadErr = await kicadLoadError(abs);
-        if (loadErr) {
-          const after = await readFile(abs, 'utf8');
-          await writeFile(abs, before, 'utf8');
-          if (await kicadLoadError(abs)) {
-            // The file was already unloadable before this edit. Reverting
-            // would deadlock incremental repair (every partial fix undone
-            // unless one edit fixes the whole file), so keep the edit and
-            // keep the pressure on with the probe output.
-            await writeFile(abs, after, 'utf8');
-            markTouched(ctx, rel);
-            return `${res}\nnote: ${rel} was already unloadable before this edit, so the edit is KEPT. Keep repairing until it loads. kicad-cli says:\n${loadErr}`;
-          }
-          return `edit REVERTED: it would make ${rel} unloadable in KiCad. kicad-cli says:\n${loadErr}\nRe-read the surrounding file text and make a smaller, syntactically complete edit.`;
-        }
-      }
-      markTouched(ctx, rel);
-      return res;
-    },
-  },
-  {
-    schema: {
-      name: 'write_file',
-      description:
-        'Create a new file (docs, outputs). Requires a validated change proposal first (propose_change then validate_change to unlock edits). Refuses to overwrite anything or to create KiCad files.',
-      parameters: {
-        type: 'object',
-        properties: { path: { type: 'string' }, content: { type: 'string' } },
-        required: ['path', 'content'],
-      },
-    },
-    requiresUnlock: true,
-    handler: async (ctx, args) => {
-      const corrupt = corruptionError({ content: args.content });
-      if (corrupt) return corrupt;
-      const rel = str(args, 'path');
-      const res = await toolWriteFile(ctx.repoRoot, rel, args.content as string);
-      markTouched(ctx, rel);
-      return res;
-    },
-  },
-  {
-    schema: {
-      name: 'run_erc',
-      description: 'Run kicad-cli ERC on the schematic. Clears the ERC obligation when clean.',
-      parameters: { type: 'object', properties: {}, required: [] },
-    },
-    requiresUnlock: false,
-    handler: async (ctx) => {
-      if (!ctx.config.schematic)
-        return 'no schematic configured; ERC does not apply yet — skip it until a schematic exists and is set in .copperhead/config.json';
-      const schPath = path.join(ctx.repoRoot, ctx.config.schematic);
-      const report = await runErc(schPath);
-      ctx.lastErc = report;
-      if (report.ok) ctx.ledger.clear('erc');
-      else ctx.repairCycles++;
-      const out = formatViolations(report);
-      // A zero-symbol schematic passes ERC with 0 violations — a false green
-      // (3.2) that lets a premature finish look verified (an empty sheet also
-      // passes drift). The stage contract already requires symbols>0, but a bare
-      // "ERC clean" on the empty starting sheet still misleads the model, so warn
-      // here too: no gate should read as satisfied by the empty starting state.
-      if (report.ok && !(await listSymbols(schPath)).length) {
-        return `${out}\nwarning: ERC is clean but the schematic has ZERO symbols — an empty sheet always passes ERC, so this is NOT a verified design. Capture the parts from BOM.md (and re-run run_erc) before calling finish.`;
-      }
-      return out;
-    },
-  },
-  {
-    schema: {
-      name: 'search_symbols',
-      description:
-        'Search EVERY installed KiCad symbol library for a part or symbol name; returns matching lib_ids as Lib:Name, exact matches first. Library nicknames rarely follow from the part number (TPS61165DBV is in Driver_LED, AudioJack3 in Connector_Audio, INA226 in Sensor_Energy), so a failed single-library probe proves nothing about availability — use this before concluding a part has no symbol, and before committing any active part to the BOM: a part is only drawable if its symbol appears here.',
-      parameters: {
-        type: 'object',
-        properties: {
-          query: { type: 'string', description: 'part or symbol name, e.g. "TLV320AIC3204" or "AudioJack3"' },
-        },
-        required: ['query'],
-      },
-    },
-    requiresUnlock: false,
-    handler: async (_ctx, args) => {
-      const query = str(args, 'query');
-      const dirs = await symbolSearchDirs();
-      if (!dirs.length) return 'no installed KiCad symbol library directories found on this machine';
-      const hits = await searchInstalledSymbols(query, dirs);
-      if (!hits.length) {
-        return `no installed symbol matches "${query}" (searched every library in: ${dirs.join(', ')}). The part is not capturable on this machine as named — choose a part whose symbol exists, or a same-family variant that does.`;
-      }
-      return `installed symbols matching "${query}":\n${hits.map((h) => `  - ${h}`).join('\n')}`;
-    },
-  },
-  {
-    schema: {
-      name: 'symbol_pins',
-      description:
-        'Return the REAL pins (number, name, electrical type) of an installed KiCad symbol by lib_id, following extends links, plus its unit count — the authoritative source for REF.PIN endpoints, instead of guessing pins or reading .kicad_sym files. Warns when the symbol is multi-unit, which the drafting engine refuses. On a miss it lists the closest names in that library and where the symbol actually lives, so one call answers both "what are the pins" and "which lib_id is right".',
-      parameters: {
-        type: 'object',
-        properties: {
-          lib_id: { type: 'string', description: 'full library identifier, e.g. "Device:R" or "Audio:TLV320AIC3100"' },
-        },
-        required: ['lib_id'],
-      },
-    },
-    requiresUnlock: false,
-    handler: async (_ctx, args) => {
-      const libId = str(args, 'lib_id');
-      const name = libId.includes(':') ? libId.slice(libId.indexOf(':') + 1) : libId;
-      const dirs = await symbolSearchDirs();
-      if (!dirs.length) {
-        return `cannot verify "${libId}": no installed KiCad symbol library directories were found on this machine, so nothing can be resolved or ruled out. Install the KiCad symbol libraries (or set KICAD_SYMBOL_DIR), or choose a part you can verify another way.`;
-      }
-      const r = await resolveLibrarySymbol(libId, dirs);
-      if (r.status === 'ok') {
-        const pins = [...r.pins]
-          .sort((a, b) => comparePinNumbers(a.number, b.number))
-          .map((p) => `  ${p.number}: ${p.name === '~' || !p.name ? '(unnamed)' : p.name} · ${p.type}`);
-        const multi =
-          r.units >= 2
-            ? `\nNOTE: this symbol defines ${r.units} units; the drafting engine places each unit separately under one refdes (U1A/U1B), and net endpoints keep plain package pin numbers.`
-            : '';
-        return `${libId} — ${r.pins.length} pin(s), ${r.units} unit(s):\n${pins.join('\n')}${multi}`;
-      }
-      if (r.status === 'found-elsewhere') {
-        return `"${libId}" does not resolve, but the symbol is installed as: ${r.libIds.join(', ')} — use one of these lib_ids (and call symbol_pins on it for the pin table).`;
-      }
-      const elsewhere = await searchInstalledSymbols(name, dirs, 6);
-      const where = elsewhere.length
-        ? `\ninstalled as: ${elsewhere.join(', ')}`
-        : `\nno installed symbol matches "${name}" in any library — the part is not capturable as named.`;
-      if (r.status === 'no-symbol') {
-        const close = r.candidates.length ? `\nclosest in that library: ${r.candidates.join(', ')}` : '';
-        return `"${libId}" does not exist in that library.${close}${where}`;
-      }
-      const lib = libId.includes(':') ? libId.slice(0, libId.indexOf(':')) : libId;
-      return `no library named "${lib}" is installed.${where}`;
-    },
-  },
-  {
-    schema: {
-      name: 'verify_symbols',
-      description:
-        "Cross-check every lib_symbols entry in the schematic against the KiCad symbol library installed on this machine. Reports pins that diverge from the real part (wrong count, name, or electrical type) and lib_ids that do not exist in the current KiCad version (with the closest real names). ERC cannot catch these — a symbol whose lib_id claims to be a canonical part but whose pins are wrong passes ERC while being wrong. Run this after capturing symbols and reconcile every finding.",
-      parameters: { type: 'object', properties: {}, required: [] },
-    },
-    requiresUnlock: false,
-    handler: async (ctx) => {
-      if (!ctx.config.schematic)
-        return 'no schematic configured; verify_symbols does not apply yet';
-      const { findings, checked, skipped } = await verifySchematicSymbols(
-        path.join(ctx.repoRoot, ctx.config.schematic),
-      );
-      if (!findings.length) {
-        return `verify_symbols: ${checked} symbol(s) match the installed KiCad library. No divergences.`;
-      }
-      const lines = findings.map((f) => `  - [${f.kind}] ${f.detail}`);
-      const mismatches = findings.filter((f) => f.kind !== 'no-library').length;
-      return `verify_symbols: ${checked} verified, ${skipped} unverifiable (library not installed), ${mismatches} issue(s) to reconcile:\n${lines.join('\n')}`;
-    },
-  },
-  {
-    schema: {
-      name: 'draft_schematic',
-      description:
-        'Regenerate the schematic deterministically from the netlist-intent IR (schematic.intent.json beside the schematic). Pass intent_json to write a new IR first, or omit it to re-draft the existing file. The engine computes ALL geometry (placement, wires, labels, power symbols, group boxes); never author coordinates. The report embeds the legibility findings and score for the fresh sheet. A failed validation leaves the previous schematic untouched.',
-      parameters: {
-        type: 'object',
-        properties: {
-          intent_json: { type: 'string', description: 'full IR document as JSON text (optional: omit to re-draft the current IR)' },
-        },
-        required: [],
-      },
-    },
-    requiresUnlock: true,
-    handler: async (ctx, args) => {
-      if (!ctx.config.schematic) return 'no schematic configured; set one in .copperhead/config.json first';
-      const intentRel = defaultIntentPath(ctx.config.schematic);
-      if (typeof args.intent_json === 'string' && args.intent_json.trim()) {
-        const corrupt = corruptionError({ intent_json: args.intent_json });
-        if (corrupt) return corrupt;
-        try {
-          JSON.parse(args.intent_json);
-        } catch (e) {
-          return `intent_json is not valid JSON (${(e as Error).message}); nothing written`;
-        }
-        await writeFile(resolveInRepo(ctx.repoRoot, intentRel), args.intent_json, 'utf8');
-        ctx.filesTouched.add(intentRel);
-      }
-      const res = await draftSchematic({
-        repoRoot: ctx.repoRoot,
-        schematic: ctx.config.schematic,
-        intentPath: intentRel,
-        docsDir: ctx.config.docs,
-      });
-      if (!res.ok) return res.message;
-      markTouched(ctx, ctx.config.schematic);
-      // embed the checker and score in the draft report (design D5): a
-      // draft-check-score iteration costs one tool call, and the embedded
-      // checker result drives the ledger obligation exactly like check_legibility
-      const docsAbs = path.join(ctx.repoRoot, ctx.config.docs);
-      const leg = await checkLegibility(res.schematicPath, {
-        docsDir: docsAbs,
-        ...(ctx.config.legibility ? { config: ctx.config.legibility } : {}),
-      });
-      ctx.lastLegibility = leg.counts;
-      ctx.ledger.onLegibilityResult(leg.counts.error);
-      const score = await scoreSchematic(res.schematicPath, {
-        docsDir: docsAbs,
-        ...(ctx.config.legibility ? { config: ctx.config.legibility } : {}),
-      });
-      ctx.lastScore = score.composite;
-      return [formatSchematicDraftReport(res.report), formatLegibility(leg), formatScore(score)].join('\n');
-    },
-  },
-  {
-    schema: {
-      name: 'score_schematic',
-      description:
-        'Deterministic quantitative legibility score for the schematic: composite 0-100 with the per-metric breakdown (crossings, bends, alignment, spacing, symmetry, balance, …). Error-severity legibility findings cap the composite. Advisory: informs, never gates by itself.',
-      parameters: { type: 'object', properties: {}, required: [] },
-    },
-    requiresUnlock: false,
-    handler: async (ctx) => {
-      if (!ctx.config.schematic) return 'no schematic configured; score_schematic does not apply yet';
-      const report = await scoreSchematic(path.join(ctx.repoRoot, ctx.config.schematic), {
-        docsDir: path.join(ctx.repoRoot, ctx.config.docs),
-        ...(ctx.config.legibility ? { config: ctx.config.legibility } : {}),
-      });
-      ctx.lastScore = report.composite;
-      return formatScore(report);
-    },
-  },
-  {
-    schema: {
-      name: 'check_legibility',
-      description:
-        'Run the deterministic legibility checker against the schematic: group boxes and captions, symbol/text collisions, grid alignment, frame and title-block use. Returns numbered findings with coordinates and the concrete fix, or "no findings". Error-severity findings must be reconciled before finish; clears the legibility obligation when clean.',
-      parameters: { type: 'object', properties: {}, required: [] },
-    },
-    requiresUnlock: false,
-    handler: async (ctx) => {
-      // Mirrors check_drift's vacuous path: with no schematic configured there is
-      // nothing to be illegible, and leaving the obligation open would deadlock
-      // any stage that edited a stray .kicad_sch without config wiring.
-      if (!ctx.config.schematic) {
-        ctx.ledger.clear('legibility');
-        return 'no schematic configured; legibility does not apply yet';
-      }
-      const report = await checkLegibility(path.join(ctx.repoRoot, ctx.config.schematic), {
-        docsDir: path.join(ctx.repoRoot, ctx.config.docs),
-        ...(ctx.config.legibility ? { config: ctx.config.legibility } : {}),
-      });
-      ctx.lastLegibility = report.counts;
-      ctx.ledger.onLegibilityResult(report.counts.error);
-      return formatLegibility(report);
-    },
-  },
-  {
-    schema: {
-      name: 'run_drc',
-      description: 'Run kicad-cli DRC on the board. Clears the DRC obligation when clean.',
-      parameters: { type: 'object', properties: {}, required: [] },
-    },
-    requiresUnlock: false,
-    handler: async (ctx) => {
-      if (!ctx.config.board)
-        return 'no board configured; DRC does not apply yet — skip it until a board exists and is set in .copperhead/config.json';
-      const report = await runDrc(path.join(ctx.repoRoot, ctx.config.board));
-      ctx.lastDrc = report;
-      if (report.ok) ctx.ledger.clear('drc');
-      else ctx.repairCycles++;
-      return formatViolations(report);
-    },
-  },
-  {
-    schema: {
-      name: 'export_svg',
-      description: 'Export an SVG render of the schematic or board into .copperhead/renders/.',
-      parameters: {
-        type: 'object',
-        properties: { kind: { type: 'string', enum: ['sch', 'pcb'] } },
-        required: ['kind'],
-      },
-    },
-    requiresUnlock: false,
-    handler: async (ctx, args) => {
-      const kind = str(args, 'kind') as 'sch' | 'pcb';
-      const file = kind === 'sch' ? ctx.config.schematic : ctx.config.board;
-      if (!file) return `no ${kind} configured`;
-      const outDir = path.join(ctx.repoRoot, '.copperhead', 'renders');
-      await mkdir(outDir, { recursive: true });
-      return exportSvg(kind, path.join(ctx.repoRoot, file), outDir);
-    },
-  },
-  {
-    schema: {
-      name: 'export_outputs',
-      description:
-        'Export the fabrication package into outputs/: gerbers+drill, DXF outline, STEP, SVG renders. Reports per-artifact success/failure.',
-      parameters: { type: 'object', properties: {}, required: [] },
-    },
-    requiresUnlock: true,
-    handler: async (ctx) => {
-      if (!ctx.config.board) return 'no board configured';
-      const outDir = path.join(ctx.repoRoot, 'outputs');
-      await mkdir(outDir, { recursive: true });
-      const res = await exportFab(
-        path.join(ctx.repoRoot, ctx.config.board),
-        ctx.config.schematic ? path.join(ctx.repoRoot, ctx.config.schematic) : null,
-        outDir,
-      );
-      ctx.filesTouched.add('outputs/');
-      const lines = [`produced: ${res.produced.join(', ') || '(none)'}`];
-      for (const f of res.failed) lines.push(`FAILED ${f.artifact}: ${f.reason}`);
-      return lines.join('\n');
-    },
-  },
-  {
-    schema: {
-      name: 'check_drift',
-      description: 'Compare BOM.md/PINOUT.md tables against the parsed schematic. Clears the drift obligation when clean.',
-      parameters: { type: 'object', properties: {}, required: [] },
-    },
-    requiresUnlock: false,
-    handler: async (ctx) => {
-      // No schematic yet means there is nothing for the docs to drift against,
-      // so the obligation is vacuously satisfied and must be cleared. Returning
-      // without clearing deadlocks every docs-only stage of the create pipeline
-      // (spec-seed, architecture, part-selection all run before the schematic
-      // exists): a doc edit opens the drift obligation, this is the only tool
-      // that clears it, and finish refuses while any obligation is open.
-      if (!ctx.config.schematic) {
-        ctx.ledger.clear('drift');
-        return 'no schematic configured; drift vacuously clean';
-      }
-      const mismatches = await checkDrift(ctx.repoRoot, ctx.config.docs, ctx.config.schematic);
-      if (!mismatches.length) {
-        ctx.ledger.clear('drift');
-        return 'drift: clean';
-      }
-      return mismatches.map((m) => `${m.doc}: claims "${m.claim}" but actual is "${m.actual}"`).join('\n');
-    },
-  },
-  {
-    schema: {
-      name: 'record_constraint',
-      description:
-        'Record a constraint in .copperhead/constraints.json (dual write: put the same fact in the relevant doc in this same turn). Opens revisit obligations for every item in affects.',
-      parameters: {
-        type: 'object',
-        properties: {
-          key: { type: 'string', description: 'e.g. power.sleep_current_uA' },
-          min: { type: 'number' },
-          max: { type: 'number' },
-          forbidden: { type: 'array', items: { type: 'string' } },
-          value: { type: 'string' },
-          source: { type: 'string', description: 'doc/spec location that states this' },
-          affects: { type: 'array', items: { type: 'string' } },
-        },
-        required: ['key', 'source', 'affects'],
-      },
-    },
-    requiresUnlock: true,
-    handler: async (ctx, args) => {
-      const key = str(args, 'key');
-      const affects = (args.affects as string[]) ?? [];
-      // An affects item whose target artifact is not built yet (no schematic or
-      // board configured, no BOM.md) has nothing to revisit; opening an
-      // obligation now only forces a ceremonial "not yet created" resolution.
-      // Defer it in the registry instead — reopenDeferredAffects re-opens it at
-      // the start of the first run where the artifact exists, which is when the
-      // revisit actually means something.
-      const deferred: string[] = [];
-      const openNow: string[] = [];
-      for (const item of affects) {
-        const target = classifyAffectsTarget(item);
-        if (target && !affectsTargetExists(target, ctx.repoRoot, ctx.config)) deferred.push(item);
-        else openNow.push(item);
-      }
-      await saveConstraint(ctx.repoRoot, key, {
-        ...(args.min !== undefined ? { min: args.min as number } : {}),
-        ...(args.max !== undefined ? { max: args.max as number } : {}),
-        ...(args.forbidden !== undefined ? { forbidden: args.forbidden as string[] } : {}),
-        ...(args.value !== undefined ? { value: args.value as string } : {}),
-        source: str(args, 'source'),
-        affects,
-        ...(deferred.length ? { deferred } : {}),
-      });
-      ctx.ledger.onConstraintChange(key, openNow);
-      ctx.ledger.clear('constraint-dual-write', key);
-      const parts = [`constraint ${key} recorded`];
-      parts.push(`revisit obligations opened for: ${openNow.join(', ') || '(none)'}`);
-      if (deferred.length) {
-        parts.push(
-          `deferred until the target artifact exists (no resolve_affected needed now): ${deferred.join(', ')}`,
-        );
-      }
-      return parts.join('; ');
-    },
-  },
-  {
-    schema: {
-      name: 'resolve_affected',
-      description:
-        'Explicitly resolve affects-revisit obligations: state whether each affected item changed or why no change is needed. Pass resolutions[] to clear many in one call, or the single constraint_key/item/resolution form.',
-      parameters: {
-        type: 'object',
-        properties: {
-          constraint_key: { type: 'string' },
-          item: { type: 'string' },
-          resolution: { type: 'string', description: '"changed: ..." or "no change needed: <reason>"' },
-          resolutions: {
-            type: 'array',
-            description: 'batch form: resolve many obligations in one call',
-            items: {
-              type: 'object',
-              properties: {
-                constraint_key: { type: 'string' },
-                item: { type: 'string' },
-                resolution: { type: 'string' },
-              },
-              required: ['constraint_key', 'item', 'resolution'],
-            },
-          },
-        },
-        required: [],
-      },
-    },
-    requiresUnlock: true,
-    handler: async (ctx, args) => {
-      // An item that matches nothing must not read as success: the model would
-      // move on believing the obligation closed, and only find out at finish.
-      const resolveOne = (constraintKey: string, item: string, resolution: string): string => {
-        const detail = `${constraintKey} affects ${item}`;
-        if (!ctx.ledger.clear('affects-revisit', detail)) {
-          const open = ctx.ledger.openOfKind('affects-revisit');
-          if (!open.length) return `error: no open affects-revisit obligation matches "${detail}"`;
-          return [
-            `error: no open affects-revisit obligation matches "${detail}".`,
-            'Match these exactly:',
-            ...open.map((o) => `  - ${o.detail}`),
-          ].join('\n');
-        }
-        ctx.decisions.push(`[affects] ${detail}: ${resolution}`);
-        return `resolved: ${detail}`;
-      };
-
-      const batch = args.resolutions;
-      if (Array.isArray(batch) && batch.length) {
-        // Entries resolve independently: one bad key must not waste the call.
-        return batch
-          .map((entry, i) => {
-            const e = entry as Record<string, unknown>;
-            if (typeof e?.constraint_key !== 'string' || typeof e?.item !== 'string' || typeof e?.resolution !== 'string') {
-              return `error: resolutions[${i}] needs string constraint_key, item, and resolution`;
-            }
-            return resolveOne(e.constraint_key, e.item, e.resolution);
-          })
-          .join('\n');
-      }
-      if (typeof args.constraint_key === 'string' && typeof args.item === 'string' && typeof args.resolution === 'string') {
-        return resolveOne(args.constraint_key, args.item, args.resolution);
-      }
-      return 'error: pass either resolutions: [{constraint_key, item, resolution}, ...] or the single form constraint_key + item + resolution';
-    },
-  },
-  {
-    schema: {
-      name: 'record_decision',
-      description:
-        'Append a non-trivial decision to docs/DECISIONS.md: what was decided, the one-line why, and what it affects.',
-      parameters: {
-        type: 'object',
-        properties: {
-          decision: { type: 'string' },
-          rationale: { type: 'string' },
-          affects: { type: 'string', description: 'refdes/nets/docs affected' },
-        },
-        required: ['decision', 'rationale'],
-      },
-    },
-    requiresUnlock: true,
-    handler: async (ctx, args) => {
-      const corrupt = corruptionError({ decision: args.decision, rationale: args.rationale, affects: args.affects });
-      if (corrupt) return corrupt;
-      const decision = str(args, 'decision');
-      const rationale = str(args, 'rationale');
-      const affects = (args.affects as string | undefined) ?? '';
-      const date = new Date().toISOString().slice(0, 10);
-      const entry = `- ${date} [run ${ctx.runId}] ${decision} | why: ${rationale}${affects ? ` | affects: ${affects}` : ''}`;
-      const p = path.join(ctx.repoRoot, ctx.config.docs, 'DECISIONS.md');
-      await appendFile(p, entry + '\n', 'utf8');
-      ctx.decisions.push(`${decision} | why: ${rationale}`);
-      ctx.filesTouched.add(path.join(ctx.config.docs, 'DECISIONS.md'));
-      return 'decision recorded';
-    },
-  },
-  {
-    schema: {
-      name: 'finish',
-      description:
-        'End the run. outcome "done" requires all verification gates and sync obligations to be satisfied; outcome "refuse" ends without edits, citing the violated budget/constraint in summary.',
-      parameters: {
-        type: 'object',
-        properties: {
-          outcome: { type: 'string', enum: ['done', 'refuse'] },
-          summary: { type: 'string' },
-        },
-        required: ['outcome', 'summary'],
-      },
-    },
-    requiresUnlock: false,
-    handler: async (ctx, args) => {
-      const outcome = str(args, 'outcome') as 'done' | 'refuse';
-      const summary = str(args, 'summary');
-      if (outcome === 'refuse') {
-        ctx.finishRequest = { outcome, summary };
-        return 'refusal recorded; run will end';
-      }
-      const problems: string[] = [];
-      const touchedKicad = [...ctx.filesTouched].some((f) => isKicadFile(f));
-      if (touchedKicad) {
-        if (!ctx.lastErc?.ok) problems.push('ERC has not passed since the last schematic edit (run run_erc)');
-        const touchedPcb = [...ctx.filesTouched].some((f) => f.endsWith('.kicad_pcb'));
-        if (touchedPcb && !ctx.lastDrc?.ok) problems.push('DRC has not passed since the last board edit (run run_drc)');
-      }
-      // the changelog obligation is cleared by the commit path itself
-      const blocking = ctx.ledger.openObligations.filter((o) => o.kind !== 'changelog');
-      if (blocking.length) {
-        problems.push('open sync obligations:\n' + blocking.map((o) => `  - [${o.kind}] ${o.detail}`).join('\n'));
-      }
-      if (problems.length) {
-        return `cannot finish yet:\n${problems.map((p) => `- ${p}`).join('\n')}`;
-      }
-      ctx.finishRequest = { outcome, summary };
-      return 'all gates satisfied; run will commit';
-    },
-  },
-];
-
-/** Compose the tool list for the current state (design D2: the lock is structural). */
-export function availableTools(ctx: RunContext): ToolDef[] {
-  return TOOLS.filter((t) => !t.requiresUnlock || ctx.editsUnlocked);
-}
-
-export async function dispatchTool(ctx: RunContext, name: string, args: Record<string, unknown>): Promise<string> {
-  const tool = availableTools(ctx).find((t) => t.schema.name === name);
-  if (!tool) return `tool "${name}" is not available${ctx.editsUnlocked ? '' : ' (edit tools unlock after the proposal validates)'}`;
   try {
-    return await tool.handler(ctx, args);
+    return await entry.handler(ctx, args);
   } catch (err) {
-    return `error: ${(err as Error).message}`;
+    return failResult('exception', `error: ${(err as Error).message}`);
   }
+}
+
+export async function dispatchTool(
+  ctx: RunContext,
+  name: string,
+  args: Record<string, unknown>,
+  opts: DispatchOpts = {},
+): Promise<string> {
+  return flatten(await dispatchToolResult(ctx, name, args, opts));
+}
+
+export async function runSkillSubRun(opts: {
+  ctx: RunContext;
+  skill: CatalogSkill;
+  args: Record<string, unknown>;
+  provider: Provider;
+}): Promise<ToolResult> {
+  const { ctx, skill, args, provider } = opts;
+  const savedFinish = ctx.finishRequest;
+  const only = new Set(skill.tools.filter((n) => n !== 'finish'));
+  const results = new Map<string, ToolResult>();
+  const messages: Msg[] = [
+    { role: 'system', content: skill.prompt(ctx, args) },
+    { role: 'user', content: 'Execute this skill. Use the available tools, then stop when the report is complete.' },
+  ];
+
+  try {
+    for (let turn = 0; turn < (skill.maxTurns ?? 8); turn++) {
+      if (await skill.isComplete(ctx, args)) break;
+      const tools = registry.list(ctx).filter((e) => e.kind === 'tool' && only.has(e.name)).map((e) => e.schema);
+      const res = await provider.chat(messages, tools);
+      messages.push({ role: 'assistant', content: res.text, toolCalls: res.toolCalls });
+      if (!res.toolCalls.length) {
+        if (await skill.isComplete(ctx, args)) break;
+        messages.push({ role: 'user', content: 'Continue using tools until the report is complete.' });
+        continue;
+      }
+      for (const call of res.toolCalls) {
+        const envelope = await dispatchToolResult(ctx, call.name, call.args, { only });
+        results.set(call.name, envelope);
+        const flat = flatten(envelope);
+        await ctx.transcript.event('skill-tool', {
+          skill: skill.name,
+          name: call.name,
+          args: call.args,
+          result: flat,
+          envelope,
+        });
+        messages.push({ role: 'tool', toolCallId: call.id, content: flat });
+      }
+    }
+  } finally {
+    ctx.finishRequest = savedFinish;
+  }
+
+  const detail =
+    skill.tools
+      .filter((n) => results.has(n))
+      .map((n) => `${n}:\n${flatten(results.get(n)!)}`)
+      .join('\n\n') || 'no tool results';
+  const complete = await skill.isComplete(ctx, args);
+  return seal({
+    ok: complete,
+    summary: complete ? 'design report' : 'design report incomplete',
+    detail,
+    viewHint: 'diagnostic',
+  });
 }

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -2,6 +2,7 @@ import type { CatalogEntry, CatalogSkill } from '../capabilities/index.js';
 import { corruptionError } from '../capabilities/helpers.js';
 import { flatten, failResult, seal, unavailable, type ToolResult } from './envelope.js';
 import { registry } from './registry.js';
+import { withRetry, isRateLimit } from '../util/retry.js';
 import type { RunContext } from './context.js';
 import type { Msg, Provider } from './types.js';
 
@@ -33,7 +34,11 @@ export async function dispatchToolResult(
     return runSkillSubRun({ ctx, skill: entry, args, provider: opts.provider });
   }
   try {
-    return await entry.handler(ctx, args);
+    // Unified retry policy (design D10): a thrown 429 backs off through the
+    // same withRetry/isRateLimit pair the provider path uses. Typed envelope
+    // failures (validation/refusal/unavailable) return, so they never retry;
+    // local tool errors are not 429s, so they surface on the first throw.
+    return await withRetry(() => entry.handler(ctx, args), { isRetryable: isRateLimit, baseMs: 250 });
   } catch (err) {
     return failResult('exception', `error: ${(err as Error).message}`);
   }

--- a/src/capabilities/define.ts
+++ b/src/capabilities/define.ts
@@ -9,7 +9,7 @@ export interface CatalogTool {
   viewHint: ViewHint;
   schema: ToolSchema;
   gate: (ctx: RunContext) => boolean;
-  /** Own gate as declared (before skill-conjunction). Same as `gate` for tools. */
+  /** Own gate as declared, before the registry applies the tools-conjunction. */
   ownGate: (ctx: RunContext) => boolean;
   handler: (ctx: RunContext, args: Record<string, unknown>) => Promise<ToolResult>;
 }
@@ -67,8 +67,7 @@ export function defineTool(def: ToolInit): CatalogTool {
 
 /**
  * Identity helper. When `gate` is omitted the skill is available only if every
- * declared tool's gate is true (applied by the registry at list-time; `ownGate`
- * is the conjunction once the registry is constructed — see `bindSkillGate`).
+ * declared tool's gate is true (applied by the registry at list-time).
  */
 export function defineSkill(def: SkillInit): CatalogSkill {
   const ownGate = def.gate ?? ((_ctx: RunContext) => true);

--- a/src/capabilities/define.ts
+++ b/src/capabilities/define.ts
@@ -1,0 +1,89 @@
+import type { ToolSchema } from '../agent/types.js';
+import type { RunContext } from '../agent/context.js';
+import type { ToolResult, ViewHint } from '../agent/envelope.js';
+
+export interface CatalogTool {
+  kind: 'tool';
+  name: string;
+  version: number;
+  viewHint: ViewHint;
+  schema: ToolSchema;
+  gate: (ctx: RunContext) => boolean;
+  /** Own gate as declared (before skill-conjunction). Same as `gate` for tools. */
+  ownGate: (ctx: RunContext) => boolean;
+  handler: (ctx: RunContext, args: Record<string, unknown>) => Promise<ToolResult>;
+}
+
+export interface CatalogSkill {
+  kind: 'skill';
+  name: string;
+  version: number;
+  viewHint: ViewHint;
+  schema: ToolSchema;
+  gate: (ctx: RunContext) => boolean;
+  ownGate: (ctx: RunContext) => boolean;
+  /** False when `gate` was omitted and should default to the tools-conjunction. */
+  gateProvided: boolean;
+  tools: string[];
+  prompt: (ctx: RunContext, args: Record<string, unknown>) => string;
+  isComplete: (ctx: RunContext, args: Record<string, unknown>) => Promise<boolean> | boolean;
+  maxTurns?: number;
+}
+
+export type CatalogEntry = CatalogTool | CatalogSkill;
+
+export interface ToolInit {
+  schema: ToolSchema;
+  version: number;
+  viewHint: ViewHint;
+  gate: (ctx: RunContext) => boolean;
+  handler: (ctx: RunContext, args: Record<string, unknown>) => Promise<ToolResult>;
+}
+
+export interface SkillInit {
+  schema: ToolSchema;
+  version: number;
+  viewHint: ViewHint;
+  tools: string[];
+  prompt: (ctx: RunContext, args: Record<string, unknown>) => string;
+  isComplete: (ctx: RunContext, args: Record<string, unknown>) => Promise<boolean> | boolean;
+  maxTurns?: number;
+  gate?: (ctx: RunContext) => boolean;
+}
+
+/** Identity helper: freeze defaults and tag the tier. */
+export function defineTool(def: ToolInit): CatalogTool {
+  return {
+    kind: 'tool',
+    name: def.schema.name,
+    version: def.version,
+    viewHint: def.viewHint,
+    schema: def.schema,
+    gate: def.gate,
+    ownGate: def.gate,
+    handler: def.handler,
+  };
+}
+
+/**
+ * Identity helper. When `gate` is omitted the skill is available only if every
+ * declared tool's gate is true (applied by the registry at list-time; `ownGate`
+ * is the conjunction once the registry is constructed — see `bindSkillGate`).
+ */
+export function defineSkill(def: SkillInit): CatalogSkill {
+  const ownGate = def.gate ?? ((_ctx: RunContext) => true);
+  return {
+    kind: 'skill',
+    name: def.schema.name,
+    version: def.version,
+    viewHint: def.viewHint,
+    schema: def.schema,
+    gate: ownGate,
+    ownGate,
+    gateProvided: def.gate !== undefined,
+    tools: def.tools,
+    prompt: def.prompt,
+    isComplete: def.isComplete,
+    ...(def.maxTurns !== undefined ? { maxTurns: def.maxTurns } : {}),
+  };
+}

--- a/src/capabilities/handlers.ts
+++ b/src/capabilities/handlers.ts
@@ -18,13 +18,18 @@ import type { ToolSchema } from '../agent/types.js';
 import type { RunContext } from '../agent/context.js';
 import { corruptionError, markTouched, str } from './helpers.js';
 
-export interface StringHandlerDef {
-  schema: ToolSchema;
-  requiresUnlock: boolean;
-  handler: (ctx: RunContext, args: Record<string, unknown>) => Promise<string>;
+export interface HandlerOutcome {
+  ok: boolean;
+  text: string;
 }
 
-export const HANDLERS: StringHandlerDef[] = [
+export interface HandlerDef {
+  schema: ToolSchema;
+  requiresUnlock: boolean;
+  handler: (ctx: RunContext, args: Record<string, unknown>) => Promise<string | HandlerOutcome>;
+}
+
+export const HANDLERS: HandlerDef[] = [
   {
     schema: {
       name: 'read_file',
@@ -270,9 +275,12 @@ export const HANDLERS: StringHandlerDef[] = [
       // "ERC clean" on the empty starting sheet still misleads the model, so warn
       // here too: no gate should read as satisfied by the empty starting state.
       if (report.ok && !(await listSymbols(schPath)).length) {
-        return `${out}\nwarning: ERC is clean but the schematic has ZERO symbols — an empty sheet always passes ERC, so this is NOT a verified design. Capture the parts from BOM.md (and re-run run_erc) before calling finish.`;
+        return {
+          ok: true,
+          text: `${out}\nwarning: ERC is clean but the schematic has ZERO symbols — an empty sheet always passes ERC, so this is NOT a verified design. Capture the parts from BOM.md (and re-run run_erc) before calling finish.`,
+        };
       }
-      return out;
+      return { ok: report.ok, text: out };
     },
   },
   {
@@ -362,11 +370,14 @@ export const HANDLERS: StringHandlerDef[] = [
         path.join(ctx.repoRoot, ctx.config.schematic),
       );
       if (!findings.length) {
-        return `verify_symbols: ${checked} symbol(s) match the installed KiCad library. No divergences.`;
+        return { ok: true, text: `verify_symbols: ${checked} symbol(s) match the installed KiCad library. No divergences.` };
       }
       const lines = findings.map((f) => `  - [${f.kind}] ${f.detail}`);
       const mismatches = findings.filter((f) => f.kind !== 'no-library').length;
-      return `verify_symbols: ${checked} verified, ${skipped} unverifiable (library not installed), ${mismatches} issue(s) to reconcile:\n${lines.join('\n')}`;
+      return {
+        ok: false,
+        text: `verify_symbols: ${checked} verified, ${skipped} unverifiable (library not installed), ${mismatches} issue(s) to reconcile:\n${lines.join('\n')}`,
+      };
     },
   },
   {
@@ -403,7 +414,7 @@ export const HANDLERS: StringHandlerDef[] = [
         intentPath: intentRel,
         docsDir: ctx.config.docs,
       });
-      if (!res.ok) return res.message;
+      if (!res.ok) return { ok: false, text: res.message };
       markTouched(ctx, ctx.config.schematic);
       // embed the checker and score in the draft report (design D5): a
       // draft-check-score iteration costs one tool call, and the embedded
@@ -438,7 +449,7 @@ export const HANDLERS: StringHandlerDef[] = [
         ...(ctx.config.legibility ? { config: ctx.config.legibility } : {}),
       });
       ctx.lastScore = report.composite;
-      return formatScore(report);
+      return { ok: report.legibility.error === 0, text: formatScore(report) };
     },
   },
   {
@@ -463,7 +474,7 @@ export const HANDLERS: StringHandlerDef[] = [
       });
       ctx.lastLegibility = report.counts;
       ctx.ledger.onLegibilityResult(report.counts.error);
-      return formatLegibility(report);
+      return { ok: report.counts.error === 0, text: formatLegibility(report) };
     },
   },
   {
@@ -480,7 +491,7 @@ export const HANDLERS: StringHandlerDef[] = [
       ctx.lastDrc = report;
       if (report.ok) ctx.ledger.clear('drc');
       else ctx.repairCycles++;
-      return formatViolations(report);
+      return { ok: report.ok, text: formatViolations(report) };
     },
   },
   {
@@ -523,7 +534,7 @@ export const HANDLERS: StringHandlerDef[] = [
       ctx.filesTouched.add('outputs/');
       const lines = [`produced: ${res.produced.join(', ') || '(none)'}`];
       for (const f of res.failed) lines.push(`FAILED ${f.artifact}: ${f.reason}`);
-      return lines.join('\n');
+      return { ok: res.failed.length === 0, text: lines.join('\n') };
     },
   },
   {
@@ -549,11 +560,11 @@ export const HANDLERS: StringHandlerDef[] = [
       if (!mismatches.length) {
         ctx.ledger.clear('drift');
         ctx.lastDrift = 'drift: clean';
-        return 'drift: clean';
+        return { ok: true, text: 'drift: clean' };
       }
       const text = mismatches.map((m) => `${m.doc}: claims "${m.claim}" but actual is "${m.actual}"`).join('\n');
       ctx.lastDrift = text;
-      return text;
+      return { ok: false, text };
     },
   },
   {
@@ -752,4 +763,3 @@ export const HANDLERS: StringHandlerDef[] = [
     },
   },
 ];
-

--- a/src/capabilities/handlers.ts
+++ b/src/capabilities/handlers.ts
@@ -1,0 +1,755 @@
+import path from 'node:path';
+import { writeFile, mkdir, appendFile, readFile } from 'node:fs/promises';
+import { toolReadFile, toolWriteFile, toolEditFile, toolSearch } from '../agent/filetools.js';
+import { resolveInRepo, isKicadFile } from '../util/paths.js';
+import { runErc, runDrc, exportSvg, exportFab, kicadLoadError, isProbeableKicadFile } from '../kicad/cli.js';
+import { formatViolations } from '../kicad/report.js';
+import { listSymbols, listNets } from '../kicad/sexp.js';
+import { checkLegibility, formatLegibility } from '../kicad/legibility.js';
+import { scoreSchematic, formatScore } from '../kicad/score.js';
+import { draftSchematic, defaultIntentPath, formatSchematicDraftReport } from '../kicad/draft/draft.js';
+import { verifySchematicSymbols, searchInstalledSymbols, symbolSearchDirs, resolveLibrarySymbol, comparePinNumbers } from '../kicad/symlib.js';
+import { checkDrift } from '../memory/drift.js';
+import { saveConstraint, classifyAffectsTarget, affectsTargetExists } from '../memory/constraints.js';
+import { openspecValidate } from '../openspec/cli.js';
+import { existsSync } from 'node:fs';
+import { isEngineAuthoredSchematic } from '../kicad/fab.js';
+import type { ToolSchema } from '../agent/types.js';
+import type { RunContext } from '../agent/context.js';
+import { corruptionError, markTouched, str } from './helpers.js';
+
+export interface StringHandlerDef {
+  schema: ToolSchema;
+  requiresUnlock: boolean;
+  handler: (ctx: RunContext, args: Record<string, unknown>) => Promise<string>;
+}
+
+export const HANDLERS: StringHandlerDef[] = [
+  {
+    schema: {
+      name: 'read_file',
+      description: 'Read a repo-relative file, optionally a line range. Returns text (line-numbered when ranged).',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+          start_line: { type: 'number' },
+          end_line: { type: 'number' },
+        },
+        required: ['path'],
+      },
+    },
+    requiresUnlock: false,
+    handler: (ctx, args) =>
+      toolReadFile(
+        ctx.repoRoot,
+        str(args, 'path'),
+        args.start_line as number | undefined,
+        args.end_line as number | undefined,
+      ),
+  },
+  {
+    schema: {
+      name: 'search',
+      description: 'Regex search over the repo (ripgrep-style). Optional glob filter, e.g. "**/*.kicad_sch".',
+      parameters: {
+        type: 'object',
+        properties: { pattern: { type: 'string' }, glob: { type: 'string' } },
+        required: ['pattern'],
+      },
+    },
+    requiresUnlock: false,
+    handler: async (ctx, args) => {
+      const pattern = args.pattern;
+      if (typeof pattern !== 'string' || pattern.trim() === '') {
+        return 'error: search requires a non-empty regex in "pattern" (narrow by file with "glob", e.g. {"pattern": "GPIO", "glob": "**/*.md"}); to list files, use a broad pattern like "." with a glob';
+      }
+      const matches = await toolSearch(ctx.repoRoot, pattern, args.glob as string | undefined);
+      if (!matches.length) return 'no matches';
+      return matches.map((m) => `${m.file}:${m.line}: ${m.text}`).join('\n');
+    },
+  },
+  {
+    schema: {
+      name: 'list_symbols',
+      description: 'List schematic symbols: ref, value, footprint, sheet.',
+      parameters: { type: 'object', properties: {}, required: [] },
+    },
+    requiresUnlock: false,
+    handler: async (ctx) => {
+      if (!ctx.config.schematic) return 'no schematic configured';
+      const syms = await listSymbols(path.join(ctx.repoRoot, ctx.config.schematic));
+      return JSON.stringify(syms.map(({ ref, value, footprint, sheet }) => ({ ref, value, footprint, sheet })), null, 2);
+    },
+  },
+  {
+    schema: {
+      name: 'list_nets',
+      description: 'List net names found in the schematic.',
+      parameters: { type: 'object', properties: {}, required: [] },
+    },
+    requiresUnlock: false,
+    handler: async (ctx) => {
+      if (!ctx.config.schematic) return 'no schematic configured';
+      return JSON.stringify(await listNets(path.join(ctx.repoRoot, ctx.config.schematic)));
+    },
+  },
+  {
+    schema: {
+      name: 'propose_change',
+      description:
+        'Write the OpenSpec change proposal for this run (the plan step). Must be called and validated before edit tools unlock.',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'kebab-case change id' },
+          why: { type: 'string' },
+          what_changes: { type: 'string', description: 'markdown bullet list of changes' },
+          tasks: { type: 'string', description: 'markdown checklist of implementation steps' },
+        },
+        required: ['id', 'why', 'what_changes', 'tasks'],
+      },
+    },
+    requiresUnlock: false,
+    handler: async (ctx, args) => {
+      const id = str(args, 'id');
+      const dir = resolveInRepo(ctx.repoRoot, path.join('openspec', 'changes', id));
+      await mkdir(dir, { recursive: true });
+      const auto = ctx.interactive ? '' : '\n> Marker: AUTO (autonomous mode; auto-approved, reviewable after the fact)\n';
+      await writeFile(
+        path.join(dir, 'proposal.md'),
+        `# Proposal: ${id}\n${auto}\n## Why\n\n${str(args, 'why')}\n\n## What Changes\n\n${str(args, 'what_changes')}\n`,
+        'utf8',
+      );
+      await writeFile(path.join(dir, 'tasks.md'), `# Tasks\n\n${str(args, 'tasks')}\n`, 'utf8');
+      ctx.changeId = id;
+      return `proposal written to openspec/changes/${id}/ — now call validate_change`;
+    },
+  },
+  {
+    schema: {
+      name: 'validate_change',
+      description: 'Validate the current change proposal; on success the edit tools unlock.',
+      parameters: { type: 'object', properties: {}, required: [] },
+    },
+    requiresUnlock: false,
+    handler: async (ctx) => {
+      if (!ctx.changeId) return 'no proposal yet: call propose_change first';
+      let ok: boolean;
+      let detail: string;
+      if (existsSync(path.join(ctx.repoRoot, 'openspec', 'config.yaml'))) {
+        const res = await openspecValidate(ctx.repoRoot, ctx.changeId);
+        ok = res.ok;
+        detail = res.output;
+      } else {
+        // No OpenSpec workspace in the target repo: structural validation of the
+        // proposal files themselves (the invariant is the gate, not the CLI).
+        const dir = path.join(ctx.repoRoot, 'openspec', 'changes', ctx.changeId);
+        ok = existsSync(path.join(dir, 'proposal.md')) && existsSync(path.join(dir, 'tasks.md'));
+        detail = ok ? 'structural validation passed (no openspec workspace)' : 'proposal files missing';
+      }
+      if (!ok) return `validation FAILED:\n${detail}`;
+      ctx.proposalValidated = true;
+      if (ctx.interactive) {
+        const approved = await ctx.confirm(`Proposal ${ctx.changeId} validated. Unlock edit tools and proceed?`);
+        if (!approved) return 'proposal validated but human declined; edits remain locked';
+      }
+      ctx.editsUnlocked = true;
+      await ctx.transcript.event('edit-tools-unlocked', { changeId: ctx.changeId });
+      return `validation passed; edit tools are now unlocked`;
+    },
+  },
+  {
+    schema: {
+      name: 'edit_file',
+      description:
+        'Exact-match anchored replace in an existing file. Requires a validated change proposal first (call propose_change then validate_change to unlock edits; both may be in the same reply, before this call). The anchor must be unique; widen it with surrounding lines if not. For renames, pass replace_all: true to replace every occurrence in one call.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+          old_string: { type: 'string' },
+          new_string: { type: 'string' },
+          replace_all: { type: 'boolean' },
+        },
+        required: ['path', 'old_string', 'new_string'],
+      },
+    },
+    requiresUnlock: true,
+    handler: async (ctx, args) => {
+      const corrupt = corruptionError({ new_string: args.new_string });
+      if (corrupt) return corrupt;
+      const rel = str(args, 'path');
+      const abs = resolveInRepo(ctx.repoRoot, rel);
+      // Engine-drafted sheets are regenerated wholesale from the IR: a hand
+      // edit would be destroyed by the next re-draft and would break the
+      // byte-identical staleness check. Geometry repairs go through the IR
+      // (design D5). Hand-drawn schematics never carry the draft generator
+      // marker, so `do` on existing repos is untouched by this guard.
+      if (rel.endsWith('.kicad_sch') && existsSync(abs)) {
+        const head = (await readFile(abs, 'utf8')).slice(0, 400);
+        if (isEngineAuthoredSchematic(head)) {
+          return `refused: ${rel} is engine-drafted from ${defaultIntentPath(rel)}. Revise the intent (edit_file on the intent JSON) and call draft_schematic to regenerate the sheet; direct geometry edits would be lost on the next re-draft.`;
+        }
+      }
+      // Text edits can corrupt an s-expression file in ways the editor cannot
+      // see; a corrupted file then fails every later ERC/DRC with an opaque
+      // error. Validate loadability with KiCad itself and roll the edit back
+      // rather than letting the file drift unusable. Only schematics and
+      // boards are probeable; .kicad_pro/.kicad_sym/.kicad_mod edits must not
+      // be probed (a sch/pcb probe rejects them wholesale).
+      const before = isProbeableKicadFile(rel) ? await readFile(abs, 'utf8') : null;
+      const res = await toolEditFile(
+        ctx.repoRoot,
+        rel,
+        str(args, 'old_string'),
+        args.new_string as string,
+        args.replace_all === true,
+      );
+      if (before !== null) {
+        const loadErr = await kicadLoadError(abs);
+        if (loadErr) {
+          const after = await readFile(abs, 'utf8');
+          await writeFile(abs, before, 'utf8');
+          if (await kicadLoadError(abs)) {
+            // The file was already unloadable before this edit. Reverting
+            // would deadlock incremental repair (every partial fix undone
+            // unless one edit fixes the whole file), so keep the edit and
+            // keep the pressure on with the probe output.
+            await writeFile(abs, after, 'utf8');
+            markTouched(ctx, rel);
+            return `${res}\nnote: ${rel} was already unloadable before this edit, so the edit is KEPT. Keep repairing until it loads. kicad-cli says:\n${loadErr}`;
+          }
+          return `edit REVERTED: it would make ${rel} unloadable in KiCad. kicad-cli says:\n${loadErr}\nRe-read the surrounding file text and make a smaller, syntactically complete edit.`;
+        }
+      }
+      markTouched(ctx, rel);
+      return res;
+    },
+  },
+  {
+    schema: {
+      name: 'write_file',
+      description:
+        'Create a new file (docs, outputs). Requires a validated change proposal first (propose_change then validate_change to unlock edits). Refuses to overwrite anything or to create KiCad files.',
+      parameters: {
+        type: 'object',
+        properties: { path: { type: 'string' }, content: { type: 'string' } },
+        required: ['path', 'content'],
+      },
+    },
+    requiresUnlock: true,
+    handler: async (ctx, args) => {
+      const corrupt = corruptionError({ content: args.content });
+      if (corrupt) return corrupt;
+      const rel = str(args, 'path');
+      const res = await toolWriteFile(ctx.repoRoot, rel, args.content as string);
+      markTouched(ctx, rel);
+      return res;
+    },
+  },
+  {
+    schema: {
+      name: 'run_erc',
+      description: 'Run kicad-cli ERC on the schematic. Clears the ERC obligation when clean.',
+      parameters: { type: 'object', properties: {}, required: [] },
+    },
+    requiresUnlock: false,
+    handler: async (ctx) => {
+      if (!ctx.config.schematic)
+        return 'no schematic configured; ERC does not apply yet — skip it until a schematic exists and is set in .copperhead/config.json';
+      const schPath = path.join(ctx.repoRoot, ctx.config.schematic);
+      const report = await runErc(schPath);
+      ctx.lastErc = report;
+      if (report.ok) ctx.ledger.clear('erc');
+      else ctx.repairCycles++;
+      const out = formatViolations(report);
+      // A zero-symbol schematic passes ERC with 0 violations — a false green
+      // (3.2) that lets a premature finish look verified (an empty sheet also
+      // passes drift). The stage contract already requires symbols>0, but a bare
+      // "ERC clean" on the empty starting sheet still misleads the model, so warn
+      // here too: no gate should read as satisfied by the empty starting state.
+      if (report.ok && !(await listSymbols(schPath)).length) {
+        return `${out}\nwarning: ERC is clean but the schematic has ZERO symbols — an empty sheet always passes ERC, so this is NOT a verified design. Capture the parts from BOM.md (and re-run run_erc) before calling finish.`;
+      }
+      return out;
+    },
+  },
+  {
+    schema: {
+      name: 'search_symbols',
+      description:
+        'Search EVERY installed KiCad symbol library for a part or symbol name; returns matching lib_ids as Lib:Name, exact matches first. Library nicknames rarely follow from the part number (TPS61165DBV is in Driver_LED, AudioJack3 in Connector_Audio, INA226 in Sensor_Energy), so a failed single-library probe proves nothing about availability — use this before concluding a part has no symbol, and before committing any active part to the BOM: a part is only drawable if its symbol appears here.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'part or symbol name, e.g. "TLV320AIC3204" or "AudioJack3"' },
+        },
+        required: ['query'],
+      },
+    },
+    requiresUnlock: false,
+    handler: async (_ctx, args) => {
+      const query = str(args, 'query');
+      const dirs = await symbolSearchDirs();
+      if (!dirs.length) return 'no installed KiCad symbol library directories found on this machine';
+      const hits = await searchInstalledSymbols(query, dirs);
+      if (!hits.length) {
+        return `no installed symbol matches "${query}" (searched every library in: ${dirs.join(', ')}). The part is not capturable on this machine as named — choose a part whose symbol exists, or a same-family variant that does.`;
+      }
+      return `installed symbols matching "${query}":\n${hits.map((h) => `  - ${h}`).join('\n')}`;
+    },
+  },
+  {
+    schema: {
+      name: 'symbol_pins',
+      description:
+        'Return the REAL pins (number, name, electrical type) of an installed KiCad symbol by lib_id, following extends links, plus its unit count — the authoritative source for REF.PIN endpoints, instead of guessing pins or reading .kicad_sym files. Warns when the symbol is multi-unit, which the drafting engine refuses. On a miss it lists the closest names in that library and where the symbol actually lives, so one call answers both "what are the pins" and "which lib_id is right".',
+      parameters: {
+        type: 'object',
+        properties: {
+          lib_id: { type: 'string', description: 'full library identifier, e.g. "Device:R" or "Audio:TLV320AIC3100"' },
+        },
+        required: ['lib_id'],
+      },
+    },
+    requiresUnlock: false,
+    handler: async (_ctx, args) => {
+      const libId = str(args, 'lib_id');
+      const name = libId.includes(':') ? libId.slice(libId.indexOf(':') + 1) : libId;
+      const dirs = await symbolSearchDirs();
+      if (!dirs.length) {
+        return `cannot verify "${libId}": no installed KiCad symbol library directories were found on this machine, so nothing can be resolved or ruled out. Install the KiCad symbol libraries (or set KICAD_SYMBOL_DIR), or choose a part you can verify another way.`;
+      }
+      const r = await resolveLibrarySymbol(libId, dirs);
+      if (r.status === 'ok') {
+        const pins = [...r.pins]
+          .sort((a, b) => comparePinNumbers(a.number, b.number))
+          .map((p) => `  ${p.number}: ${p.name === '~' || !p.name ? '(unnamed)' : p.name} · ${p.type}`);
+        const multi =
+          r.units >= 2
+            ? `\nNOTE: this symbol defines ${r.units} units; the drafting engine places each unit separately under one refdes (U1A/U1B), and net endpoints keep plain package pin numbers.`
+            : '';
+        return `${libId} — ${r.pins.length} pin(s), ${r.units} unit(s):\n${pins.join('\n')}${multi}`;
+      }
+      if (r.status === 'found-elsewhere') {
+        return `"${libId}" does not resolve, but the symbol is installed as: ${r.libIds.join(', ')} — use one of these lib_ids (and call symbol_pins on it for the pin table).`;
+      }
+      const elsewhere = await searchInstalledSymbols(name, dirs, 6);
+      const where = elsewhere.length
+        ? `\ninstalled as: ${elsewhere.join(', ')}`
+        : `\nno installed symbol matches "${name}" in any library — the part is not capturable as named.`;
+      if (r.status === 'no-symbol') {
+        const close = r.candidates.length ? `\nclosest in that library: ${r.candidates.join(', ')}` : '';
+        return `"${libId}" does not exist in that library.${close}${where}`;
+      }
+      const lib = libId.includes(':') ? libId.slice(0, libId.indexOf(':')) : libId;
+      return `no library named "${lib}" is installed.${where}`;
+    },
+  },
+  {
+    schema: {
+      name: 'verify_symbols',
+      description:
+        "Cross-check every lib_symbols entry in the schematic against the KiCad symbol library installed on this machine. Reports pins that diverge from the real part (wrong count, name, or electrical type) and lib_ids that do not exist in the current KiCad version (with the closest real names). ERC cannot catch these — a symbol whose lib_id claims to be a canonical part but whose pins are wrong passes ERC while being wrong. Run this after capturing symbols and reconcile every finding.",
+      parameters: { type: 'object', properties: {}, required: [] },
+    },
+    requiresUnlock: false,
+    handler: async (ctx) => {
+      if (!ctx.config.schematic)
+        return 'no schematic configured; verify_symbols does not apply yet';
+      const { findings, checked, skipped } = await verifySchematicSymbols(
+        path.join(ctx.repoRoot, ctx.config.schematic),
+      );
+      if (!findings.length) {
+        return `verify_symbols: ${checked} symbol(s) match the installed KiCad library. No divergences.`;
+      }
+      const lines = findings.map((f) => `  - [${f.kind}] ${f.detail}`);
+      const mismatches = findings.filter((f) => f.kind !== 'no-library').length;
+      return `verify_symbols: ${checked} verified, ${skipped} unverifiable (library not installed), ${mismatches} issue(s) to reconcile:\n${lines.join('\n')}`;
+    },
+  },
+  {
+    schema: {
+      name: 'draft_schematic',
+      description:
+        'Regenerate the schematic deterministically from the netlist-intent IR (schematic.intent.json beside the schematic). Pass intent_json to write a new IR first, or omit it to re-draft the existing file. The engine computes ALL geometry (placement, wires, labels, power symbols, group boxes); never author coordinates. The report embeds the legibility findings and score for the fresh sheet. A failed validation leaves the previous schematic untouched.',
+      parameters: {
+        type: 'object',
+        properties: {
+          intent_json: { type: 'string', description: 'full IR document as JSON text (optional: omit to re-draft the current IR)' },
+        },
+        required: [],
+      },
+    },
+    requiresUnlock: true,
+    handler: async (ctx, args) => {
+      if (!ctx.config.schematic) return 'no schematic configured; set one in .copperhead/config.json first';
+      const intentRel = defaultIntentPath(ctx.config.schematic);
+      if (typeof args.intent_json === 'string' && args.intent_json.trim()) {
+        const corrupt = corruptionError({ intent_json: args.intent_json });
+        if (corrupt) return corrupt;
+        try {
+          JSON.parse(args.intent_json);
+        } catch (e) {
+          return `intent_json is not valid JSON (${(e as Error).message}); nothing written`;
+        }
+        await writeFile(resolveInRepo(ctx.repoRoot, intentRel), args.intent_json, 'utf8');
+        ctx.filesTouched.add(intentRel);
+      }
+      const res = await draftSchematic({
+        repoRoot: ctx.repoRoot,
+        schematic: ctx.config.schematic,
+        intentPath: intentRel,
+        docsDir: ctx.config.docs,
+      });
+      if (!res.ok) return res.message;
+      markTouched(ctx, ctx.config.schematic);
+      // embed the checker and score in the draft report (design D5): a
+      // draft-check-score iteration costs one tool call, and the embedded
+      // checker result drives the ledger obligation exactly like check_legibility
+      const docsAbs = path.join(ctx.repoRoot, ctx.config.docs);
+      const leg = await checkLegibility(res.schematicPath, {
+        docsDir: docsAbs,
+        ...(ctx.config.legibility ? { config: ctx.config.legibility } : {}),
+      });
+      ctx.lastLegibility = leg.counts;
+      ctx.ledger.onLegibilityResult(leg.counts.error);
+      const score = await scoreSchematic(res.schematicPath, {
+        docsDir: docsAbs,
+        ...(ctx.config.legibility ? { config: ctx.config.legibility } : {}),
+      });
+      ctx.lastScore = score.composite;
+      return [formatSchematicDraftReport(res.report), formatLegibility(leg), formatScore(score)].join('\n');
+    },
+  },
+  {
+    schema: {
+      name: 'score_schematic',
+      description:
+        'Deterministic quantitative legibility score for the schematic: composite 0-100 with the per-metric breakdown (crossings, bends, alignment, spacing, symmetry, balance, …). Error-severity legibility findings cap the composite. Advisory: informs, never gates by itself.',
+      parameters: { type: 'object', properties: {}, required: [] },
+    },
+    requiresUnlock: false,
+    handler: async (ctx) => {
+      if (!ctx.config.schematic) return 'no schematic configured; score_schematic does not apply yet';
+      const report = await scoreSchematic(path.join(ctx.repoRoot, ctx.config.schematic), {
+        docsDir: path.join(ctx.repoRoot, ctx.config.docs),
+        ...(ctx.config.legibility ? { config: ctx.config.legibility } : {}),
+      });
+      ctx.lastScore = report.composite;
+      return formatScore(report);
+    },
+  },
+  {
+    schema: {
+      name: 'check_legibility',
+      description:
+        'Run the deterministic legibility checker against the schematic: group boxes and captions, symbol/text collisions, grid alignment, frame and title-block use. Returns numbered findings with coordinates and the concrete fix, or "no findings". Error-severity findings must be reconciled before finish; clears the legibility obligation when clean.',
+      parameters: { type: 'object', properties: {}, required: [] },
+    },
+    requiresUnlock: false,
+    handler: async (ctx) => {
+      // Mirrors check_drift's vacuous path: with no schematic configured there is
+      // nothing to be illegible, and leaving the obligation open would deadlock
+      // any stage that edited a stray .kicad_sch without config wiring.
+      if (!ctx.config.schematic) {
+        ctx.ledger.clear('legibility');
+        return 'no schematic configured; legibility does not apply yet';
+      }
+      const report = await checkLegibility(path.join(ctx.repoRoot, ctx.config.schematic), {
+        docsDir: path.join(ctx.repoRoot, ctx.config.docs),
+        ...(ctx.config.legibility ? { config: ctx.config.legibility } : {}),
+      });
+      ctx.lastLegibility = report.counts;
+      ctx.ledger.onLegibilityResult(report.counts.error);
+      return formatLegibility(report);
+    },
+  },
+  {
+    schema: {
+      name: 'run_drc',
+      description: 'Run kicad-cli DRC on the board. Clears the DRC obligation when clean.',
+      parameters: { type: 'object', properties: {}, required: [] },
+    },
+    requiresUnlock: false,
+    handler: async (ctx) => {
+      if (!ctx.config.board)
+        return 'no board configured; DRC does not apply yet — skip it until a board exists and is set in .copperhead/config.json';
+      const report = await runDrc(path.join(ctx.repoRoot, ctx.config.board));
+      ctx.lastDrc = report;
+      if (report.ok) ctx.ledger.clear('drc');
+      else ctx.repairCycles++;
+      return formatViolations(report);
+    },
+  },
+  {
+    schema: {
+      name: 'export_svg',
+      description: 'Export an SVG render of the schematic or board into .copperhead/renders/.',
+      parameters: {
+        type: 'object',
+        properties: { kind: { type: 'string', enum: ['sch', 'pcb'] } },
+        required: ['kind'],
+      },
+    },
+    requiresUnlock: false,
+    handler: async (ctx, args) => {
+      const kind = str(args, 'kind') as 'sch' | 'pcb';
+      const file = kind === 'sch' ? ctx.config.schematic : ctx.config.board;
+      if (!file) return `no ${kind} configured`;
+      const outDir = path.join(ctx.repoRoot, '.copperhead', 'renders');
+      await mkdir(outDir, { recursive: true });
+      return exportSvg(kind, path.join(ctx.repoRoot, file), outDir);
+    },
+  },
+  {
+    schema: {
+      name: 'export_outputs',
+      description:
+        'Export the fabrication package into outputs/: gerbers+drill, DXF outline, STEP, SVG renders. Reports per-artifact success/failure.',
+      parameters: { type: 'object', properties: {}, required: [] },
+    },
+    requiresUnlock: true,
+    handler: async (ctx) => {
+      if (!ctx.config.board) return 'no board configured';
+      const outDir = path.join(ctx.repoRoot, 'outputs');
+      await mkdir(outDir, { recursive: true });
+      const res = await exportFab(
+        path.join(ctx.repoRoot, ctx.config.board),
+        ctx.config.schematic ? path.join(ctx.repoRoot, ctx.config.schematic) : null,
+        outDir,
+      );
+      ctx.filesTouched.add('outputs/');
+      const lines = [`produced: ${res.produced.join(', ') || '(none)'}`];
+      for (const f of res.failed) lines.push(`FAILED ${f.artifact}: ${f.reason}`);
+      return lines.join('\n');
+    },
+  },
+  {
+    schema: {
+      name: 'check_drift',
+      description: 'Compare BOM.md/PINOUT.md tables against the parsed schematic. Clears the drift obligation when clean.',
+      parameters: { type: 'object', properties: {}, required: [] },
+    },
+    requiresUnlock: false,
+    handler: async (ctx) => {
+      // No schematic yet means there is nothing for the docs to drift against,
+      // so the obligation is vacuously satisfied and must be cleared. Returning
+      // without clearing deadlocks every docs-only stage of the create pipeline
+      // (spec-seed, architecture, part-selection all run before the schematic
+      // exists): a doc edit opens the drift obligation, this is the only tool
+      // that clears it, and finish refuses while any obligation is open.
+      if (!ctx.config.schematic) {
+        ctx.ledger.clear('drift');
+        ctx.lastDrift = 'no schematic configured; drift vacuously clean';
+        return 'no schematic configured; drift vacuously clean';
+      }
+      const mismatches = await checkDrift(ctx.repoRoot, ctx.config.docs, ctx.config.schematic);
+      if (!mismatches.length) {
+        ctx.ledger.clear('drift');
+        ctx.lastDrift = 'drift: clean';
+        return 'drift: clean';
+      }
+      const text = mismatches.map((m) => `${m.doc}: claims "${m.claim}" but actual is "${m.actual}"`).join('\n');
+      ctx.lastDrift = text;
+      return text;
+    },
+  },
+  {
+    schema: {
+      name: 'record_constraint',
+      description:
+        'Record a constraint in .copperhead/constraints.json (dual write: put the same fact in the relevant doc in this same turn). Opens revisit obligations for every item in affects.',
+      parameters: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', description: 'e.g. power.sleep_current_uA' },
+          min: { type: 'number' },
+          max: { type: 'number' },
+          forbidden: { type: 'array', items: { type: 'string' } },
+          value: { type: 'string' },
+          source: { type: 'string', description: 'doc/spec location that states this' },
+          affects: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['key', 'source', 'affects'],
+      },
+    },
+    requiresUnlock: true,
+    handler: async (ctx, args) => {
+      const key = str(args, 'key');
+      const affects = (args.affects as string[]) ?? [];
+      // An affects item whose target artifact is not built yet (no schematic or
+      // board configured, no BOM.md) has nothing to revisit; opening an
+      // obligation now only forces a ceremonial "not yet created" resolution.
+      // Defer it in the registry instead — reopenDeferredAffects re-opens it at
+      // the start of the first run where the artifact exists, which is when the
+      // revisit actually means something.
+      const deferred: string[] = [];
+      const openNow: string[] = [];
+      for (const item of affects) {
+        const target = classifyAffectsTarget(item);
+        if (target && !affectsTargetExists(target, ctx.repoRoot, ctx.config)) deferred.push(item);
+        else openNow.push(item);
+      }
+      await saveConstraint(ctx.repoRoot, key, {
+        ...(args.min !== undefined ? { min: args.min as number } : {}),
+        ...(args.max !== undefined ? { max: args.max as number } : {}),
+        ...(args.forbidden !== undefined ? { forbidden: args.forbidden as string[] } : {}),
+        ...(args.value !== undefined ? { value: args.value as string } : {}),
+        source: str(args, 'source'),
+        affects,
+        ...(deferred.length ? { deferred } : {}),
+      });
+      ctx.ledger.onConstraintChange(key, openNow);
+      ctx.ledger.clear('constraint-dual-write', key);
+      const parts = [`constraint ${key} recorded`];
+      parts.push(`revisit obligations opened for: ${openNow.join(', ') || '(none)'}`);
+      if (deferred.length) {
+        parts.push(
+          `deferred until the target artifact exists (no resolve_affected needed now): ${deferred.join(', ')}`,
+        );
+      }
+      return parts.join('; ');
+    },
+  },
+  {
+    schema: {
+      name: 'resolve_affected',
+      description:
+        'Explicitly resolve affects-revisit obligations: state whether each affected item changed or why no change is needed. Pass resolutions[] to clear many in one call, or the single constraint_key/item/resolution form.',
+      parameters: {
+        type: 'object',
+        properties: {
+          constraint_key: { type: 'string' },
+          item: { type: 'string' },
+          resolution: { type: 'string', description: '"changed: ..." or "no change needed: <reason>"' },
+          resolutions: {
+            type: 'array',
+            description: 'batch form: resolve many obligations in one call',
+            items: {
+              type: 'object',
+              properties: {
+                constraint_key: { type: 'string' },
+                item: { type: 'string' },
+                resolution: { type: 'string' },
+              },
+              required: ['constraint_key', 'item', 'resolution'],
+            },
+          },
+        },
+        required: [],
+      },
+    },
+    requiresUnlock: true,
+    handler: async (ctx, args) => {
+      // An item that matches nothing must not read as success: the model would
+      // move on believing the obligation closed, and only find out at finish.
+      const resolveOne = (constraintKey: string, item: string, resolution: string): string => {
+        const detail = `${constraintKey} affects ${item}`;
+        if (!ctx.ledger.clear('affects-revisit', detail)) {
+          const open = ctx.ledger.openOfKind('affects-revisit');
+          if (!open.length) return `error: no open affects-revisit obligation matches "${detail}"`;
+          return [
+            `error: no open affects-revisit obligation matches "${detail}".`,
+            'Match these exactly:',
+            ...open.map((o) => `  - ${o.detail}`),
+          ].join('\n');
+        }
+        ctx.decisions.push(`[affects] ${detail}: ${resolution}`);
+        return `resolved: ${detail}`;
+      };
+
+      const batch = args.resolutions;
+      if (Array.isArray(batch) && batch.length) {
+        // Entries resolve independently: one bad key must not waste the call.
+        return batch
+          .map((entry, i) => {
+            const e = entry as Record<string, unknown>;
+            if (typeof e?.constraint_key !== 'string' || typeof e?.item !== 'string' || typeof e?.resolution !== 'string') {
+              return `error: resolutions[${i}] needs string constraint_key, item, and resolution`;
+            }
+            return resolveOne(e.constraint_key, e.item, e.resolution);
+          })
+          .join('\n');
+      }
+      if (typeof args.constraint_key === 'string' && typeof args.item === 'string' && typeof args.resolution === 'string') {
+        return resolveOne(args.constraint_key, args.item, args.resolution);
+      }
+      return 'error: pass either resolutions: [{constraint_key, item, resolution}, ...] or the single form constraint_key + item + resolution';
+    },
+  },
+  {
+    schema: {
+      name: 'record_decision',
+      description:
+        'Append a non-trivial decision to docs/DECISIONS.md: what was decided, the one-line why, and what it affects.',
+      parameters: {
+        type: 'object',
+        properties: {
+          decision: { type: 'string' },
+          rationale: { type: 'string' },
+          affects: { type: 'string', description: 'refdes/nets/docs affected' },
+        },
+        required: ['decision', 'rationale'],
+      },
+    },
+    requiresUnlock: true,
+    handler: async (ctx, args) => {
+      const corrupt = corruptionError({ decision: args.decision, rationale: args.rationale, affects: args.affects });
+      if (corrupt) return corrupt;
+      const decision = str(args, 'decision');
+      const rationale = str(args, 'rationale');
+      const affects = (args.affects as string | undefined) ?? '';
+      const date = new Date().toISOString().slice(0, 10);
+      const entry = `- ${date} [run ${ctx.runId}] ${decision} | why: ${rationale}${affects ? ` | affects: ${affects}` : ''}`;
+      const p = path.join(ctx.repoRoot, ctx.config.docs, 'DECISIONS.md');
+      await appendFile(p, entry + '\n', 'utf8');
+      ctx.decisions.push(`${decision} | why: ${rationale}`);
+      ctx.filesTouched.add(path.join(ctx.config.docs, 'DECISIONS.md'));
+      return 'decision recorded';
+    },
+  },
+  {
+    schema: {
+      name: 'finish',
+      description:
+        'End the run. outcome "done" requires all verification gates and sync obligations to be satisfied; outcome "refuse" ends without edits, citing the violated budget/constraint in summary.',
+      parameters: {
+        type: 'object',
+        properties: {
+          outcome: { type: 'string', enum: ['done', 'refuse'] },
+          summary: { type: 'string' },
+        },
+        required: ['outcome', 'summary'],
+      },
+    },
+    requiresUnlock: false,
+    handler: async (ctx, args) => {
+      const outcome = str(args, 'outcome') as 'done' | 'refuse';
+      const summary = str(args, 'summary');
+      if (outcome === 'refuse') {
+        ctx.finishRequest = { outcome, summary };
+        return 'refusal recorded; run will end';
+      }
+      const problems: string[] = [];
+      const touchedKicad = [...ctx.filesTouched].some((f) => isKicadFile(f));
+      if (touchedKicad) {
+        if (!ctx.lastErc?.ok) problems.push('ERC has not passed since the last schematic edit (run run_erc)');
+        const touchedPcb = [...ctx.filesTouched].some((f) => f.endsWith('.kicad_pcb'));
+        if (touchedPcb && !ctx.lastDrc?.ok) problems.push('DRC has not passed since the last board edit (run run_drc)');
+      }
+      // the changelog obligation is cleared by the commit path itself
+      const blocking = ctx.ledger.openObligations.filter((o) => o.kind !== 'changelog');
+      if (blocking.length) {
+        problems.push('open sync obligations:\n' + blocking.map((o) => `  - [${o.kind}] ${o.detail}`).join('\n'));
+      }
+      if (problems.length) {
+        return `cannot finish yet:\n${problems.map((p) => `- ${p}`).join('\n')}`;
+      }
+      ctx.finishRequest = { outcome, summary };
+      return 'all gates satisfied; run will commit';
+    },
+  },
+];
+

--- a/src/capabilities/helpers.ts
+++ b/src/capabilities/helpers.ts
@@ -1,0 +1,37 @@
+import { isKicadFile } from '../util/paths.js';
+import type { RunContext } from '../agent/context.js';
+
+export const str = (args: Record<string, unknown>, key: string): string => {
+  const v = args[key];
+  if (typeof v !== 'string' || v === '') throw new Error(`missing required string arg "${key}"`);
+  return v;
+};
+
+// U+FFFD (the Unicode replacement character) is what a byte sequence becomes
+// when UTF-8 decoding fails — most often a multibyte glyph (Ω, µ, ±, °) split
+// across a streaming chunk boundary and decoded per-chunk upstream in the
+// provider SDK (I2). It never appears in a legitimately authored PCB doc, so
+// its presence in a content-bearing tool arg means the value arrived corrupted.
+// Reject the call before it lands on disk so the model re-emits; the corruption
+// is nondeterministic (it depends on where a chunk boundary fell), so the retry
+// almost always comes through clean — far cheaper than shipping a mangled value
+// like "5.1kΩ" → "5.1k�" into DECISIONS.md and only noticing on review.
+const REPLACEMENT_CHAR = '�';
+export function corruptionError(fields: Record<string, unknown>): string | null {
+  const bad = Object.entries(fields)
+    .filter(([, v]) => typeof v === 'string' && v.includes(REPLACEMENT_CHAR))
+    .map(([k]) => k);
+  if (!bad.length) return null;
+  return `rejected: the ${bad.join(', ')} value contains U+FFFD (�), the replacement character that signals a UTF-8 decoding error — a special character (e.g. Ω, µ, ±, °) was likely mangled in transit. Re-send this exact call with the intended character written correctly, or spell it in ASCII (e.g. "ohm", "uF", "+/-", "deg").`;
+}
+
+export function markTouched(ctx: RunContext, rel: string): void {
+  ctx.filesTouched.add(rel);
+  if (isKicadFile(rel)) {
+    ctx.ledger.onKicadEdit(rel);
+    if (rel.endsWith('.kicad_sch')) ctx.lastErc = null;
+    if (rel.endsWith('.kicad_pcb')) ctx.lastDrc = null;
+  } else if (rel.endsWith('.md')) {
+    ctx.ledger.onDocEdit(rel);
+  }
+}

--- a/src/capabilities/index.ts
+++ b/src/capabilities/index.ts
@@ -1,0 +1,48 @@
+import { textResult, type ViewHint } from '../agent/envelope.js';
+import { defineTool, type CatalogEntry, type CatalogTool } from './define.js';
+import { HANDLERS } from './handlers.js';
+import generateReport from './skills/generate-report.js';
+
+export type { CatalogEntry, CatalogSkill, CatalogTool } from './define.js';
+export { defineTool, defineSkill } from './define.js';
+
+const HINT: Record<string, ViewHint> = {
+  read_file: 'query',
+  search: 'query',
+  list_symbols: 'query',
+  list_nets: 'query',
+  propose_change: 'mutation',
+  validate_change: 'diagnostic',
+  edit_file: 'mutation',
+  write_file: 'mutation',
+  run_erc: 'diagnostic',
+  search_symbols: 'query',
+  symbol_pins: 'query',
+  verify_symbols: 'diagnostic',
+  draft_schematic: 'mutation',
+  score_schematic: 'diagnostic',
+  check_legibility: 'diagnostic',
+  run_drc: 'diagnostic',
+  export_svg: 'export',
+  export_outputs: 'export',
+  check_drift: 'diagnostic',
+  record_constraint: 'mutation',
+  resolve_affected: 'mutation',
+  record_decision: 'mutation',
+  finish: 'diagnostic',
+};
+
+function wrap(def: (typeof HANDLERS)[number]): CatalogTool {
+  const viewHint = HINT[def.schema.name];
+  if (!viewHint) throw new Error(`missing viewHint for ${def.schema.name}`);
+  return defineTool({
+    schema: def.schema,
+    version: 1,
+    viewHint,
+    gate: def.requiresUnlock ? (ctx) => ctx.editsUnlocked : () => true,
+    handler: async (ctx, args) => textResult(await def.handler(ctx, args), viewHint),
+  });
+}
+
+/** Tools from HANDLERS + every skill module imported below (conformance checks skills/). */
+export const catalog: CatalogEntry[] = [...HANDLERS.map(wrap), generateReport];

--- a/src/capabilities/index.ts
+++ b/src/capabilities/index.ts
@@ -1,4 +1,4 @@
-import { textResult, type ViewHint } from '../agent/envelope.js';
+import { outcomeResult, textResult, type ViewHint } from '../agent/envelope.js';
 import { defineTool, type CatalogEntry, type CatalogTool } from './define.js';
 import { HANDLERS } from './handlers.js';
 import generateReport from './skills/generate-report.js';
@@ -40,7 +40,12 @@ function wrap(def: (typeof HANDLERS)[number]): CatalogTool {
     version: 1,
     viewHint,
     gate: def.requiresUnlock ? (ctx) => ctx.editsUnlocked : () => true,
-    handler: async (ctx, args) => textResult(await def.handler(ctx, args), viewHint),
+    handler: async (ctx, args) => {
+      const result = await def.handler(ctx, args);
+      return typeof result === 'string'
+        ? textResult(result, viewHint)
+        : outcomeResult(result.text, result.ok, viewHint);
+    },
   });
 }
 

--- a/src/capabilities/skills/generate-report.ts
+++ b/src/capabilities/skills/generate-report.ts
@@ -1,0 +1,25 @@
+import { defineSkill } from '../define.js';
+
+export default defineSkill({
+  schema: {
+    name: 'generate_report',
+    description:
+      'Read-only report of the current design: ERC, DRC (if a board exists), drift, nets, and an optional SVG path. Does not edit files.',
+    parameters: {
+      type: 'object',
+      properties: { scope: { type: 'string', enum: ['power', 'all'], description: 'Report scope (default all)' } },
+      required: [],
+    },
+  },
+  version: 1,
+  viewHint: 'diagnostic',
+  tools: ['read_file', 'search', 'list_nets', 'run_erc', 'run_drc', 'export_svg', 'check_drift'],
+  maxTurns: 8,
+  prompt: (_ctx, args) => `You are generating a read-only design report (scope: ${args.scope === 'power' ? 'power' : 'all'}).
+Call the available tools to gather ERC, DRC (only if a board is configured; otherwise skip), drift, and the net list. Optionally export an SVG of the schematic.
+Do not edit any file. Do not call finish. When you have those results, stop calling tools.`,
+  isComplete: (ctx) =>
+    (!ctx.config.schematic || ctx.lastErc !== null) &&
+    (!ctx.config.board || ctx.lastDrc !== null) &&
+    (!ctx.config.schematic || ctx.lastDrift != null),
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -311,6 +311,55 @@ program
     },
   );
 
+const skillCmd = program.command('skill').description('run a registered skill (nested tool loop; no git commit)');
+
+skillCmd
+  .command('list')
+  .description('list registered skills (LLM-free, network-free)')
+  .action(async () => {
+    const repo = repoOf(program.opts());
+    try {
+      const { listSkills } = await import('./commands/skill.js');
+      const skills = await listSkills(repo);
+      if (program.opts().json) console.log(JSON.stringify(skills, null, 2));
+      else {
+        for (const s of skills) {
+          console.log(`${s.available ? '·' : '×'} ${s.name.replaceAll('_', '-')}  ${s.description.split('\n')[0]}`);
+        }
+      }
+      process.exit(0);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+skillCmd
+  .command('run')
+  .description('run a skill by name (generate-report)')
+  .argument('<name>', 'skill name (kebab or underscore)')
+  .option('--model <model>', 'codex | cursor | gpt-5 | claude | claude-code | compat:<id>')
+  .option('--scope <scope>', 'generate-report scope: power | all', 'all')
+  .action(async (name: string, opts: { model?: string; scope?: string }) => {
+    const repo = repoOf(program.opts());
+    const json = Boolean(program.opts().json);
+    try {
+      const { runSkill, providerForSkillRun, formatSkillEnvelope } = await import('./commands/skill.js');
+      const { provider } = await providerForSkillRun(repo, opts.model);
+      const result = await runSkill({
+        repoRoot: repo,
+        name,
+        args: { scope: opts.scope === 'power' ? 'power' : 'all' },
+        provider,
+      });
+      console.log(formatSkillEnvelope(result, json));
+      process.exit(result.ok ? 0 : 1);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
 program
   .command('sync')
   .description('verify the whole design state for inconsistencies and resolve drift')

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -1,7 +1,7 @@
 import { loadConfig, resolveModel } from '../config.js';
 import { flatten, type ToolResult } from '../agent/envelope.js';
 import { makeProvider } from '../agent/loop.js';
-import { registry, runSkillSubRun, type RunContext } from '../agent/tools.js';
+import { dispatchToolResult, registry, type RunContext } from '../agent/tools.js';
 import type { Provider } from '../agent/types.js';
 import { Transcript } from '../agent/transcript.js';
 import { ObligationsLedger } from '../agent/ledger.js';
@@ -18,7 +18,7 @@ export function catalogNameFromCli(name: string): string {
 }
 
 export async function listSkills(repoRoot: string): Promise<{ name: string; available: boolean; description: string }[]> {
-  const ctx = await minimalCtx(repoRoot);
+  const ctx = await minimalCtx(repoRoot, false);
   const listed = new Set(registry.list(ctx).map((e) => e.name));
   return registry.skills().map((s) => ({
     name: s.name,
@@ -40,7 +40,7 @@ export async function runSkill(opts: {
   if (!registry.list(ctx).some((e) => e.name === catalogName)) {
     throw new SkillCliError(`skill "${opts.name}" is not available in this repo`);
   }
-  return runSkillSubRun({ ctx, skill: entry, args: opts.args ?? {}, provider: opts.provider });
+  return dispatchToolResult(ctx, entry.name, opts.args ?? {}, { provider: opts.provider });
 }
 
 export async function providerForSkillRun(repoRoot: string, modelFlag?: string): Promise<{ provider: Provider; model: string }> {
@@ -64,9 +64,9 @@ export function formatSkillEnvelope(result: ToolResult, json: boolean): string {
   return result.ok ? body : `error: ${body}`;
 }
 
-async function minimalCtx(repoRoot: string): Promise<RunContext> {
+async function minimalCtx(repoRoot: string, initializeTranscript = true): Promise<RunContext> {
   const transcript = new Transcript(repoRoot);
-  await transcript.init();
+  if (initializeTranscript) await transcript.init();
   return {
     repoRoot,
     config: await loadConfig(repoRoot),

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -1,0 +1,91 @@
+import { loadConfig, resolveModel } from '../config.js';
+import { flatten, type ToolResult } from '../agent/envelope.js';
+import { makeProvider } from '../agent/loop.js';
+import { registry, runSkillSubRun, type RunContext } from '../agent/tools.js';
+import type { Provider } from '../agent/types.js';
+import { Transcript } from '../agent/transcript.js';
+import { ObligationsLedger } from '../agent/ledger.js';
+
+export class SkillCliError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SkillCliError';
+  }
+}
+
+export function catalogNameFromCli(name: string): string {
+  return name.replace(/-/g, '_');
+}
+
+export async function listSkills(repoRoot: string): Promise<{ name: string; available: boolean; description: string }[]> {
+  const ctx = await minimalCtx(repoRoot);
+  const listed = new Set(registry.list(ctx).map((e) => e.name));
+  return registry.skills().map((s) => ({
+    name: s.name,
+    available: listed.has(s.name),
+    description: s.schema.description,
+  }));
+}
+
+export async function runSkill(opts: {
+  repoRoot: string;
+  name: string;
+  args?: Record<string, unknown>;
+  provider: Provider;
+}): Promise<ToolResult> {
+  const catalogName = catalogNameFromCli(opts.name);
+  const entry = registry.get(catalogName);
+  if (!entry || entry.kind !== 'skill') throw new SkillCliError(`unknown skill "${opts.name}"`);
+  const ctx = await minimalCtx(opts.repoRoot);
+  if (!registry.list(ctx).some((e) => e.name === catalogName)) {
+    throw new SkillCliError(`skill "${opts.name}" is not available in this repo`);
+  }
+  return runSkillSubRun({ ctx, skill: entry, args: opts.args ?? {}, provider: opts.provider });
+}
+
+export async function providerForSkillRun(repoRoot: string, modelFlag?: string): Promise<{ provider: Provider; model: string }> {
+  const config = await loadConfig(repoRoot);
+  try {
+    const { model } = resolveModel(modelFlag, config);
+    return { provider: await makeProvider(model), model };
+  } catch (err) {
+    const msg = (err as Error).message;
+    throw new SkillCliError(
+      msg.includes('no model') || msg.includes('API_KEY') || msg.includes('configured')
+        ? `${msg} — skill run needs OPENAI_API_KEY, ANTHROPIC_API_KEY, or --model for a saved-login provider (codex, claude-code, cursor).`
+        : msg,
+    );
+  }
+}
+
+export function formatSkillEnvelope(result: ToolResult, json: boolean): string {
+  if (json) return JSON.stringify(result, null, 2);
+  const body = flatten(result);
+  return result.ok ? body : `error: ${body}`;
+}
+
+async function minimalCtx(repoRoot: string): Promise<RunContext> {
+  const transcript = new Transcript(repoRoot);
+  await transcript.init();
+  return {
+    repoRoot,
+    config: await loadConfig(repoRoot),
+    transcript,
+    ledger: new ObligationsLedger(),
+    runId: 'skill',
+    interactive: false,
+    confirm: async () => true,
+    editsUnlocked: false,
+    changeId: null,
+    proposalValidated: false,
+    filesTouched: new Set(),
+    decisions: [],
+    lastErc: null,
+    lastDrc: null,
+    lastLegibility: null,
+    lastScore: null,
+    lastDrift: null,
+    repairCycles: 0,
+    finishRequest: null,
+  };
+}

--- a/test/budget-efficiency.test.ts
+++ b/test/budget-efficiency.test.ts
@@ -60,6 +60,8 @@ async function makeCtx(repo: string): Promise<RunContext> {
     decisions: [],
     lastErc: null,
     lastDrc: null,
+    lastLegibility: null,
+    lastScore: null,
     repairCycles: 0,
     finishRequest: null,
   };

--- a/test/capability-conformance.test.ts
+++ b/test/capability-conformance.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { catalog, defineSkill } from '../src/capabilities/index.js';
 import { HANDLERS } from '../src/capabilities/handlers.js';
 import { registry } from '../src/agent/tools.js';
+import { ToolRegistry } from '../src/agent/registry.js';
 import type { RunContext } from '../src/agent/context.js';
 import { tempFixtureRepo } from './helpers.js';
 import { loadConfig } from '../src/config.js';
@@ -98,8 +99,19 @@ describe('capability conformance', () => {
       });
       expect(weak.ownGate(ctx)).toBe(true);
       expect(registry.conjunction(weak.tools, ctx)).toBe(false);
+      const isolated = new ToolRegistry([...registry.all(), weak]);
+      expect(isolated.list(ctx).map((e) => e.name)).not.toContain('smuggle_edits');
     } finally {
       await cleanup();
     }
+  });
+
+  it('constructing an isolated registry does not mutate singleton catalog entries', () => {
+    const original = registry.get('generate_report');
+    expect(original?.kind).toBe('skill');
+    if (original?.kind !== 'skill') return;
+    const gate = original.gate;
+    new ToolRegistry(registry.all());
+    expect(registry.get('generate_report')?.gate).toBe(gate);
   });
 });

--- a/test/capability-conformance.test.ts
+++ b/test/capability-conformance.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { catalog, defineSkill } from '../src/capabilities/index.js';
+import { HANDLERS } from '../src/capabilities/handlers.js';
+import { registry } from '../src/agent/tools.js';
+import type { RunContext } from '../src/agent/context.js';
+import { tempFixtureRepo } from './helpers.js';
+import { loadConfig } from '../src/config.js';
+import { Transcript } from '../src/agent/transcript.js';
+import { ObligationsLedger } from '../src/agent/ledger.js';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+async function lockedCtx(repo: string): Promise<RunContext> {
+  const transcript = new Transcript(repo);
+  await transcript.init();
+  return {
+    repoRoot: repo,
+    config: await loadConfig(repo),
+    transcript,
+    ledger: new ObligationsLedger(),
+    runId: 'conf',
+    interactive: false,
+    confirm: async () => true,
+    editsUnlocked: false,
+    changeId: null,
+    proposalValidated: false,
+    filesTouched: new Set(),
+    decisions: [],
+    lastErc: null,
+    lastDrc: null,
+    lastLegibility: null,
+    lastScore: null,
+    repairCycles: 0,
+    finishRequest: null,
+  };
+}
+
+describe('capability conformance', () => {
+  it('every registered entry is versioned with a viewHint and a unique name', () => {
+    const names = catalog.map((e) => e.name);
+    expect(new Set(names).size).toBe(names.length);
+    for (const e of catalog) {
+      expect(e.version, e.name).toBeGreaterThanOrEqual(1);
+      expect(e.viewHint, e.name).toBeTruthy();
+    }
+  });
+
+  it('catalog tools match HANDLERS and the barrel imports every skills/ file', async () => {
+    const toolNames = catalog.filter((e) => e.kind === 'tool').map((e) => e.name).sort();
+    expect(toolNames).toEqual(HANDLERS.map((h) => h.schema.name).sort());
+    const index = await readFile(path.join(ROOT, 'src/capabilities/index.ts'), 'utf8');
+    const skills = (await readdir(path.join(ROOT, 'src/capabilities/skills'))).filter((f) => f.endsWith('.ts'));
+    expect(skills.length).toBeGreaterThan(0);
+    for (const f of skills) {
+      expect(index).toContain(`./skills/${f.replace(/\.ts$/, '.js')}`);
+    }
+  });
+
+  it('every skill tool name resolves and none lists finish', () => {
+    for (const s of registry.skills()) {
+      expect(s.tools, s.name).not.toContain('finish');
+      for (const n of s.tools) {
+        const t = registry.get(n);
+        expect(t, `${s.name} → ${n}`).toBeTruthy();
+        expect(t?.kind).toBe('tool');
+      }
+    }
+  });
+
+  it('a skill effective gate is at least as strict as each declared tool', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const ctx = await lockedCtx(repo);
+      for (const s of registry.skills()) {
+        const conj = registry.conjunction(s.tools, ctx);
+        if (s.ownGate(ctx)) expect(conj, s.name).toBe(true);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a weaker declared gate is detected (conformance helper)', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const ctx = await lockedCtx(repo);
+      const weak = defineSkill({
+        schema: { name: 'smuggle_edits', description: 'test', parameters: { type: 'object', properties: {} } },
+        version: 1,
+        viewHint: 'mutation',
+        tools: ['edit_file', 'read_file'],
+        gate: () => true,
+        prompt: () => '',
+        isComplete: () => true,
+      });
+      expect(weak.ownGate(ctx)).toBe(true);
+      expect(registry.conjunction(weak.tools, ctx)).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/test/create-hardening.test.ts
+++ b/test/create-hardening.test.ts
@@ -36,6 +36,8 @@ async function makeCtx(repo: string): Promise<RunContext> {
     decisions: [],
     lastErc: null,
     lastDrc: null,
+    lastLegibility: null,
+    lastScore: null,
     repairCycles: 0,
     finishRequest: null,
   };

--- a/test/envelope.test.ts
+++ b/test/envelope.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { flatten, okResult, failResult, seal, textResult, unavailable, isRetryableToolKind } from '../src/agent/envelope.js';
+import { toolLine } from '../src/agent/theme.js';
+
+describe('ToolResult envelope', () => {
+  it('flattens success as summary plus detail', () => {
+    const r = okResult('ERC clean\n0 violations', 'diagnostic');
+    expect(r.ok).toBe(true);
+    expect(r.summary).toBe('ERC clean');
+    expect(flatten(r)).toBe('ERC clean\n0 violations');
+  });
+
+  it('flattens typed errors to the original message', () => {
+    const r = failResult('validation', 'error: search requires a non-empty regex');
+    expect(r.error?.kind).toBe('validation');
+    expect(flatten(r)).toContain('search requires');
+  });
+
+  it('unavailable preserves lock phrasing', () => {
+    const r = unavailable('edit_file', false);
+    expect(r.ok).toBe(false);
+    expect(r.error?.kind).toBe('unavailable');
+    expect(flatten(r)).toContain('not available');
+    expect(flatten(r)).toContain('unlock');
+  });
+
+  it('only exception kinds are retryable', () => {
+    expect(isRetryableToolKind('exception')).toBe(true);
+    expect(isRetryableToolKind('validation')).toBe(false);
+    expect(isRetryableToolKind('refusal')).toBe(false);
+    expect(isRetryableToolKind('unavailable')).toBe(false);
+  });
+
+  it('textResult maps error: prefixes to validation (not retried)', () => {
+    const r = textResult('error: search requires a non-empty regex in "pattern"', 'query');
+    expect(r.ok).toBe(false);
+    expect(r.error?.kind).toBe('validation');
+  });
+
+  it('redacts key-shaped tokens at construction', () => {
+    const r = okResult('token sk-abcdefghijklmnopqrstuvwxyz123456 in body', 'query', {
+      raw: 'sk-abcdefghijklmnopqrstuvwxyz123456',
+    });
+    expect(r.summary).not.toMatch(/sk-[A-Za-z0-9]{20,}/);
+    expect(JSON.stringify(r.data)).not.toMatch(/sk-[A-Za-z0-9]{20,}/);
+  });
+
+  it('redacts *_KEY env values at construction so the renderer never sees them', () => {
+    const prev = process.env.NEXAR_FAKE_KEY;
+    process.env.NEXAR_FAKE_KEY = 'nexar-secret-value-abcdefgh';
+    try {
+      const r = seal({
+        ok: true,
+        summary: 'got nexar-secret-value-abcdefgh',
+        data: { token: 'nexar-secret-value-abcdefgh' },
+        viewHint: 'query',
+      });
+      expect(r.summary).not.toContain('nexar-secret-value-abcdefgh');
+      expect(JSON.stringify(r.data)).not.toContain('nexar-secret-value-abcdefgh');
+      const line = toolLine('web_search', r.summary, r.ok);
+      expect(line).not.toContain('nexar-secret-value-abcdefgh');
+    } finally {
+      if (prev === undefined) delete process.env.NEXAR_FAKE_KEY;
+      else process.env.NEXAR_FAKE_KEY = prev;
+    }
+  });
+});

--- a/test/envelope.test.ts
+++ b/test/envelope.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { flatten, okResult, failResult, seal, textResult, unavailable, isRetryableToolKind } from '../src/agent/envelope.js';
+import {
+  flatten,
+  okResult,
+  failResult,
+  outcomeResult,
+  seal,
+  textResult,
+  unavailable,
+  isRetryableToolKind,
+} from '../src/agent/envelope.js';
 import { toolLine } from '../src/agent/theme.js';
 
 describe('ToolResult envelope', () => {
@@ -35,6 +44,33 @@ describe('ToolResult envelope', () => {
     const r = textResult('error: search requires a non-empty regex in "pattern"', 'query');
     expect(r.ok).toBe(false);
     expect(r.error?.kind).toBe('validation');
+  });
+
+  it('uses a handler-owned diagnostic outcome for the glyph and keeps failure detail', () => {
+    const r = outcomeResult(
+      'ERC: 3 violation(s)\n  error unconnected_pin: pin 2 of U1',
+      false,
+      'diagnostic',
+    );
+    expect(r.ok).toBe(false);
+    expect(flatten(r)).toContain('unconnected_pin');
+    expect(toolLine('run_erc', r.summary, r.ok)).toContain('▸');
+  });
+
+  it('keeps partial detail on an unsuccessful envelope without a typed invocation error', () => {
+    const r = seal({
+      ok: false,
+      summary: 'design report incomplete',
+      detail: 'run_erc:\nERC: clean',
+      viewHint: 'diagnostic',
+    });
+    expect(flatten(r)).toBe('design report incomplete\nrun_erc:\nERC: clean');
+  });
+
+  it('textResult maps refusal prefixes to refusal', () => {
+    const r = textResult('cannot finish yet:\n- run ERC', 'diagnostic');
+    expect(r.ok).toBe(false);
+    expect(r.error?.kind).toBe('refusal');
   });
 
   it('redacts key-shaped tokens at construction', () => {

--- a/test/gating-sync.test.ts
+++ b/test/gating-sync.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { writeFile, readFile } from 'node:fs/promises';
 import { runInit } from '../src/memory/scaffold.js';
 import { loadConfig } from '../src/config.js';
-import { availableTools, dispatchTool, type RunContext } from '../src/agent/tools.js';
+import { availableTools, dispatchTool, dispatchToolResult, registry, type RunContext } from '../src/agent/tools.js';
 import { ObligationsLedger } from '../src/agent/ledger.js';
 import { Transcript } from '../src/agent/transcript.js';
 import {
@@ -33,6 +33,8 @@ async function makeCtx(repo: string): Promise<RunContext> {
     decisions: [],
     lastErc: null,
     lastDrc: null,
+    lastLegibility: null,
+    lastScore: null,
     repairCycles: 0,
     finishRequest: null,
   };
@@ -47,12 +49,17 @@ describe('spec gating: structural edit lock (invariant 1)', () => {
       const names = (): string[] => availableTools(ctx).map((t) => t.schema.name);
       expect(names()).not.toContain('edit_file');
       expect(names()).not.toContain('write_file');
+      expect(registry.list(ctx).map((e) => e.name)).not.toContain('edit_file');
+      expect(registry.list(ctx).map((e) => e.name)).not.toContain('write_file');
       expect(names()).toContain('read_file');
       expect(names()).toContain('propose_change');
+      expect(names()).toContain('generate_report');
 
       const denied = await dispatchTool(ctx, 'edit_file', { path: 'docs/BOM.md', old_string: 'a', new_string: 'b' });
       expect(denied).toContain('not available');
       expect(denied).toContain('unlock');
+      const deniedEnv = await dispatchToolResult(ctx, 'edit_file', { path: 'docs/BOM.md', old_string: 'a', new_string: 'b' });
+      expect(deniedEnv.error?.kind).toBe('unavailable');
 
       await dispatchTool(ctx, 'propose_change', {
         id: 'test-change',

--- a/test/init-check.test.ts
+++ b/test/init-check.test.ts
@@ -167,6 +167,7 @@ describe('check is LLM-free by construction (AC-2.1)', () => {
       seen.add(file);
       const text = await readFile(file, 'utf8');
       expect(text, file).not.toMatch(/providers\/|from 'openai'|@anthropic-ai/);
+      expect(file, file).not.toMatch(/capabilities/);
       for (const m of text.matchAll(/from '(\.[^']+)\.js'/g)) {
         queue.push(path.join(path.dirname(file), m[1]!) + '.ts');
       }

--- a/test/observability.test.ts
+++ b/test/observability.test.ts
@@ -356,16 +356,16 @@ describe('--json routes progress to stderr (AC-2.4/8.9)', () => {
 describe('interactive chrome theme (AC-8.8/8.9)', () => {
   it('plain helpers emit zero SGR when color is off', () => {
     setColorEnabled(false);
-    expect(toolLine('run_erc', 'clean')).toBe('  ✓ run_erc  clean');
-    expect(toolLine('edit_file', 'replaced 1 region')).toBe('  ▸ edit_file  replaced 1 region');
+    expect(toolLine('run_erc', 'clean', true)).toBe('  ✓ run_erc  clean');
+    expect(toolLine('edit_file', 'replaced 1 region', false)).toBe('  ▸ edit_file  replaced 1 region');
     expect(stageLine('spec-seed', 'running')).toBe('stage spec-seed: running');
-    expect(toolLine('run_erc', 'clean')).not.toContain('\x1b');
+    expect(toolLine('run_erc', 'clean', true)).not.toContain('\x1b');
   });
 
   it('interactive tool lines pick ✓ for clean results when color is on', () => {
     setColorEnabled(true);
     try {
-      const line = toolLine('run_erc', 'ERC clean');
+      const line = toolLine('run_erc', 'ERC clean', true);
       expect(line).toContain('run_erc');
       expect(line).toContain('✓');
       expect(line).toContain('\x1b');

--- a/test/observability.test.ts
+++ b/test/observability.test.ts
@@ -374,6 +374,22 @@ describe('interactive chrome theme (AC-8.8/8.9)', () => {
     }
   });
 
+  it('viewHint styles the tool name: mutation reads differently from query (issue #246 Phase 0)', () => {
+    setColorEnabled(true);
+    try {
+      const mutation = toolLine('edit_file', 'replaced 1 region', true, 'mutation');
+      const query = toolLine('edit_file', 'replaced 1 region', true, 'query');
+      expect(mutation).not.toBe(query);
+      expect(mutation).toContain('edit_file');
+    } finally {
+      setColorEnabled(false);
+    }
+    // plain mode: hint changes nothing, the string contract stays byte-stable
+    expect(toolLine('edit_file', 'replaced 1 region', true, 'mutation')).toBe(
+      toolLine('edit_file', 'replaced 1 region', true, 'query'),
+    );
+  });
+
   it('makeRenderer(--plain) disables color so later stage lines stay zero-ANSI', () => {
     setColorEnabled(true);
     makeRenderer({ json: false, plain: true });

--- a/test/tool-registry.test.ts
+++ b/test/tool-registry.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from 'vitest';
+import { execa } from 'execa';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { availableTools, dispatchTool, dispatchToolResult, registry } from '../src/agent/tools.js';
+import { flatten } from '../src/agent/envelope.js';
+import { defineSkill } from '../src/capabilities/define.js';
+import { ToolRegistry } from '../src/agent/registry.js';
+import { runSkill, listSkills, catalogNameFromCli, providerForSkillRun } from '../src/commands/skill.js';
+import { parseToolCalls } from '../src/agent/providers/tool-protocol.js';
+import type { Provider, Turn } from '../src/agent/types.js';
+import { runInit } from '../src/memory/scaffold.js';
+import { loadConfig } from '../src/config.js';
+import { Transcript } from '../src/agent/transcript.js';
+import { ObligationsLedger } from '../src/agent/ledger.js';
+import type { RunContext } from '../src/agent/context.js';
+import { tempFixtureRepo } from './helpers.js';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+class ScriptedProvider implements Provider {
+  readonly name = 'scripted';
+  private i = 0;
+  constructor(private readonly turns: Turn[]) {}
+  async chat(): Promise<Turn> {
+    const t = this.turns[Math.min(this.i, this.turns.length - 1)]!;
+    this.i++;
+    return t;
+  }
+}
+
+async function makeCtx(repo: string, unlocked = false): Promise<RunContext> {
+  const transcript = new Transcript(repo);
+  await transcript.init();
+  return {
+    repoRoot: repo,
+    config: await loadConfig(repo),
+    transcript,
+    ledger: new ObligationsLedger(),
+    runId: 'reg',
+    interactive: false,
+    confirm: async () => true,
+    editsUnlocked: unlocked,
+    changeId: null,
+    proposalValidated: unlocked,
+    filesTouched: new Set(),
+    decisions: [],
+    lastErc: null,
+    lastDrc: null,
+    lastLegibility: null,
+    lastScore: null,
+    lastDrift: null,
+    repairCycles: 0,
+    finishRequest: null,
+  };
+}
+
+const reportTurn = (): Turn => ({
+  text: null,
+  toolCalls: [
+    { id: '1', name: 'run_erc', args: {} },
+    { id: '2', name: 'run_drc', args: {} },
+    { id: '3', name: 'check_drift', args: {} },
+    { id: '4', name: 'list_nets', args: {} },
+  ],
+  usage: { inputTokens: 1, outputTokens: 1 },
+});
+
+describe('tool-registry catalog', () => {
+  it('combined catalog: read tools and generate_report present, edits absent while locked', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const names = registry.list(ctx).map((e) => e.name);
+      expect(names).toContain('read_file');
+      expect(names).toContain('generate_report');
+      expect(names).not.toContain('edit_file');
+      expect(names).not.toContain('write_file');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('unknown name is unavailable; dispatch of generate_report is a skill', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const miss = await dispatchToolResult(ctx, 'not_a_tool', {});
+      expect(miss.error?.kind).toBe('unavailable');
+      const skill = registry.get('generate_report');
+      expect(skill?.kind).toBe('skill');
+      const env = await dispatchToolResult(ctx, 'generate_report', { scope: 'all' }, {
+        provider: new ScriptedProvider([reportTurn()]),
+      });
+      expect(env.detail ?? env.summary).toBeTruthy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('unlock is presence of edit tools', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      expect(availableTools(ctx).map((t) => t.name)).not.toContain('edit_file');
+      ctx.editsUnlocked = true;
+      expect(availableTools(ctx).map((t) => t.name)).toContain('edit_file');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a skill listing edit_file is absent while locked', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const smuggle = defineSkill({
+        schema: { name: 'smuggle_edits', description: 'x', parameters: { type: 'object', properties: {} } },
+        version: 1,
+        viewHint: 'mutation',
+        tools: ['edit_file', 'read_file'],
+        prompt: () => '',
+        isComplete: () => true,
+      });
+      const reg = new ToolRegistry([...registry.all(), smuggle]);
+      expect(reg.list(ctx).map((e) => e.name)).not.toContain('smuggle_edits');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('generate_report cannot write and its report is the envelope', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const skill = registry.get('generate_report');
+      expect(skill?.kind).toBe('skill');
+      if (skill?.kind !== 'skill') return;
+      expect(skill.tools).not.toContain('edit_file');
+      expect(skill.tools).not.toContain('write_file');
+      expect(skill.tools).not.toContain('propose_change');
+      expect(skill.tools).not.toContain('finish');
+      const before = await execa('git', ['rev-parse', 'HEAD'], { cwd: repo });
+      const result = await runSkill({
+        repoRoot: repo,
+        name: 'generate-report',
+        provider: new ScriptedProvider([reportTurn()]),
+      });
+      expect(result.summary.length).toBeGreaterThan(0);
+      expect(skill.tools.every((n) => !['edit_file', 'write_file'].includes(n))).toBe(true);
+      const after = await execa('git', ['rev-parse', 'HEAD'], { cwd: repo });
+      expect(after.stdout).toBe(before.stdout);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('nested skill does not set parent finishRequest', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      ctx.finishRequest = { outcome: 'done', summary: 'parent' };
+      await dispatchToolResult(ctx, 'generate_report', {}, { provider: new ScriptedProvider([reportTurn()]) });
+      expect(ctx.finishRequest).toEqual({ outcome: 'done', summary: 'parent' });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('validation results are not retried (empty search is one validation envelope)', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const r = await dispatchToolResult(ctx, 'search', { pattern: '' });
+      expect(r.error?.kind).toBe('validation');
+      expect(flatten(r)).toContain('pattern');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('off-catalog names stay prose in parseToolCalls', () => {
+    const catalog = new Set(['read_file']);
+    const parsed = parseToolCalls('```json\n{"tool":"edit_file","args":{}}\n```', () => 'id1', catalog);
+    expect(parsed.toolCalls).toEqual([]);
+  });
+
+  it('provider-facing flatten is a string', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const s = await dispatchTool(ctx, 'list_nets', {});
+      expect(typeof s).toBe('string');
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+describe('skill CLI', () => {
+  it('catalogNameFromCli maps kebab to underscore', () => {
+    expect(catalogNameFromCli('generate-report')).toBe('generate_report');
+  });
+
+  it('listSkills is LLM-free and includes generate_report', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const listed = await listSkills(repo);
+      expect(listed.some((s) => s.name === 'generate_report' && s.available)).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('unknown skill names the name', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      await expect(
+        runSkill({ repoRoot: repo, name: 'does-not-exist', provider: new ScriptedProvider([]) }),
+      ).rejects.toThrow(/does-not-exist/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('run without a key names the missing env', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    const saved = {
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+      COPPERHEAD_MODEL: process.env.COPPERHEAD_MODEL,
+    };
+    try {
+      await runInit({ repoRoot: repo });
+      delete process.env.OPENAI_API_KEY;
+      delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.COPPERHEAD_MODEL;
+      await expect(providerForSkillRun(repo)).rejects.toThrow(/API_KEY|login|no model/);
+    } finally {
+      if (saved.OPENAI_API_KEY !== undefined) process.env.OPENAI_API_KEY = saved.OPENAI_API_KEY;
+      if (saved.ANTHROPIC_API_KEY !== undefined) process.env.ANTHROPIC_API_KEY = saved.ANTHROPIC_API_KEY;
+      if (saved.COPPERHEAD_MODEL !== undefined) process.env.COPPERHEAD_MODEL = saved.COPPERHEAD_MODEL;
+      await cleanup();
+    }
+  });
+
+  it('copperhead --help lists skill', async () => {
+    const res = await execa('npx', ['tsx', 'src/cli.ts', '--help'], {
+      cwd: ROOT,
+      reject: false,
+      env: { ...process.env, NO_COLOR: '1' },
+    });
+    expect(res.stdout).toMatch(/\bskill\b/);
+  }, 60_000);
+
+  it('skill list works without API keys', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const res = await execa('npx', ['tsx', 'src/cli.ts', '--repo', repo, 'skill', 'list'], {
+        cwd: ROOT,
+        reject: false,
+        env: { NO_COLOR: '1' },
+      });
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).toMatch(/generate-report|generate_report/);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+});

--- a/test/tool-registry.test.ts
+++ b/test/tool-registry.test.ts
@@ -1,12 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import { execa } from 'execa';
+import { existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { availableTools, dispatchTool, dispatchToolResult, registry } from '../src/agent/tools.js';
+import { availableTools, dispatchTool, dispatchToolResult, registry, runSkillSubRun } from '../src/agent/tools.js';
 import { flatten } from '../src/agent/envelope.js';
 import { defineSkill } from '../src/capabilities/define.js';
 import { ToolRegistry } from '../src/agent/registry.js';
-import { runSkill, listSkills, catalogNameFromCli, providerForSkillRun } from '../src/commands/skill.js';
+import {
+  runSkill,
+  listSkills,
+  catalogNameFromCli,
+  providerForSkillRun,
+  formatSkillEnvelope,
+} from '../src/commands/skill.js';
 import { parseToolCalls } from '../src/agent/providers/tool-protocol.js';
 import type { Provider, Turn } from '../src/agent/types.js';
 import { runInit } from '../src/memory/scaffold.js';
@@ -21,8 +29,10 @@ const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
 class ScriptedProvider implements Provider {
   readonly name = 'scripted';
   private i = 0;
+  calls = 0;
   constructor(private readonly turns: Turn[]) {}
   async chat(): Promise<Turn> {
+    this.calls++;
     const t = this.turns[Math.min(this.i, this.turns.length - 1)]!;
     this.i++;
     return t;
@@ -67,6 +77,12 @@ const reportTurn = (): Turn => ({
 });
 
 describe('tool-registry catalog', () => {
+  it('exposes a positive protocol version and rejects duplicate names', () => {
+    expect(registry.protocolVersion).toBeGreaterThanOrEqual(1);
+    const first = registry.all()[0]!;
+    expect(() => new ToolRegistry([first, first])).toThrow(/duplicate catalog name/);
+  });
+
   it('combined catalog: read tools and generate_report present, edits absent while locked', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
@@ -91,10 +107,42 @@ describe('tool-registry catalog', () => {
       expect(miss.error?.kind).toBe('unavailable');
       const skill = registry.get('generate_report');
       expect(skill?.kind).toBe('skill');
+      ctx.lastErc = { ok: true, source: 'erc', violations: [] };
+      ctx.lastDrc = { ok: true, source: 'drc', violations: [] };
+      ctx.lastDrift = 'drift: clean';
+      const provider = new ScriptedProvider([reportTurn()]);
       const env = await dispatchToolResult(ctx, 'generate_report', { scope: 'all' }, {
-        provider: new ScriptedProvider([reportTurn()]),
+        provider,
       });
       expect(env.detail ?? env.summary).toBeTruthy();
+      expect(provider.calls).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a skill without a provider returns a validation envelope', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const env = await dispatchToolResult(ctx, 'generate_report', {});
+      expect(env.ok).toBe(false);
+      expect(env.error?.kind).toBe('validation');
+      expect(flatten(env)).toContain('requires a provider');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('an off-list skill tool names the real reason, not the proposal lock', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const env = await dispatchToolResult(ctx, 'edit_file', {}, { only: new Set(['read_file']) });
+      expect(flatten(env)).toContain('not part of this skill');
+      expect(flatten(env)).not.toContain('proposal validates');
     } finally {
       await cleanup();
     }
@@ -185,6 +233,20 @@ describe('tool-registry catalog', () => {
     }
   });
 
+  it('a failing diagnostic carries ok false instead of a success glyph', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      await writeFile(path.join(repo, 'docs', 'BOM.md'), '| Refdes | Value | Footprint | MPN | Rationale |\n|---|---|---|---|---|\n| R2 | wrong | x | x | x |\n');
+      const ctx = await makeCtx(repo);
+      const env = await dispatchToolResult(ctx, 'check_drift', {});
+      expect(env.ok).toBe(false);
+      expect(flatten(env)).toContain('claims');
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('a thrown 429 retries through withRetry; a plain exception surfaces once (design D10)', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
@@ -221,6 +283,147 @@ describe('tool-registry catalog', () => {
     }
   }, 20_000);
 
+  it('a provider throw inside a skill sub-run becomes an exception envelope', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const exploding: Provider = {
+        name: 'exploding',
+        async chat() {
+          throw new Error('provider 502');
+        },
+      };
+      const env = await dispatchToolResult(ctx, 'generate_report', {}, { provider: exploding });
+      expect(env.ok).toBe(false);
+      expect(env.error?.kind).toBe('exception');
+      expect(flatten(env)).toContain('provider 502');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a skill provider 429 retries with backoff and then resumes the sub-run', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      let calls = 0;
+      const skill = defineSkill({
+        schema: { name: 'retry_report', description: 'test', parameters: { type: 'object', properties: {} } },
+        version: 1,
+        viewHint: 'diagnostic',
+        tools: [],
+        maxTurns: 1,
+        prompt: () => '',
+        isComplete: () => calls >= 3,
+      });
+      const provider: Provider = {
+        name: 'rate-limited',
+        async chat() {
+          calls++;
+          if (calls < 3) throw Object.assign(new Error('rate limited'), { status: 429 });
+          return { text: 'done', toolCalls: [], usage: { inputTokens: 1, outputTokens: 1 } };
+        },
+      };
+      const env = await runSkillSubRun({ ctx, skill, args: {}, provider });
+      expect(env.ok).toBe(true);
+      expect(calls).toBe(3);
+    } finally {
+      await cleanup();
+    }
+  }, 20_000);
+
+  it('a hung skill provider is bounded by the turn timeout and becomes an envelope', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      ctx.config.turnTimeoutMs = 10;
+      let calls = 0;
+      let closes = 0;
+      const provider: Provider = {
+        name: 'hung',
+        async chat() {
+          calls++;
+          return new Promise<Turn>(() => {});
+        },
+        async close() {
+          closes++;
+        },
+      };
+      const env = await dispatchToolResult(ctx, 'generate_report', {}, { provider });
+      expect(env.ok).toBe(false);
+      expect(env.error?.kind).toBe('exception');
+      expect(flatten(env)).toContain('turn exceeded');
+      expect(calls).toBe(4);
+      expect(closes).toBe(4);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('an incomplete skill preserves partial results and repeated calls in call order', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const skill = defineSkill({
+        schema: { name: 'partial_report', description: 'test', parameters: { type: 'object', properties: {} } },
+        version: 1,
+        viewHint: 'diagnostic',
+        tools: ['list_nets'],
+        maxTurns: 1,
+        prompt: () => '',
+        isComplete: () => false,
+      });
+      const provider = new ScriptedProvider([{
+        text: null,
+        toolCalls: [
+          { id: '1', name: 'list_nets', args: {} },
+          { id: '2', name: 'list_nets', args: {} },
+        ],
+        usage: { inputTokens: 1, outputTokens: 1 },
+      }]);
+      const env = await runSkillSubRun({ ctx, skill, args: {}, provider });
+      expect(env.ok).toBe(false);
+      expect(flatten(env)).toContain('design report incomplete');
+      expect((env.detail?.match(/list_nets:/g) ?? []).length).toBe(2);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a tool-less skill turn is nudged and the next turn can complete', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const skill = defineSkill({
+        schema: { name: 'drift_report', description: 'test', parameters: { type: 'object', properties: {} } },
+        version: 1,
+        viewHint: 'diagnostic',
+        tools: ['check_drift'],
+        maxTurns: 2,
+        prompt: () => '',
+        isComplete: (runCtx) => runCtx.lastDrift != null,
+      });
+      const provider = new ScriptedProvider([
+        { text: 'thinking', toolCalls: [], usage: { inputTokens: 1, outputTokens: 1 } },
+        {
+          text: null,
+          toolCalls: [{ id: '1', name: 'check_drift', args: {} }],
+          usage: { inputTokens: 1, outputTokens: 1 },
+        },
+      ]);
+      const env = await runSkillSubRun({ ctx, skill, args: {}, provider });
+      expect(env.ok).toBe(true);
+      expect(provider.calls).toBe(2);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('off-catalog names stay prose in parseToolCalls', () => {
     const catalog = new Set(['read_file']);
     const parsed = parseToolCalls('```json\n{"tool":"edit_file","args":{}}\n```', () => 'id1', catalog);
@@ -249,11 +452,19 @@ describe('skill CLI', () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await runInit({ repoRoot: repo });
+      const runs = path.join(repo, '.copperhead', 'runs');
+      expect(existsSync(runs)).toBe(false);
       const listed = await listSkills(repo);
       expect(listed.some((s) => s.name === 'generate_report' && s.available)).toBe(true);
+      expect(existsSync(runs)).toBe(false);
     } finally {
       await cleanup();
     }
+  });
+
+  it('formats the JSON skill envelope', () => {
+    const text = formatSkillEnvelope({ ok: true, summary: 'report', viewHint: 'diagnostic' }, true);
+    expect(JSON.parse(text)).toMatchObject({ ok: true, summary: 'report' });
   });
 
   it('unknown skill names the name', async () => {
@@ -264,6 +475,24 @@ describe('skill CLI', () => {
         runSkill({ repoRoot: repo, name: 'does-not-exist', provider: new ScriptedProvider([]) }),
       ).rejects.toThrow(/does-not-exist/);
     } finally {
+      await cleanup();
+    }
+  });
+
+  it('names a registered skill that is unavailable in the current repo', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    const skill = registry.get('generate_report');
+    expect(skill?.kind).toBe('skill');
+    if (skill?.kind !== 'skill') return;
+    const gate = skill.gate;
+    try {
+      await runInit({ repoRoot: repo });
+      skill.gate = () => false;
+      await expect(
+        runSkill({ repoRoot: repo, name: 'generate-report', provider: new ScriptedProvider([]) }),
+      ).rejects.toThrow(/not available in this repo/);
+    } finally {
+      skill.gate = gate;
       await cleanup();
     }
   });
@@ -290,7 +519,7 @@ describe('skill CLI', () => {
   });
 
   it('copperhead --help lists skill', async () => {
-    const res = await execa('npx', ['tsx', 'src/cli.ts', '--help'], {
+    const res = await execa(process.execPath, ['--import', 'tsx', 'src/cli.ts', '--help'], {
       cwd: ROOT,
       reject: false,
       env: { ...process.env, NO_COLOR: '1' },
@@ -302,13 +531,40 @@ describe('skill CLI', () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       await runInit({ repoRoot: repo });
-      const res = await execa('npx', ['tsx', 'src/cli.ts', '--repo', repo, 'skill', 'list'], {
+      const res = await execa(process.execPath, ['--import', 'tsx', 'src/cli.ts', '--repo', repo, 'skill', 'list'], {
         cwd: ROOT,
         reject: false,
         env: { NO_COLOR: '1' },
       });
       expect(res.exitCode).toBe(0);
       expect(res.stdout).toMatch(/generate-report|generate_report/);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  it('CLI catch paths print friendly errors without stack traces', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const unknown = await execa(
+        process.execPath,
+        ['--import', 'tsx', 'src/cli.ts', '--repo', repo, 'skill', 'run', 'does-not-exist', '--model', 'codex'],
+        { cwd: ROOT, reject: false, env: { ...process.env, NO_COLOR: '1' } },
+      );
+      expect(unknown.exitCode).toBe(1);
+      expect(unknown.stderr).toContain('does-not-exist');
+      expect(unknown.stderr).not.toMatch(/\n\s+at /);
+
+      await writeFile(path.join(repo, '.copperhead', 'config.json'), '{not-json', 'utf8');
+      const brokenList = await execa(
+        process.execPath,
+        ['--import', 'tsx', 'src/cli.ts', '--repo', repo, 'skill', 'list'],
+        { cwd: ROOT, reject: false, env: { ...process.env, NO_COLOR: '1' } },
+      );
+      expect(brokenList.exitCode).toBe(1);
+      expect(brokenList.stderr.length).toBeGreaterThan(0);
+      expect(brokenList.stderr).not.toMatch(/\n\s+at /);
     } finally {
       await cleanup();
     }

--- a/test/tool-registry.test.ts
+++ b/test/tool-registry.test.ts
@@ -185,6 +185,42 @@ describe('tool-registry catalog', () => {
     }
   });
 
+  it('a thrown 429 retries through withRetry; a plain exception surfaces once (design D10)', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      const entry = registry.get('list_nets');
+      expect(entry?.kind).toBe('tool');
+      if (entry?.kind !== 'tool') return;
+      const orig = entry.handler;
+      try {
+        let rateLimited = 0;
+        entry.handler = async () => {
+          rateLimited++;
+          if (rateLimited < 3) throw Object.assign(new Error('rate limited'), { status: 429 });
+          return { ok: true, summary: 'nets: 2' };
+        };
+        const recovered = await dispatchToolResult(ctx, 'list_nets', {});
+        expect(recovered.ok).toBe(true);
+        expect(rateLimited).toBe(3);
+
+        let plain = 0;
+        entry.handler = async () => {
+          plain++;
+          throw new Error('kicad-cli exploded');
+        };
+        const failed = await dispatchToolResult(ctx, 'list_nets', {});
+        expect(failed.error?.kind).toBe('exception');
+        expect(plain).toBe(1);
+      } finally {
+        entry.handler = orig;
+      }
+    } finally {
+      await cleanup();
+    }
+  }, 20_000);
+
   it('off-catalog names stay prose in parseToolCalls', () => {
     const catalog = new Set(['read_file']);
     const parsed = parseToolCalls('```json\n{"tool":"edit_file","args":{}}\n```', () => 'id1', catalog);


### PR DESCRIPTION
## What

Adds a two-tier tool catalog (atomic tools plus skills) and a `copperhead skill` CLI. Users can run `copperhead skill list` (no LLM) and `copperhead skill run generate-report` for a read-only design report. `check`, `create` stages, and spec-gated edits are unchanged.

## Why

Closes Phase 0 of [#246](https://github.com/copperheadhq/copperhead/issues/246) (option 2 from the issue discussion). The tool system was a flat string-returning array; part-research (#41) and MCP (#40) need one registry, `gate()` predicates, versioned schemas, and structured envelopes. This PR is that frame plus one proof skill. It does not implement part-research or MCP.

## Design

One catalog, two tiers. [registry.ts](src/agent/registry.ts) `list(ctx)` applies each entry's `gate()`. Dispatch in [tools.ts](src/agent/tools.ts) runs a tool handler or a nested skill sub-run and returns one `ToolResult`. Providers still get a flattened string (same wire shape). Decisions: [design.md](openspec/changes/formalize-tool-registry/design.md) D1–D10.

Load-bearing choices:
- `gate()` replaces `requiresUnlock`. A skill's default gate is the conjunction of its tools' gates, so a skill that lists `edit_file` is absent until a proposal validates (D2, D3).
- Nested skill is a turn-loop extract, not a second `do`: shared ledger/transcript/`editsUnlocked`, no git snapshot, no commit, no `openspec archive`, `finish` not in the child catalog (D6).
- Envelope `{ ok, summary, detail?, data?, error?, viewHint? }` is sealed (redacted) at construction in [envelope.ts](src/agent/envelope.ts). [theme.ts](src/agent/theme.ts) `toolLine` uses `ok` for the glyph, not a pass/fail regex on prose (D4, D10).
- Proof skill [`generate_report`](src/capabilities/skills/generate-report.ts): read-only tools only, `maxTurns` 8, report is the envelope. [`STAGES`](src/commands/create.ts) stay in `create`.
- Atomic tools stay the [`HANDLERS`](src/capabilities/handlers.ts) table wrapped in the barrel; skills are one file each under `src/capabilities/skills/`.

Invariants: spec-gating stays absence from `registry.list(ctx)` ([gating-sync.test.ts](test/gating-sync.test.ts) keeps `"not available"` / `"unlock"` plus additive `error.kind === 'unavailable'`). Verification-gating stays on the parent `finish`. [`check.ts`](src/commands/check.ts) still imports no capability module.

## Spec / OpenSpec

Change: `formalize-tool-registry` (`openspec validate formalize-tool-registry` passes).

Delta specs: [tool-registry](openspec/changes/formalize-tool-registry/specs/tool-registry/spec.md), [spec-gating](openspec/changes/formalize-tool-registry/specs/spec-gating/spec.md), [agent-core](openspec/changes/formalize-tool-registry/specs/agent-core/spec.md), [cli-surface](openspec/changes/formalize-tool-registry/specs/cli-surface/spec.md), [safety-rails](openspec/changes/formalize-tool-registry/specs/safety-rails/spec.md).

Main spec: [SPEC.md](openspec/specs/SPEC.md) §3 (`skill list` / `skill run`) and §4.2 (`generate_report` in the catalog). AC-2.1 (check module graph excludes `src/capabilities/` and provider SDKs) and AC-4.1 (redaction, including envelope construction) are the acceptance criteria this change is responsible for.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | fail (833 pass, 4 fail, 21 skip) |
| Live-LLM (opt-in) | `COPPERHEAD_MODEL=claude-code` (`skill run`) | pass (see manual log) |

New tests (all pass): [envelope.test.ts](test/envelope.test.ts), [capability-conformance.test.ts](test/capability-conformance.test.ts), [tool-registry.test.ts](test/tool-registry.test.ts) (27 tests). Gating lock, observability glyph, and check module-graph tests also pass.

The 4 `npm test` failures are this machine's KiCad 10.0.5 `lib_symbol_mismatch` warnings on the open-key fixture (`Symbol 'R' doesn't match copy in library 'Device'`). The fixture ignores `lib_symbol_issues` but not the KiCad 10 `lib_symbol_mismatch` check, so ERC is not clean and finish/`check` AC-2.1 fail. Not caused by this PR; live-LLM agent-integration tests were skipped (no `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `COPPERHEAD_TEST_CODEX`).

`npm run docs:build` was not run.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): `edit` (temp copy of `test/fixtures/open-key`, same fixture as `./manual-tests/setup.sh edit`, then `init`)
- Commands run and outcome:

```text
$ npx tsx src/cli.ts --help
Commands include: skill    run a registered skill (nested tool loop; no git commit)

$ npx tsx src/cli.ts skill --help
Commands: list, run [options] <name>

$ npx tsx src/cli.ts --repo <edit-sandbox> skill list
· generate-report  Read-only report of the current design: ERC, DRC (if a board exists), drift, nets, and an optional SVG path. Does not edit files.

$ npx tsx src/cli.ts --json --repo <edit-sandbox> skill list
[{ "name": "generate_report", "available": true, "description": "..." }]

$ npx tsx src/cli.ts --repo <edit-sandbox> skill run banana
unknown skill "banana"
exit 1 (no stack trace)

$ env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u COPPERHEAD_MODEL npx tsx src/cli.ts --repo <edit-sandbox> skill run generate-report
no model configured: ... skill run needs OPENAI_API_KEY, ANTHROPIC_API_KEY, or --model for a saved-login provider (codex, claude-code, cursor).
exit 1 (no stack trace)

$ npx tsx src/cli.ts --repo <edit-sandbox> --plain skill run generate-report
# COPPERHEAD_MODEL=claude-code
design report
... run_erc / run_drc / check_drift output ...
exit 0
git diff -- hardware: empty (schematic/PCB untouched; no report file written)
```

## Docs

- [README.md](README.md): `skill list` / `skill run generate-report`; note that `create` stages are not yet skills
- [SPEC.md](openspec/specs/SPEC.md) §3 and §4.2 (drafted for archive)

---

## Invariant checklist

- [x] **Spec-gated in**: `edit_file`/`write_file` stay structurally absent from the agent tool list until an OpenSpec proposal validates (gated by omission, not prompt text).
- [x] **Verification-gated out**: mutations still end in ERC (and DRC when the board changed) passing, with repair up to `maxRepairCycles` then rollback to the git snapshot. Skill sub-runs cannot call `finish` or commit.
- [x] **`check`/`verify` stays LLM-free and network-free**: nothing reachable from `src/commands/check` touches a provider, an API key, or the network. Module-graph guard now also excludes `src/capabilities/`.
- [N/A] **No sexp serialization**: this PR does not touch the `src/kicad/` parser or edit path.
- [x] **Sync-obligations ledger**: post-tool-call hooks keep feeding the ledger, and commit keeps refusing while obligations are open. Nested skills share the parent ledger and cannot clear it via `finish`.
- [x] **Secrets**: transcripts and summaries redact `sk-[A-Za-z0-9_-]+` at write time; envelope `data`/`summary`/`detail` are also redacted at construction (`*_KEY`/`*_SECRET`/`*_TOKEN` env values); keys live only in env vars; `.gitignore` keeps `.env` and `.copperhead/runs/`.
- [x] **Spec coherence**: SPEC.md and the change artifacts (`proposal.md`, `design.md`, delta specs, `tasks.md`) moved together and `openspec validate formalize-tool-registry` passes.
```