### PR TITLE
spec(hosted-run): propose the Phase 0 seam for files, git, and artifacts

### DIFF
--- a/openspec/changes/add-hosted-run-seam/.openspec.yaml
+++ b/openspec/changes/add-hosted-run-seam/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/add-hosted-run-seam/design.md
+++ b/openspec/changes/add-hosted-run-seam/design.md
@@ -1,0 +1,77 @@
+# add-hosted-run-seam: Design
+
+## D1: the event bound is enforced where redaction already runs
+
+`Transcript.event()` (`src/agent/transcript.ts:87`) is the single point every event passes through, and it already applies `redactSecrets` there. Putting the size bound at the same call means both write-time invariants, AC-4.1 and the size bound, are enforced on one line and cannot drift apart as callers are added.
+
+The alternative, bounding at each call site, was rejected for the reason the original defect happened: `event()` has many callers across `loop.ts` and `create.ts`, and the pathological line came from one of them handing over a whole tool result. A rule enforced per caller is a rule that a new caller can forget.
+
+Order matters: redact first, then bound. Redaction can only shorten a string (`[REDACTED]` is shorter than any secret it replaces), so bounding after redaction cannot reintroduce a secret at the truncation boundary, whereas bounding first could cut a secret in half and leave an unmatchable fragment that redaction then misses.
+
+## D2: the bound is 128 KiB, chosen from measured traffic
+
+Measured over 1106 events from real `create` runs in this repository's manual-test sandboxes:
+
+| Percentile | Bytes |
+| --- | --- |
+| median | 337 |
+| p90 | 6334 |
+| p99 | 18042 |
+| p99.9 | 20581 |
+| max | 60981 |
+
+128 KiB (131072) sits at roughly twice the largest event ever observed, so no event in that corpus would be truncated, while bounding the failure case that motivated this (a line large enough to blow a one-million-token prompt) by about an order of magnitude.
+
+64 KiB was considered and rejected: at 65536 it leaves only seven percent of headroom over the observed maximum, which is close enough that an ordinary large capture would start truncating, and a bound that fires on legitimate traffic teaches readers to distrust it.
+
+The number is a named constant rather than a literal, since the hosted activity log's inline payload limit has to agree with it and the platform will want to reference one definition.
+
+## D3: truncation records what was lost, and never drops the event
+
+An over-bound event is written with its payload replaced by a marker naming the original byte count, not discarded. Two reasons.
+
+The transcript is an audit trail, and an event vanishing entirely is worse than an event arriving abbreviated: the run's history acquires a hole with nothing to indicate one exists. It is also the resume path's input, so a silently missing event is a silently different resume.
+
+Recording the original size is what makes the hosted `ArtifactRef` spill implementable later. The platform's rule is that an event over the inline limit spills its body to an artifact and keeps a reference; locally there is no artifact store, so the marker is the degenerate form of the same rule. Keeping the shape identical means the hosted path adds a location to an existing marker rather than introducing a new event shape.
+
+## D4: artifact classification is derived from version control, not declared
+
+Which outputs survive a destroyed workspace is already decided, by whether the run commits them:
+
+| Producer | Written to | In the board template's `.gitignore` | Therefore |
+| --- | --- | --- | --- |
+| `exportFab` (gerbers, drill, DXF, STEP) | `outputs/` | no | committed, reference only |
+| `export bom` | `outputs/<supplier>-bom.csv` | no | committed, reference only |
+| `exportSvg` | `.copperhead/renders/` | no (only `runs/` is ignored) | committed, reference only |
+| `Transcript` | `.copperhead/runs/<ts>/` | yes | dies with the workspace, must be stored |
+| `create` report | `.copperhead/runs/` | yes | dies with the workspace, must be stored |
+
+Stating the rule rather than enumerating a fixed list means a producer added later classifies itself, and the classification cannot drift from reality: if a directory's ignore status changes, the classification changes with it, which is the correct outcome rather than a stale table.
+
+One consequence worth stating rather than discovering later: the board template ignores `build/`, `fab/` and `gerbers/` under the comment "build and fabrication output, which is regenerated from the design", but the fab tool writes to `outputs/`, which none of those cover. Fabrication output is therefore committed today, which contradicts the template's evident intent. The rule above classifies by what actually happens, so gerbers are references. Whether that is the desired behaviour is a question for the template, not for this contract, and is raised in tasks rather than silently settled here.
+
+## D5: `location` carries its own discriminant
+
+`ArtifactRef.location` is a union of a repository coordinate and a stored-object coordinate. Narrowing it by property presence alone works in TypeScript but degrades as soon as a third backend exists, and the whole premise of freezing these types is that changing them afterwards breaks both streams. A `kind: 'repo' | 'blob'` tag inside `location`, distinct from the top-level `ArtifactRef.kind` which names the artifact's role, costs one field now and avoids a versioned type change later.
+
+The two `kind` fields are deliberately not merged. The top-level one answers what the artifact is for (`pointer`, `derived`, `log`, `manifest`), which the console filters on; the nested one answers where its bytes are, which resolution dispatches on. A `log` is always blob-backed today, but collapsing them would encode that coincidence as a constraint.
+
+## D6: `WritebackResult` includes a policy-skip state now
+
+The union distinguishes an empty diff (`nothing-to-write`) from writeback being disabled for the run (`skipped-by-policy`). Whether hosted runs can disable writeback is a platform question this repository cannot answer, so this is provisional.
+
+It is included rather than deferred because the two directions are not symmetric. Adding a state later is a cross-stream break, since stream 1 exhaustively matches the union. Carrying an unused state costs one unreachable branch. When the cost of being wrong is that asymmetric, the reversible choice wins.
+
+## D7: the layout contract names runs, not only artifacts
+
+`src/agent/runmeta.ts:108` computes `priorRuns` by listing `.copperhead/runs` and filtering out the current run id, so it treats every entry there as a run. The shared-path report at `src/commands/create.ts:736` already violates that assumption: `REPORT.md` and `report.json` sit beside the run directories and are each counted as a run, inflating `priorRuns` by two.
+
+Retention makes this sharper, because deleting expired artifacts from that directory would move the same number. The contract therefore has to state which entries are runs and which are not, so a retention policy has a rule to respect and the miscount has a definition to be fixed against.
+
+The miscount itself is not fixed here. `src/commands/create.ts:736` is currently touched by open work on the report path (#155, #149, and #251's planned change), and a fourth edit to the same lines would collide. This change states the contract that fix must satisfy and leaves the fix to whichever of those lands.
+
+## D8: retention cannot be purely time-based
+
+`.copperhead/runs/<ts>/` is simultaneously agent memory and an artifact source. The resume path reads a prior run's transcript; the same file is an artifact with a retention window. A retention policy that deletes on age alone can therefore delete an input a resume still depends on.
+
+The contract states that retention is run-state aware: an artifact belonging to a run that can still be resumed is not eligible for deletion regardless of age. The mechanism is a platform concern, but the constraint originates here, because this repository is what makes the file load-bearing.

--- a/openspec/changes/add-hosted-run-seam/proposal.md
+++ b/openspec/changes/add-hosted-run-seam/proposal.md
@@ -1,0 +1,40 @@
+# add-hosted-run-seam: Proposal
+
+## Why
+
+A hosted run destroys its workspace when it ends. Everything the run produced goes with it: the gerbers, drill, DXF and STEP written to `outputs/` (`src/agent/tools.ts:616`), the supplier BOM at `outputs/<supplier>-bom.csv` (`src/commands/export.ts:29`), the SVG renders under `.copperhead/renders/` (`src/agent/tools.ts:601`), and the transcript, summary and per-run report under `.copperhead/runs/` (`src/agent/transcript.ts:77`, `src/commands/create.ts:736`). The `/artifacts` console surface is a shell because nothing durable exists behind it (#250).
+
+Phase 0 of that stream is the part this repository owns: the contract the platform consumes. The platform cannot store, classify, or bound what a run emits until this repository states what it emits, how large an event may be, and which outputs survive in the repository versus which die with the workspace. Both streams compile against that contract, so a later change to it is a cross-stream break, which is why it lands before any storage or runner work.
+
+Two of the three obligations are already defects rather than gaps:
+
+**A transcript event has no size bound.** `Transcript.event()` (`src/agent/transcript.ts:87`) redacts and appends whatever it is handed, as one JSON line. A stage attempt has already died on this: `Prompt is too long, the request is ~1003121 tokens but this conversation is only ~403383 tokens`, because a single `transcript.jsonl` line carried an entire tool result inline. The existing clip at `src/agent/filetools.ts:95` bounds an individual search match, not an event, so it did not and could not prevent it. Measured across 1106 events from real `create` runs, the median event is 337 bytes, p99 is 18042, and the largest is 60981, so the pathological case is three orders of magnitude outside normal traffic rather than a tail of it.
+
+**Redaction has no pattern for a storage credential.** `src/util/redact.ts` carries seven patterns: `sk-`, `Bearer`, `npm_`, `gh[pousr]_`, `github_pat_`, `AIza`, `gsk_`. A shared access signature is a query string whose secret is its `sig=` value and matches none of them. This is sharper than an ordinary redaction gap because the transcript is itself an artifact this stream uploads: an unredacted signature becomes a live download credential stored inside a downloadable object. The Git side is already covered, since a GitHub App installation token is `ghs_` and `gh[pousr]_[A-Za-z0-9]{36,}` matches it, including inside an `x-access-token:...@github.com` clone URL.
+
+## What Changes
+
+- **A per-event byte bound on the transcript, with a spill rule.** `Transcript.event()` gains a cap enforced at the same write that already applies redaction, so the size bound and AC-4.1 are enforced in one place and cannot diverge. An event over the bound is written with its payload replaced by a truncation marker recording the original size, which is the local form of the `ArtifactRef` spill the hosted activity log needs.
+- **Redaction widens from model and forge credentials to storage credentials.** A shared-access-signature pattern joins the seven existing ones, tested in `test/safety.test.ts` beside them, so a future storage backend with a differently shaped credential fails a test rather than a transcript.
+- **The `.copperhead/` layout becomes a stated contract**, naming which entries are runs and which are outputs. This is load-bearing beyond documentation: `src/agent/runmeta.ts:108` derives `priorRuns` by listing `.copperhead/runs` and filtering the current run id, so any entry added to or removed from that directory silently moves a number the agent reads.
+- **An artifact classification rule, derived rather than invented.** Whether an output survives is already decided by version control: an output the run commits survives in the repository and needs only a reference, while an output excluded by `.gitignore` dies with the workspace and must be stored. The contract states the rule and the classification each producer falls under, so the platform is not left to guess per file.
+- **The seam types are stated as this repository's obligations** (`Workspace`, `WritebackResult`, `ArtifactRef`), including the `location` discriminant and the writeback states, so both streams have one definition to build against.
+
+## Capabilities
+
+### Added Capabilities
+
+- `hosted-run-seam`: the artifact classification rule, the `.copperhead/` on-disk layout contract, and the seam types a hosted runner consumes.
+
+### Modified Capabilities
+
+- `agent-core`: transcript events gain a byte bound and a truncation rule; write-time redaction widens to storage credentials.
+
+## Impact
+
+- **Code**: `src/agent/transcript.ts` (the event bound and truncation marker), `src/util/redact.ts` (the storage-credential pattern).
+- **Tests**: `test/safety.test.ts` gains the storage-credential case beside the seven existing per-pattern cases, and a case asserting an over-bound event is truncated with its original size recorded rather than dropped.
+- **Docs**: `.copperhead/README.md` states the layout contract.
+- **Unchanged contracts**: nothing here is reachable from `src/commands/check`, so `check`/`verify` stays LLM-free and network-free (AC-2.1); the edit-tool gate and the verification gate are untouched, and artifact handling stays post-verification so it never becomes a route to "done" without ERC and DRC.
+- **Not in scope**: blob storage, the artifact metadata table and its row-level security, signature minting, console download, and every runner-side concern (clone, `GIT_ASKPASS`, writeback). Those are Phases 1 and 2 and land in the platform repository against the contract this change fixes.
+- **Deliberately excluded**: the board template shipping `.copperhead/config.json` with `docsDir` and `ecadDir` while `loadConfig` (`src/config.ts:113-115`) reads `docs`, `schematic` and `board`, so both keys are silently ignored. It is a live defect for template users today and independent of this stream, so it is filed separately rather than carried here.

--- a/openspec/changes/add-hosted-run-seam/specs/agent-core/spec.md
+++ b/openspec/changes/add-hosted-run-seam/specs/agent-core/spec.md
@@ -1,0 +1,46 @@
+# agent-core — Delta Spec
+
+## MODIFIED Requirements
+
+### Requirement: Transcript events are bounded at write time
+
+`Transcript.event()` SHALL enforce a maximum serialized size on every event it writes, at the same call that applies write-time redaction, so the size bound and AC-4.1 are enforced in one place and cannot diverge as callers are added.
+
+The bound SHALL be 131072 bytes (128 KiB), expressed as a named constant rather than a literal, since the hosted activity log's inline payload limit has to agree with it. Redaction SHALL be applied before the bound is evaluated, so a truncation boundary can never split a secret into an unmatchable fragment.
+
+An event exceeding the bound SHALL be written with its payload replaced by a truncation marker recording the original byte count. It SHALL NOT be dropped: the transcript is an audit trail and a resume input, so an absent event is a silent hole in both. The marker is the local form of the hosted `ArtifactRef` spill, so the hosted path adds a location to the same shape rather than introducing a second one.
+
+#### Scenario: An oversized event is truncated, not dropped
+
+- **WHEN** a tool result large enough to exceed the bound is passed to `event()`
+- **THEN** the transcript gains one line for that event, its payload replaced by a marker naming the original byte count, and the run continues
+
+#### Scenario: Ordinary events are untouched
+
+- **WHEN** an event of typical size is written (measured traffic: median 337 bytes, p99 18042, maximum observed 60981)
+- **THEN** it is written whole, since the bound sits at roughly twice the largest event observed in real runs
+
+#### Scenario: A secret spanning the boundary is still redacted
+
+- **WHEN** an event carries a credential positioned so that truncation would fall inside it
+- **THEN** redaction has already replaced the credential before the bound is evaluated, so no fragment of it reaches the transcript
+
+### Requirement: Write-time redaction covers storage credentials
+
+The redaction patterns applied at transcript and summary write time (AC-4.1) SHALL include a shared access signature alongside the existing model, registry and forge credential patterns.
+
+This is load-bearing rather than defensive: the transcript is itself an artifact the hosted path uploads, so an unredacted signature becomes a live download credential stored inside a downloadable object. A signature is a query string whose secret is its `sig=` value and matches none of the seven existing patterns.
+
+Git credentials are already covered and SHALL remain so: a GitHub App installation token is `ghs_`, which the existing `gh[pousr]_` pattern matches, including when embedded in an `x-access-token:...@github.com` clone URL.
+
+Each credential shape SHALL be covered by its own test case, so a future storage backend with a differently shaped credential fails a test rather than a transcript.
+
+#### Scenario: A signature in a transcript is redacted
+
+- **WHEN** an event or summary contains a URL carrying a shared access signature
+- **THEN** the signature is replaced before the line is written, and the artifact that transcript becomes carries no usable credential
+
+#### Scenario: An installation token in a clone URL is redacted
+
+- **WHEN** writeback output quoting `https://x-access-token:<token>@github.com/...` reaches a transcript
+- **THEN** the token is replaced by the existing forge pattern, with no new pattern required

--- a/openspec/changes/add-hosted-run-seam/specs/hosted-run-seam/spec.md
+++ b/openspec/changes/add-hosted-run-seam/specs/hosted-run-seam/spec.md
@@ -1,0 +1,75 @@
+# hosted-run-seam — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Artifact classification is derived from version control
+
+Every output a run produces SHALL be classified by whether the run commits it, not by an enumerated list.
+
+An output the run commits survives in the repository after the workspace is destroyed, so the platform SHALL store a reference to it (path plus the commit the writeback produced) and SHALL NOT copy its bytes. An output excluded by `.gitignore` does not survive, so the platform SHALL store its bytes.
+
+Deriving the rule rather than fixing a list means a producer added later classifies itself, and the classification cannot go stale: if a directory's ignore status changes, the classification follows.
+
+Under this rule, with the current producers and the board template's `.gitignore`:
+
+| Producer | Written to | Classification |
+| --- | --- | --- |
+| `exportFab` (gerbers, drill, DXF, STEP) | `outputs/` | reference |
+| `export bom` | `outputs/<supplier>-bom.csv` | reference |
+| `exportSvg` | `.copperhead/renders/` | reference |
+| `Transcript` (JSONL, `summary.md`) | `.copperhead/runs/<ts>/` | stored |
+| `create` report (`REPORT.md`, `report.json`) | `.copperhead/runs/` | stored |
+
+#### Scenario: A committed output needs no copy
+
+- **WHEN** a run writes gerbers to `outputs/` and the writeback commits them
+- **THEN** the artifact record holds the repository path and the commit, and no bytes are copied to storage
+
+#### Scenario: An ignored output must be stored
+
+- **WHEN** a run writes a transcript under `.copperhead/runs/`, which `.gitignore` excludes
+- **THEN** the artifact record holds a stored-object location, because the file does not survive the workspace
+
+### Requirement: The `.copperhead/` layout is a stated contract
+
+The on-disk layout of `.copperhead/` SHALL be documented as a contract naming which entries are runs and which are not.
+
+This is load-bearing rather than descriptive. `src/agent/runmeta.ts` derives `priorRuns` by listing `.copperhead/runs` and filtering out the current run id, so it treats every entry there as a run. Any entry added to or removed from that directory therefore moves a number the agent reads, whether or not the writer intended to.
+
+The contract SHALL state that `.copperhead/runs/<run-id>/` entries are runs, and that any sibling entry is not, so a retention policy has a rule to respect and the existing miscount has a definition to be fixed against.
+
+#### Scenario: A non-run entry is not counted as a run
+
+- **WHEN** a file that is not a run directory exists beside the run directories
+- **THEN** the contract identifies it as a non-run entry, and `priorRuns` counts only run directories
+
+### Requirement: Artifact retention is run-state aware
+
+Retention SHALL NOT be purely time-based. An artifact belonging to a run that can still be resumed SHALL NOT be eligible for deletion regardless of age.
+
+`.copperhead/runs/<ts>/` is simultaneously agent memory and an artifact source: the resume path reads a prior run's transcript, and the same file is an artifact with a retention window. Deleting on age alone can therefore remove an input a resume depends on.
+
+The mechanism is a platform concern; the constraint originates here, because this repository is what makes the file load-bearing.
+
+#### Scenario: A resumable run's transcript survives its retention window
+
+- **WHEN** an artifact reaches its retention age while the run it belongs to can still be resumed
+- **THEN** it is retained, and the resume reads the same transcript it would have read before
+
+### Requirement: The seam types are versioned and carry their own discriminants
+
+The types a hosted runner consumes, `Workspace`, `WritebackResult` and `ArtifactRef`, SHALL be versioned from their first definition, since both streams compile against them and a later change is a cross-stream break.
+
+`ArtifactRef.location` SHALL carry a `kind: 'repo' | 'blob'` discriminant rather than relying on property presence for narrowing. This is distinct from the top-level `ArtifactRef.kind`, which names the artifact's role (`pointer`, `derived`, `log`, `manifest`) and is what the console filters on; the nested discriminant names where the bytes are and is what resolution dispatches on. The two SHALL NOT be merged, since a role that is blob-backed today would otherwise encode that coincidence as a constraint.
+
+`WritebackResult` SHALL distinguish an empty diff from writeback being disabled for the run. Whether hosted runs can disable writeback is a platform question, so this state is provisional; it is included rather than deferred because adding a state later breaks stream 1's exhaustive match, while an unused state costs one unreachable branch.
+
+#### Scenario: A reference artifact resolves without ambiguity
+
+- **WHEN** a consumer receives an `ArtifactRef` whose `location.kind` is `repo`
+- **THEN** it resolves the path at the recorded commit, with no inference from which properties are present
+
+#### Scenario: A skipped writeback is distinguishable from an empty one
+
+- **WHEN** a run completes with writeback disabled by policy
+- **THEN** the result names that state, and is not reported as having had nothing to write

--- a/openspec/changes/add-hosted-run-seam/tasks.md
+++ b/openspec/changes/add-hosted-run-seam/tasks.md
@@ -1,0 +1,38 @@
+# add-hosted-run-seam: Tasks
+
+## 1. Transcript event bound
+
+- [ ] 1.1 Add a named `MAX_EVENT_BYTES` constant (131072) to `src/agent/transcript.ts`, chosen against measured traffic (1106 real events: median 337, p99 18042, max 60981) so no observed event truncates
+- [ ] 1.2 Enforce the bound inside `Transcript.event()`, after `redactSecrets` and before the append, so redaction cannot be split at the truncation boundary and both write-time invariants sit on one line
+- [ ] 1.3 Replace an over-bound payload with a truncation marker recording the original byte count; never drop the event, since the transcript is both an audit trail and a resume input
+- [ ] 1.4 Tests in `test/safety.test.ts`: an oversized event yields one line carrying the original size, an ordinary event is written whole, and a credential positioned across the boundary is still fully redacted
+
+## 2. Storage-credential redaction
+
+- [ ] 2.1 Add a shared-access-signature pattern to `src/util/redact.ts` beside the seven existing patterns
+- [ ] 2.2 Test it in `test/safety.test.ts`'s `secret redaction (AC-4.1)` block, one case per shape as the existing seven are, so a future storage backend with a different credential shape fails a test rather than a transcript
+- [ ] 2.3 Regression case asserting a GitHub App installation token inside an `x-access-token:...@github.com` clone URL is redacted by the existing `gh[pousr]_` pattern, so the Git side is covered by assertion rather than by assumption
+
+## 3. The `.copperhead/` layout contract
+
+- [ ] 3.1 State the layout in `.copperhead/README.md`: which entries are runs, which are not, and which are artifact sources
+- [ ] 3.2 State the classification rule (committed means reference, ignored means stored) with the current producer table, so a producer added later classifies itself
+- [ ] 3.3 State that retention is run-state aware: an artifact belonging to a resumable run is not eligible for deletion regardless of age
+
+## 4. Seam types
+
+- [ ] 4.1 Define `Workspace`, `WritebackResult` and `ArtifactRef`, versioned from the first definition
+- [ ] 4.2 Give `ArtifactRef.location` its own `kind: 'repo' | 'blob'` discriminant, kept distinct from the top-level role `kind`
+- [ ] 4.3 Include `WritebackResult`'s policy-skip state, marked provisional pending a platform answer on whether hosted runs can disable writeback
+
+## 5. Follow-ups raised, not resolved here
+
+- [ ] 5.1 Open a separate issue for the board template shipping `docsDir`/`ecadDir` while `loadConfig` (`src/config.ts:113-115`) reads `docs`/`schematic`/`board`, so both keys are silently ignored. Independent of this stream and live for template users today
+- [ ] 5.2 Raise the template's fabrication-output ignore mismatch: it ignores `build/`, `fab/` and `gerbers/` under the comment "build and fabrication output, which is regenerated from the design", but the fab tool writes to `outputs/`, which none of those cover. Gerbers are therefore committed today, and classified as references by the rule above, which may not be the intent
+- [ ] 5.3 Do not fix the `priorRuns` miscount here. `src/commands/create.ts:736` is already touched by #155, #149 and #251's planned change; this change states the contract that fix must satisfy and leaves the edit to whichever lands
+
+## 6. Verification
+
+- [ ] 6.1 `npm run typecheck` and `npm test` clean, compared against a stashed baseline rather than a remembered count
+- [ ] 6.2 Extend the module-graph guard in `test/init-check.test.ts` to cover any module added here, so `check` staying LLM-free and network-free (AC-2.1) is asserted rather than assumed
+- [ ] 6.3 Confirm `test/gating-sync.test.ts` stays green and is extended, never relaxed


### PR DESCRIPTION
Phase 0 of #250. Proposal only: no implementation in this PR.

## What

An OpenSpec change (`add-hosted-run-seam`) fixing the contract the hosted platform consumes, so Phases 1 and 2 have something to build against. Storage, signature minting, and every runner-side concern stay out; they land in the platform repository against what this fixes.

## Why

A hosted run destroys its workspace when it ends, and everything it produced goes with it: gerbers and drill written to `outputs/` (`tools.ts:616`), the supplier BOM (`export.ts:29`), SVG renders (`tools.ts:601`), and the transcript, summary and report under `.copperhead/runs/` (`transcript.ts:77`, `create.ts:736`). `/artifacts` is a shell because nothing durable exists behind it.

Two of the three obligations turned out to be defects rather than gaps.

**Transcript events have no size bound.** `Transcript.event()` redacts and appends whatever it is handed, as one JSON line. A stage attempt has already died on this: `Prompt is too long, the request is ~1003121 tokens but this conversation is only ~403383 tokens`, because one line carried an entire tool result. The existing clip at `filetools.ts:95` bounds an individual search match, not an event, so it did not and could not prevent it.

**Redaction has no storage-credential pattern.** `redact.ts` carries seven: `sk-`, `Bearer`, `npm_`, `gh[pousr]_`, `github_pat_`, `AIza`, `gsk_`. A shared access signature is a query string whose secret is its `sig=` value and matches none of them. That is sharper than an ordinary redaction gap, because the transcript is itself an artifact this stream uploads: an unredacted signature becomes a live download credential stored inside a downloadable object. The Git side is already covered, since an installation token is `ghs_` and `gh[pousr]_[A-Za-z0-9]{36,}` matches it, including inside an `x-access-token:...@github.com` clone URL.

## Design decisions worth review

**The 128 KiB bound is measured, not picked.** Across 1106 events from real `create` runs in the manual-test sandboxes:

| Percentile | Bytes |
| --- | --- |
| median | 337 |
| p90 | 6334 |
| p99 | 18042 |
| p99.9 | 20581 |
| max | 60981 |

128 KiB sits at roughly twice the largest event ever observed, so nothing in that corpus truncates, while the failure case above is bounded by about an order of magnitude. 64 KiB was considered and rejected: at 65536 it leaves seven percent of headroom over the observed maximum, close enough that an ordinary large capture would start truncating, and a bound that fires on legitimate traffic teaches readers to distrust it.

**The bound sits where redaction already runs, and after it.** One call point means both write-time invariants are enforced together and cannot drift as callers are added, which matters because the original defect came from one of many callers. Ordering is deliberate: redaction only ever shortens a string, so bounding afterwards cannot reintroduce a secret at the boundary, whereas bounding first could halve one and leave an unmatchable fragment.

**Truncation records the original size and never drops the event.** The transcript is an audit trail and a resume input, so a missing event is a hole in both. Recording the size is also what makes the hosted `ArtifactRef` spill implementable later: locally there is no store, so the marker is the degenerate form of the same rule, and the hosted path adds a location to an existing shape rather than introducing a second one.

**Artifact classification is derived from version control rather than declared.** An output the run commits survives and needs only a reference; an output `.gitignore` excludes dies with the workspace and must be stored. Deriving the rule means a producer added later classifies itself, and the classification cannot go stale against a fixed list.

## Both review items from the plan are addressed

**`ArtifactRef.location` carries its own `kind` discriminant** (`repo` or `blob`), kept distinct from the top-level `ArtifactRef.kind` which names the artifact's role. The two are deliberately not merged: a `log` is always blob-backed today, but collapsing them would encode that coincidence as a constraint.

**`WritebackResult` includes a policy-skip state, marked provisional.** Whether hosted runs can disable writeback is a platform question this repository cannot answer. It is included rather than deferred because the directions are not symmetric: adding a state later breaks stream 1's exhaustive match, while carrying an unused one costs a single unreachable branch. Happy to drop it if the answer is no.

## Raised, deliberately not resolved here

- The board template ships `.copperhead/config.json` with `docsDir` and `ecadDir`, while `loadConfig` (`config.ts:113-115`) reads `docs`, `schematic` and `board`, so both keys are silently ignored. Live for template users today and independent of this stream, so it is filed separately as asked.
- The template ignores `build/`, `fab/` and `gerbers/` under the comment "build and fabrication output, which is regenerated from the design", but the fab tool writes to `outputs/`, which none of those cover. Fabrication output is therefore committed today, which contradicts the template's evident intent and decides whether gerbers are references or stored objects.
- The `priorRuns` miscount at `create.ts:736` is not fixed here. #155, #149 and #251's planned change already touch those lines; this change states the contract the fix must satisfy and leaves the edit to whichever lands.

## Testing

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | n/a, no source files touched |
| Unit + offline | `npm test` | n/a, no source files touched |
| OpenSpec validate | `openspec validate add-hosted-run-seam` | **not run**, CLI not installed on this machine |

Documents only: six files under `openspec/changes/add-hosted-run-seam/`, no `src/` or `test/` changes, so the suite is unaffected. Structure and artifact shape were checked by hand against `add-symbol-search-tool` and `deterministic-schematic-drafting`.

`openspec validate` is the gap worth closing before merge. `doctor` now reports the CLI as missing with `npm i -g @fission-ai/openspec`, which is how I noticed.

### Manual test log

n/a: proposal-only change, no runtime behaviour to exercise. The measurements backing the 128 KiB bound came from reading committed transcripts in the manual-test sandboxes rather than from a new run:

```text
$ awk '{ print length }' manual-tests/runs/*/.copperhead/runs/*/transcript.jsonl | sort -n
events: 1106  median: 337  p90: 6334  p99: 18042  p99.9: 20581  max: 60981
```

---

## Invariant checklist

- [ ] N/A **Spec-gated in**: no tool-list change; this adds planning artifacts only.
- [ ] N/A **Verification-gated out**: no ERC/DRC gate or rollback logic touched. The spec states that artifact handling stays post-verification, so it never becomes a route to "done" without them.
- [x] **`check`/`verify` stays LLM-free and network-free**: nothing here is reachable from `src/commands/check`, and there are no code changes at all. Tasks require extending the module-graph guard in `test/init-check.test.ts` when implementation lands, so this stays asserted rather than assumed.
- [ ] N/A **No sexp serialization**: the KiCad parser is untouched.
- [ ] N/A **Sync-obligations ledger**: untouched.
- [x] **Secrets**: the change widens AC-4.1 rather than weakening it, adding storage credentials to the redacted set and requiring a per-shape test beside the seven existing ones.
- [x] **Spec coherence**: this is the spec artifact. `proposal.md`, `design.md`, two delta specs and `tasks.md` move together; `openspec validate` still needs running, as noted above.
