### PR TITLE
fix: include examples/ in published npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "files": [
     "dist",
     "src",
+    "examples",
     "LICENSE",
     "NOTICE",
     "README.md"


### PR DESCRIPTION
## What

Adds `examples` to `package.json`'s `files` field, so it actually ships with `npm install -g copperhead`.

## Why

`copperhead demo` (no args) hardcodes its default brief as `examples/simple/usb-c-breakout.md`, resolved relative to the package's own install directory (`src/commands/demo.ts`, `DEFAULT_BRIEF`). `examples/` was never listed in `package.json`'s `files` field, so it's excluded from every published tarball, and a fresh `npm install -g copperhead` fails immediately on the plain `copperhead demo` flow:

```
demo brief missing at .../node_modules/copperhead/examples/simple/usb-c-breakout.md; reinstall copperhead or run from a full checkout
```

This isn't a broken install; it reproduces on a correct, fresh `npm install -g copperhead` every time, because the package itself never contained the file. (Scope note: `copperhead create --brief <path>` is not affected by this bug in normal use — that flag resolves relative to the user's own working directory, not the package install directory, so it only touches `examples/` if a user is running from inside a full copperhead source checkout, which is a different scenario from the global-install one this PR fixes.)

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | 813 passed, 11 failed (pre-existing, unrelated: `kicad-cli-resolve.test.ts` PATH-mocking tests conflict with a real `kicad-cli` present on this machine's PATH; same failures reproduce on `main` with this change reverted), 21 skipped |

No new or changed tests: this is a packaging manifest fix with no behavior for tests to cover.

### Manual test log

- Sandbox variant used: n/a (packaging-only change, not exercised through the agent loop)
- Commands run and outcome:

```text
$ npm pack --pack-destination /tmp/pkg-fix-test
$ tar tzf /tmp/pkg-fix-test/copperhead-0.10.0.tgz | grep "^package/examples/" | wc -l
13
# (0 before this change)

$ npm i -g /tmp/pkg-fix-test/copperhead-0.10.0.tgz
$ ls $(npm root -g)/copperhead/examples/simple/
coin-cell-led-beacon.md  rp2040-blinky.md  usb-c-breakout.md

$ cd /tmp/pkgtest-demo && git init -q
$ copperhead demo --model claude-code
  copperhead demo  USB-C power breakout
  repo   .../copperhead/demo-runs/usb-c-breakout
  brief  .../copperhead/examples/simple/usb-c-breakout.md
  scaffold ready
stage spec-seed: running
...
# no longer fails with "demo brief missing"
```

## Docs

None needed; no user-facing behavior beyond fixing what was already documented in the README's quick-start (`copperhead demo`).

---

## Invariant checklist

- [x] **Spec-gated in**: N/A, no tool-list change
- [x] **Verification-gated out**: N/A, no mutation path touched
- [x] **`check`/`verify` stays LLM-free and network-free**: N/A, not touched
- [x] **No sexp serialization**: N/A, not touched
- [x] **Sync-obligations ledger**: N/A, not touched
- [x] **Secrets**: N/A, not touched
- [x] **Spec coherence**: N/A, no spec-level behavior changed
