### PR TITLE
fix: keep demo output outside package installs

### DIFF
--- a/src/commands/demo.ts
+++ b/src/commands/demo.ts
@@ -18,7 +18,6 @@ import { runCreate } from './create.js';
 
 const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const DEFAULT_BRIEF = path.join(PKG_ROOT, 'examples/simple/usb-c-breakout.md');
-const DEFAULT_DEMO_DIR = path.join(PKG_ROOT, 'demo-runs/usb-c-breakout');
 
 export interface DemoOptions {
   model: string;
@@ -45,7 +44,9 @@ export function defaultBriefPath(): string {
 }
 
 export function defaultDemoDir(): string {
-  return process.env.COPPERHEAD_DEMO_DIR ?? DEFAULT_DEMO_DIR;
+  return (
+    process.env.COPPERHEAD_DEMO_DIR ?? path.resolve(process.cwd(), 'demo-runs/usb-c-breakout')
+  );
 }
 
 /** Marker identifying a directory scaffolded by `copperhead demo`. */

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -10,7 +10,12 @@ import {
   completeSlash,
   SLASH_COMMANDS,
 } from '../src/commands/repl.js';
-import { demoTourText, scaffoldDemoRepo, defaultBriefPath } from '../src/commands/demo.js';
+import {
+  demoTourText,
+  scaffoldDemoRepo,
+  defaultBriefPath,
+  defaultDemoDir,
+} from '../src/commands/demo.js';
 import { pickModel, selectMenu } from '../src/util/select.js';
 import {
   keySequence,
@@ -557,6 +562,27 @@ describe('session log file', () => {
 });
 
 describe('demo scaffold', () => {
+  it('defaults to the working directory and honors COPPERHEAD_DEMO_DIR', async () => {
+    const originalCwd = process.cwd();
+    const originalOverride = process.env.COPPERHEAD_DEMO_DIR;
+    const cwd = await mkdtemp(path.join(tmpdir(), 'copperhead-demo-cwd-'));
+    const override = path.join(tmpdir(), 'custom-copperhead-demo');
+
+    try {
+      delete process.env.COPPERHEAD_DEMO_DIR;
+      process.chdir(cwd);
+      expect(defaultDemoDir()).toBe(path.join(process.cwd(), 'demo-runs/usb-c-breakout'));
+
+      process.env.COPPERHEAD_DEMO_DIR = override;
+      expect(defaultDemoDir()).toBe(override);
+    } finally {
+      process.chdir(originalCwd);
+      if (originalOverride === undefined) delete process.env.COPPERHEAD_DEMO_DIR;
+      else process.env.COPPERHEAD_DEMO_DIR = originalOverride;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('creates a git repo with config ready for create', async () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'copperhead-demo-'));
     try {


### PR DESCRIPTION
## What

Makes `copperhead demo` create its default repository at `demo-runs/usb-c-breakout` under the invoking working directory instead of inside the installed npm package. `--dir` and `COPPERHEAD_DEMO_DIR` continue to take precedence.

## Why

A system-wide global install can place copperhead in a root-owned directory such as `/usr/lib/node_modules`. The previous default attempted to create `demo-runs/` there, causing `EACCES` for normal users. Even with a user-writable npm prefix, an npm update could delete demo work stored inside the package directory.

This addresses the medium follow-up finding from #262 while keeping that packaging-only PR unchanged.

## Design

`defaultDemoDir()` now resolves the documented relative default from `process.cwd()`. Package-relative resolution remains limited to the bundled demo brief. Existing directory safety checks and explicit overrides are unchanged.

## Spec / OpenSpec

No spec artifact changes are needed. `openspec/specs/SPEC.md` already documents the default as the relative path `demo-runs/usb-c-breakout/`; this fix aligns the implementation with that behavior.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Focused | `npx vitest run test/repl.test.ts` | pass, 36 tests |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | 814 passed, 11 failed, 21 skipped |
| Live-LLM (opt-in) | not keyed | skipped |

The 11 full-suite failures are pre-existing environment-dependent KiCad 10.0.6 failures. Five are PATH-mocking assertions in `kicad-cli-resolve.test.ts`; the remaining six are existing KiCad library/ERC assumptions in `draft-engine.test.ts`, `draft-reference-boards.test.ts`, and `draft-tools.test.ts`. None exercise the changed demo directory behavior.

The regression test changes the process working directory and confirms the default follows it. It also confirms `COPPERHEAD_DEMO_DIR` still wins.

### Manual test log (required)

- Sandbox variant used: create command surface, without running the live-LLM pipeline
- Commands run and outcome:

```text
$ node dist/cli.js demo --tour
What copperhead does
...
# pass: built CLI demo surface runs

$ cd /tmp/opencode
$ node --input-type=module -e "import { defaultDemoDir } from 'file:///.../dist/commands/demo.js'; console.log(defaultDemoDir())"
/private/var/.../opencode/demo-runs/usb-c-breakout
# pass: the built default follows the invoking directory

$ COPPERHEAD_DEMO_DIR=/tmp/copperhead-custom-demo node --input-type=module -e "import { defaultDemoDir } from 'file:///.../dist/commands/demo.js'; console.log(defaultDemoDir())"
/tmp/copperhead-custom-demo
# pass: the environment override still takes precedence
```

## Docs

No documentation changes needed. Existing CLI and specification docs already describe the destination as the relative path `demo-runs/usb-c-breakout`.

---

## Invariant checklist

- [x] **Spec-gated in**: N/A, no agent tool-list change
- [x] **Verification-gated out**: N/A, no KiCad mutation path changed
- [x] **`check`/`verify` stays LLM-free and network-free**: N/A, not touched
- [x] **No sexp serialization**: N/A, not touched
- [x] **Sync-obligations ledger**: N/A, not touched
- [x] **Secrets**: N/A, not touched
- [x] **Spec coherence**: verified, the implementation now matches the documented relative default
