### PR TITLE
docs(site): restyle the docs after GitBook's clean theme

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,0 +1,37 @@
+name: Docs build
+
+# The deploy workflow only runs on push to main, so without this a docs change
+# reaches docs.copperhead.sh with its build unverified: a broken import goes
+# green on every PR check and fails afterwards, on main. This job builds the
+# site exactly as the deploy does, and publishes nothing.
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-pr.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # lastUpdated timestamps come from git history
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+      - run: npm ci
+        working-directory: docs
+      - run: npm run build
+        working-directory: docs

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig({
         Sidebar: './src/components/Sidebar.astro',
         PageTitle: './src/components/PageTitle.astro',
         ThemeSelect: './src/components/ThemeSelect.astro',
+        Footer: './src/components/Footer.astro',
       },
       customCss: [
         '@fontsource-variable/inter',
@@ -136,7 +137,7 @@ export default defineConfig({
             {
               label: 'Technical spec',
               link: `${REPO}/blob/main/openspec/specs/SPEC.md`,
-              attrs: { target: '_blank', 'data-icon': 'external' },
+              attrs: { target: '_blank', rel: 'noopener', 'data-icon': 'external' },
             },
           ],
         },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -14,12 +14,41 @@ export default defineConfig({
       title: 'copperhead',
       description:
         'Cursor for circuit boards: an AI agent that designs, documents, and validates real PCBs on KiCad repositories',
+      logo: { src: './src/assets/mark.svg', alt: '' },
       social: [
         { icon: 'external', label: 'copperhead.sh', href: 'https://copperhead.sh' },
         { icon: 'github', label: 'GitHub', href: REPO },
       ],
       editLink: { baseUrl: `${REPO}/edit/main/docs/` },
       lastUpdated: true,
+      // Theme: see src/styles/custom.css for the palette and layout, and
+      // src/components/ for the overridden header, sidebar, title, and theme toggle.
+      components: {
+        Header: './src/components/Header.astro',
+        Sidebar: './src/components/Sidebar.astro',
+        PageTitle: './src/components/PageTitle.astro',
+        ThemeSelect: './src/components/ThemeSelect.astro',
+      },
+      customCss: [
+        '@fontsource-variable/inter',
+        '@fontsource/ibm-plex-mono/400.css',
+        '@fontsource/ibm-plex-mono/500.css',
+        './src/styles/custom.css',
+      ],
+      expressiveCode: {
+        styleOverrides: {
+          borderRadius: '0.75rem',
+          codeFontFamily: "'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+          codeFontSize: '0.875rem',
+          codeLineHeight: '1.65',
+          codePaddingBlock: '0.875rem',
+          codePaddingInline: '1rem',
+          frames: {
+            shadowColor: 'transparent',
+            frameBoxShadowCssValue: 'none',
+          },
+        },
+      },
       plugins: [
         starlightLlmsTxt({
           projectName: 'copperhead',
@@ -59,7 +88,6 @@ export default defineConfig({
           ],
         }),
       ],
-      customCss: ['./src/styles/custom.css'],
       head: [
         { tag: 'meta', attrs: { name: 'theme-color', content: '#b87333' } },
         { tag: 'link', attrs: { rel: 'icon', href: '/favicon.ico', sizes: '32x32' } },
@@ -69,46 +97,48 @@ export default defineConfig({
         { tag: 'meta', attrs: { name: 'twitter:card', content: 'summary_large_image' } },
         { tag: 'meta', attrs: { name: 'twitter:image', content: 'https://docs.copperhead.sh/og.png' } },
       ],
+      // `data-icon` picks the leading icon for each row; see SidebarSublist.astro.
       sidebar: [
         {
           label: 'Getting started',
           items: [
-            { label: 'Introduction', link: '/getting-started/introduction/' },
-            { label: 'Quickstart', link: '/getting-started/quickstart/' },
-            { label: 'Agent install', link: '/getting-started/agent-install/' },
-            { label: 'Simple demo', link: '/getting-started/demo/' },
+            { label: 'Welcome', link: '/', attrs: { 'data-icon': 'star' } },
+            { label: 'Introduction', link: '/getting-started/introduction/', attrs: { 'data-icon': 'information' } },
+            { label: 'Quickstart', link: '/getting-started/quickstart/', attrs: { 'data-icon': 'rocket' } },
+            { label: 'Agent install', link: '/getting-started/agent-install/', attrs: { 'data-icon': 'puzzle' } },
+            { label: 'Simple demo', link: '/getting-started/demo/', attrs: { 'data-icon': 'laptop' } },
           ],
         },
         {
           label: 'Concepts',
           items: [
-            { label: 'The agent loop', link: '/concepts/agent-loop/' },
-            { label: 'Guardrails', link: '/concepts/guardrails/' },
-            { label: 'Docs as memory', link: '/concepts/docs-as-memory/' },
+            { label: 'The agent loop', link: '/concepts/agent-loop/', attrs: { 'data-icon': 'random' } },
+            { label: 'Guardrails', link: '/concepts/guardrails/', attrs: { 'data-icon': 'padlock' } },
+            { label: 'Docs as memory', link: '/concepts/docs-as-memory/', attrs: { 'data-icon': 'open-book' } },
           ],
         },
         {
           label: 'Workflows',
           items: [
-            { label: 'Design from a brief', link: '/workflows/create-from-brief/' },
-            { label: 'Edit an existing board', link: '/workflows/edit-existing-board/' },
-            { label: 'Verify and sync', link: '/workflows/verify-and-sync/' },
+            { label: 'Design from a brief', link: '/workflows/create-from-brief/', attrs: { 'data-icon': 'add-document' } },
+            { label: 'Edit an existing board', link: '/workflows/edit-existing-board/', attrs: { 'data-icon': 'pencil' } },
+            { label: 'Verify and sync', link: '/workflows/verify-and-sync/', attrs: { 'data-icon': 'approve-check' } },
           ],
         },
         {
           label: 'Reference',
           items: [
-            { label: 'CLI', link: '/reference/cli/' },
-            { label: 'Configuration', link: '/reference/configuration/' },
-            { label: 'Schematic legibility rules', link: '/reference/schematic-legibility/' },
-            { label: 'How schematics are drafted', link: '/reference/schematic-drafting/' },
-            { label: 'The schematic intent file', link: '/reference/schematic-intent/' },
+            { label: 'CLI', link: '/reference/cli/', attrs: { 'data-icon': 'forward-slash' } },
+            { label: 'Configuration', link: '/reference/configuration/', attrs: { 'data-icon': 'setting' } },
+            { label: 'Schematic legibility rules', link: '/reference/schematic-legibility/', attrs: { 'data-icon': 'list-format' } },
+            { label: 'How schematics are drafted', link: '/reference/schematic-drafting/', attrs: { 'data-icon': 'pen' } },
+            { label: 'The schematic intent file', link: '/reference/schematic-intent/', attrs: { 'data-icon': 'document' } },
+            {
+              label: 'Technical spec',
+              link: `${REPO}/blob/main/openspec/specs/SPEC.md`,
+              attrs: { target: '_blank', 'data-icon': 'external' },
+            },
           ],
-        },
-        {
-          label: 'Technical spec',
-          link: `${REPO}/blob/main/openspec/specs/SPEC.md`,
-          attrs: { target: '_blank' },
         },
       ],
     }),

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,6 +7,8 @@
       "name": "copperhead-docs",
       "dependencies": {
         "@astrojs/starlight": "^0.41.3",
+        "@fontsource-variable/inter": "^5.3.0",
+        "@fontsource/ibm-plex-mono": "^5.3.0",
         "astro": "^7.1.1",
         "sharp": "^0.35.3",
         "starlight-llms-txt": "^0.11.0"
@@ -71,9 +73,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -89,9 +88,6 @@
       "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -109,9 +105,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -127,9 +120,6 @@
       "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -451,9 +441,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -466,9 +453,6 @@
       "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -483,9 +467,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -498,9 +479,6 @@
       "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1115,6 +1093,24 @@
         "@expressive-code/core": "^0.44.0"
       }
     },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.3.0.tgz",
+      "integrity": "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -1226,9 +1222,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1244,9 +1237,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1264,9 +1254,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1282,9 +1269,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1302,9 +1286,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1320,9 +1301,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1340,9 +1318,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1359,9 +1334,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1377,9 +1349,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1403,9 +1372,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1427,9 +1393,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1453,9 +1416,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1477,9 +1437,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1503,9 +1460,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1528,9 +1482,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1552,9 +1503,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1923,9 +1871,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1941,9 +1886,6 @@
       "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1961,9 +1903,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1979,9 +1918,6 @@
       "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1999,9 +1935,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2017,9 +1950,6 @@
       "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4138,9 +4068,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4160,9 +4087,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4184,9 +4108,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4206,9 +4127,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,8 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.3",
+    "@fontsource-variable/inter": "^5.3.0",
+    "@fontsource/ibm-plex-mono": "^5.3.0",
     "astro": "^7.1.1",
     "sharp": "^0.35.3",
     "starlight-llms-txt": "^0.11.0"

--- a/docs/src/assets/mark.svg
+++ b/docs/src/assets/mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="4.625 4.625 22.75 22.75" width="24" height="24">
+  <circle cx="16" cy="16" r="5.25" fill="none" stroke="#b87333" stroke-width="2.25"/>
+  <path d="M16 5.75v5M16 21.25v5M5.75 16h5M21.25 16h5" stroke="#b87333" stroke-width="2.25"/>
+</svg>

--- a/docs/src/components/DocCard.astro
+++ b/docs/src/components/DocCard.astro
@@ -1,0 +1,76 @@
+---
+/**
+ * A compact link card: bold title, short description, optional leading icon.
+ * External links open in a new tab and get a small external-link marker.
+ */
+import { Icon } from '@astrojs/starlight/components';
+import type { StarlightIcon } from '@astrojs/starlight/types';
+
+interface Props {
+	href: string;
+	title: string;
+	description?: string;
+	icon?: StarlightIcon;
+}
+
+const { href, title, description, icon } = Astro.props;
+const external = /^https?:\/\//.test(href);
+---
+
+<a
+	class="doc-card"
+	{href}
+	target={external ? '_blank' : undefined}
+	rel={external ? 'noopener' : undefined}
+>
+	{icon && <Icon name={icon} class="card-icon" size="1.125rem" />}
+	<span class="title">
+		{title}
+		{external && <Icon name="external" class="external" size="0.8em" />}
+	</span>
+	{description && <span class="description">{description}</span>}
+</a>
+
+<style>
+	.doc-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+		padding: 1rem 1.125rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.75rem;
+		background-color: var(--sl-color-black);
+		color: var(--sl-color-white);
+		text-decoration: none;
+		transition:
+			border-color 0.15s,
+			transform 0.15s;
+	}
+	.doc-card:hover {
+		border-color: var(--sl-color-accent);
+		transform: translateY(-1px);
+	}
+	.card-icon {
+		color: var(--sl-color-text-accent);
+		margin-bottom: 0.25rem;
+	}
+	.title {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		font-size: var(--sl-text-sm);
+		font-weight: 600;
+		line-height: 1.3;
+	}
+	.doc-card:hover .title {
+		color: var(--sl-color-text-accent);
+	}
+	.external {
+		color: var(--sl-color-gray-3);
+	}
+	.description {
+		font-size: var(--sl-text-sm);
+		line-height: 1.5;
+		color: var(--sl-color-gray-3);
+	}
+</style>

--- a/docs/src/components/DocCards.astro
+++ b/docs/src/components/DocCards.astro
@@ -1,0 +1,19 @@
+---
+/** Two-column grid of DocCard links (single column on narrow viewports). */
+---
+
+<div class="doc-cards not-content"><slot /></div>
+
+<style>
+	.doc-cards {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 0.75rem;
+	}
+	@media (min-width: 40rem) {
+		.doc-cards {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: 0.875rem;
+		}
+	}
+</style>

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * Footer override.
+ *
+ * Identical to Starlight's default except that the pagination cards come
+ * before the edit/last-updated meta row in the DOM. The theme shows the cards
+ * first; doing that with CSS `order` alone would leave keyboard focus running
+ * in the old DOM order, so tabbing past the content would jump to the
+ * bottom-most element and then back up the page (WCAG 2.4.3, Focus Order).
+ *
+ * The layout rules Starlight scopes to its own Footer.astro come with it,
+ * since that component no longer renders.
+ */
+import EditLink from 'virtual:starlight/components/EditLink';
+import LastUpdated from 'virtual:starlight/components/LastUpdated';
+import Pagination from 'virtual:starlight/components/Pagination';
+import config from 'virtual:starlight/user-config';
+import { Icon } from '@astrojs/starlight/components';
+---
+
+<footer class="sl-flex">
+	<Pagination />
+	<div class="meta sl-flex">
+		<EditLink />
+		<LastUpdated />
+	</div>
+
+	{
+		config.credits && (
+			<a class="kudos sl-flex" href="https://starlight.astro.build">
+				<Icon name="starlight" /> {Astro.locals.t('builtWithStarlight.label')}
+			</a>
+		)
+	}
+</footer>
+
+<style>
+	footer {
+		flex-direction: column;
+		gap: 1.25rem;
+	}
+
+	.meta {
+		gap: 0.75rem 3rem;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		font-size: var(--sl-text-sm);
+		color: var(--sl-color-gray-3);
+	}
+	.meta > :global(p:only-child) {
+		margin-inline-start: auto;
+	}
+
+	.kudos {
+		align-items: center;
+		gap: 0.5em;
+		margin: 1.5rem auto;
+		font-size: var(--sl-text-xs);
+		text-decoration: none;
+		color: var(--sl-color-gray-3);
+	}
+	.kudos:hover {
+		color: var(--sl-color-white);
+	}
+	.kudos :global(svg) {
+		color: var(--sl-color-orange);
+	}
+</style>

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -1,0 +1,162 @@
+---
+/**
+ * Site header override.
+ *
+ * Layout: logo and wordmark on the left, a wide search box that starts where
+ * the content column starts, and a right-hand group with text links, the
+ * GitHub icon, the theme toggle, and a filled call-to-action button.
+ */
+import config from 'virtual:starlight/user-config';
+import Search from '@astrojs/starlight/components/Search.astro';
+import SiteTitle from '@astrojs/starlight/components/SiteTitle.astro';
+import { Icon } from '@astrojs/starlight/components';
+import ThemeSelect from './ThemeSelect.astro';
+
+const shouldRenderSearch =
+	config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
+
+const social = config.social ?? [];
+const textLinks = social.filter((link) => link.icon !== 'github');
+const github = social.find((link) => link.icon === 'github');
+---
+
+<div class="header">
+	<div class="title-wrapper sl-flex">
+		<SiteTitle />
+	</div>
+	<div class="search-wrapper sl-flex print:hidden">
+		{shouldRenderSearch && <Search />}
+	</div>
+	<div class="sl-hidden md:sl-flex print:hidden right-group">
+		{
+			textLinks.map(({ label, href }) => (
+				<a class="nav-link" {href}>
+					{label}
+					<Icon name="external" size="0.8em" />
+				</a>
+			))
+		}
+		{
+			github && (
+				<a class="icon-link" href={github.href} rel="me" aria-label={github.label}>
+					<Icon name="github" size="1.15rem" />
+				</a>
+			)
+		}
+		<ThemeSelect />
+		<a class="cta" href="/getting-started/quickstart/">Get started</a>
+	</div>
+</div>
+
+<style>
+	.header {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		height: 100%;
+	}
+
+	.title-wrapper {
+		/* Prevent long titles overflowing and covering the search and menu buttons on narrow viewports. */
+		overflow: clip;
+		/* Avoid clipping focus ring around link inside title wrapper. */
+		padding: 0.25rem;
+		margin: -0.25rem;
+		min-width: 0;
+		flex: 0 0 auto;
+	}
+
+	.search-wrapper {
+		flex: 1 1 auto;
+		justify-content: flex-end;
+		min-width: 0;
+	}
+
+	.right-group {
+		flex: 0 0 auto;
+		align-items: center;
+		gap: 0.375rem;
+		margin-inline-start: auto;
+	}
+
+	.nav-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		padding: 0.4rem 0.625rem;
+		border-radius: 0.5rem;
+		font-size: var(--sl-text-sm);
+		font-weight: 500;
+		color: var(--sl-color-gray-2);
+		text-decoration: none;
+		white-space: nowrap;
+		transition:
+			color 0.12s,
+			background-color 0.12s;
+	}
+	.nav-link svg {
+		color: var(--sl-color-gray-3);
+	}
+	.nav-link:hover {
+		color: var(--sl-color-white);
+		background-color: var(--ch-hover-bg);
+	}
+
+	.icon-link {
+		display: grid;
+		place-items: center;
+		width: 2.125rem;
+		height: 2.125rem;
+		border-radius: 0.5rem;
+		color: var(--sl-color-gray-2);
+		transition:
+			color 0.12s,
+			background-color 0.12s;
+	}
+	.icon-link:hover {
+		color: var(--sl-color-white);
+		background-color: var(--ch-hover-bg);
+	}
+
+	.cta {
+		display: inline-flex;
+		align-items: center;
+		height: 2.25rem;
+		margin-inline-start: 0.375rem;
+		padding-inline: 1rem;
+		border-radius: 999px;
+		background-color: var(--sl-color-accent);
+		color: var(--ch-on-accent);
+		font-size: var(--sl-text-sm);
+		font-weight: 600;
+		text-decoration: none;
+		white-space: nowrap;
+		transition:
+			background-color 0.12s,
+			transform 0.12s;
+	}
+	.cta:hover {
+		background-color: var(--ch-accent-hover);
+		transform: translateY(-1px);
+	}
+
+	@media (min-width: 50rem) {
+		.search-wrapper {
+			justify-content: flex-start;
+		}
+	}
+
+	/* Between the tablet and desktop breakpoints there is no room for the text links. */
+	@media (min-width: 50rem) and (max-width: 63.99rem) {
+		.nav-link {
+			display: none;
+		}
+	}
+
+	/* From desktop up, the search box starts where the content column starts. */
+	@media (min-width: 64rem) {
+		.title-wrapper {
+			width: calc(var(--sl-sidebar-width) - var(--sl-nav-pad-x));
+		}
+	}
+</style>

--- a/docs/src/components/JumpLink.astro
+++ b/docs/src/components/JumpLink.astro
@@ -1,0 +1,82 @@
+---
+/**
+ * A single wide link row for the landing page's "Jump right in" section:
+ * leading icon, title, optional one-line description, trailing chevron.
+ */
+import { Icon } from '@astrojs/starlight/components';
+import type { StarlightIcon } from '@astrojs/starlight/types';
+
+interface Props {
+	href: string;
+	title: string;
+	description?: string;
+	icon?: StarlightIcon;
+}
+
+const { href, title, description, icon } = Astro.props;
+---
+
+<a class="jump-link not-content" {href}>
+	{icon && <Icon name={icon} class="jump-icon" size="1.125rem" />}
+	<span class="body">
+		<span class="title">{title}</span>
+		{description && <span class="description">{description}</span>}
+	</span>
+	<Icon name="right-caret" class="caret rtl:flip" size="1.125rem" />
+</a>
+
+<style>
+	.jump-link {
+		display: flex;
+		align-items: center;
+		gap: 0.875rem;
+		padding: 0.875rem 1.125rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.75rem;
+		background-color: var(--sl-color-black);
+		color: var(--sl-color-white);
+		text-decoration: none;
+		transition:
+			border-color 0.15s,
+			transform 0.15s;
+	}
+	.jump-link + .jump-link {
+		margin-top: 0.75rem;
+	}
+	.jump-link:hover {
+		border-color: var(--sl-color-accent);
+		transform: translateY(-1px);
+	}
+	.jump-icon {
+		flex-shrink: 0;
+		color: var(--sl-color-text-accent);
+	}
+	.body {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+	.title {
+		font-size: var(--sl-text-base);
+		font-weight: 600;
+		line-height: 1.3;
+	}
+	.description {
+		font-size: var(--sl-text-sm);
+		line-height: 1.45;
+		color: var(--sl-color-gray-3);
+	}
+	.caret {
+		flex-shrink: 0;
+		color: var(--sl-color-gray-3);
+		transition:
+			color 0.15s,
+			transform 0.15s;
+	}
+	.jump-link:hover .caret {
+		color: var(--sl-color-text-accent);
+		transform: translateX(2px);
+	}
+</style>

--- a/docs/src/components/PageTitle.astro
+++ b/docs/src/components/PageTitle.astro
@@ -1,0 +1,61 @@
+---
+/**
+ * Page title override: a small section eyebrow (the sidebar group the page
+ * lives in), the title, and the page description as a lead paragraph.
+ */
+import type { StarlightRouteData } from '@astrojs/starlight/route-data';
+
+type SidebarEntry = StarlightRouteData['sidebar'][number];
+
+const { entry, sidebar } = Astro.locals.starlightRoute;
+const { title, description } = entry.data;
+
+/** Walk the sidebar tree and return the labels of the groups that contain the current page. */
+function groupTrail(entries: SidebarEntry[], trail: string[] = []): string[] | undefined {
+	for (const item of entries) {
+		if (item.type === 'link') {
+			if (item.isCurrent) return trail;
+		} else {
+			const found = groupTrail(item.entries, [...trail, item.label]);
+			if (found) return found;
+		}
+	}
+	return undefined;
+}
+
+const eyebrow = (groupTrail(sidebar) ?? []).join(' / ');
+---
+
+<div class="page-title">
+	{eyebrow && <p class="eyebrow">{eyebrow}</p>}
+	<h1 id="_top">{title}</h1>
+	{description && <p class="lead">{description}</p>}
+</div>
+
+<style>
+	.page-title {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		margin-top: 0.5rem;
+	}
+	.eyebrow {
+		font-size: var(--sl-text-xs);
+		font-weight: 500;
+		color: var(--sl-color-text-accent);
+	}
+	h1 {
+		font-size: var(--sl-text-h1);
+		font-weight: 700;
+		line-height: 1.15;
+		letter-spacing: -0.025em;
+		color: var(--sl-color-white);
+		text-wrap: balance;
+	}
+	.lead {
+		font-size: var(--sl-text-lg);
+		line-height: 1.55;
+		color: var(--sl-color-gray-2);
+		text-wrap: pretty;
+	}
+</style>

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -1,0 +1,75 @@
+---
+/**
+ * Sidebar override. Same structure as Starlight's default (so the sidebar
+ * state persister keeps working), with a custom sublist renderer and a small
+ * version footer pinned to the bottom of the panel on desktop.
+ */
+import MobileMenuFooter from '@astrojs/starlight/components/MobileMenuFooter.astro';
+import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro';
+import { Icon } from '@astrojs/starlight/components';
+import SidebarSublist from './SidebarSublist.astro';
+import pkg from '../../../package.json';
+
+const { sidebar } = Astro.locals.starlightRoute;
+const releaseUrl = `https://github.com/copperheadhq/copperhead/releases/tag/v${pkg.version}`;
+---
+
+<SidebarPersister>
+	<SidebarSublist sublist={sidebar} />
+</SidebarPersister>
+
+<div class="md:sl-hidden">
+	<MobileMenuFooter />
+</div>
+
+<div class="sl-hidden md:sl-block version-wrap">
+	<a class="version sl-flex" href={releaseUrl}>
+		<Icon name="github" size="0.9rem" />
+		<span class="tag">v{pkg.version}</span>
+		<span class="license">Apache-2.0</span>
+	</a>
+</div>
+
+<style>
+	/* Pinned to the bottom of the sidebar panel; the list scrolls underneath. */
+	.version-wrap {
+		position: sticky;
+		bottom: 0;
+		margin-top: auto;
+		padding-top: 1.25rem;
+		padding-bottom: 0.75rem;
+		background: linear-gradient(to bottom, transparent, var(--sl-color-bg-sidebar) 40%);
+	}
+	.version {
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.75rem;
+		background-color: var(--sl-color-black);
+		font-size: var(--sl-text-xs);
+		font-weight: 500;
+		color: var(--sl-color-gray-2);
+		text-decoration: none;
+		white-space: nowrap;
+		transition:
+			border-color 0.12s,
+			color 0.12s;
+	}
+	.version:hover {
+		border-color: var(--sl-color-gray-4);
+		color: var(--sl-color-white);
+	}
+	.version svg {
+		color: var(--sl-color-gray-3);
+		flex-shrink: 0;
+	}
+	.tag {
+		font-family: var(--__sl-font-mono);
+	}
+	.license {
+		margin-inline-start: auto;
+		color: var(--sl-color-gray-3);
+		font-weight: 400;
+	}
+</style>

--- a/docs/src/components/SidebarSublist.astro
+++ b/docs/src/components/SidebarSublist.astro
@@ -1,0 +1,221 @@
+---
+/**
+ * Sidebar list renderer.
+ *
+ * Differences from Starlight's default:
+ * - group labels are small uppercase headings; the collapse caret only shows on hover
+ * - links are pill-shaped rows with an optional leading icon, set per link in the
+ *   sidebar config via `attrs: { 'data-icon': '<starlight icon name>' }`
+ * - the active page is highlighted with a tinted pill instead of a solid block
+ * - no tree lines on nested lists
+ */
+import { Badge, Icon } from '@astrojs/starlight/components';
+import SidebarRestorePoint from '@astrojs/starlight/components/SidebarRestorePoint.astro';
+import type { StarlightRouteData } from '@astrojs/starlight/route-data';
+import type { StarlightIcon } from '@astrojs/starlight/types';
+
+type SidebarEntry = StarlightRouteData['sidebar'][number];
+type SidebarLink = Extract<SidebarEntry, { type: 'link' }>;
+
+interface Props {
+	sublist: SidebarEntry[];
+	nested?: boolean;
+}
+
+const { sublist, nested } = Astro.props;
+
+/** Flatten a sidebar tree into its links. */
+function flatten(entries: SidebarEntry[]): SidebarLink[] {
+	return entries.flatMap((entry) => (entry.type === 'link' ? [entry] : flatten(entry.entries)));
+}
+
+/** Read the optional icon name off a link's attrs. */
+function iconOf(entry: SidebarLink): StarlightIcon | undefined {
+	const icon = (entry.attrs as Record<string, unknown>)['data-icon'];
+	return typeof icon === 'string' ? (icon as StarlightIcon) : undefined;
+}
+
+/** Attrs to spread onto the anchor, minus the ones this component consumes. */
+function anchorAttrs(entry: SidebarLink): Record<string, unknown> {
+	const { 'data-icon': _icon, class: _class, ...rest } = entry.attrs as Record<string, unknown>;
+	return rest;
+}
+---
+
+<ul class:list={{ 'top-level': !nested }}>
+	{
+		sublist.map((entry) => (
+			<li>
+				{entry.type === 'link' ? (
+					<a
+						href={entry.href}
+						aria-current={entry.isCurrent ? 'page' : undefined}
+						class:list={['item', { large: !nested }, entry.attrs.class]}
+						{...anchorAttrs(entry)}
+					>
+						{iconOf(entry) && <Icon name={iconOf(entry)!} class="item-icon" size="1rem" />}
+						<span class="label">{entry.label}</span>
+						{entry.badge && (
+							<Badge
+								variant={entry.badge.variant}
+								class={entry.badge.class}
+								text={entry.badge.text}
+							/>
+						)}
+					</a>
+				) : (
+					<details open={flatten(entry.entries).some((i) => i.isCurrent) || !entry.collapsed}>
+						<summary>
+							<span class="group-label">
+								<span class="group-title">{entry.label}</span>
+								{entry.badge && (
+									<Badge
+										variant={entry.badge.variant}
+										class={entry.badge.class}
+										text={entry.badge.text}
+									/>
+								)}
+							</span>
+							<Icon name="right-caret" class="caret" size="1rem" />
+						</summary>
+						<SidebarRestorePoint />
+						<Astro.self sublist={entry.entries} nested />
+					</details>
+				)}
+			</li>
+		))
+	}
+</ul>
+
+<style>
+	ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	li {
+		overflow-wrap: anywhere;
+	}
+
+	.top-level > li + li {
+		margin-top: 1.125rem;
+	}
+
+	/* Lists inside a group. */
+	ul ul {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		margin-top: 0.25rem;
+	}
+
+	/* Third level and deeper: indent under the parent. */
+	ul ul ul {
+		margin-inline-start: 1.25rem;
+	}
+
+	summary {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		padding: 0.25rem 0.75rem;
+		border-radius: 0.5rem;
+		cursor: pointer;
+		user-select: none;
+	}
+	summary::marker,
+	summary::-webkit-details-marker {
+		display: none;
+	}
+	summary:hover {
+		background-color: var(--ch-hover-bg);
+	}
+
+	.group-label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		min-width: 0;
+	}
+	.group-title {
+		font-size: 0.6875rem;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--sl-color-white);
+	}
+
+	.caret {
+		flex-shrink: 0;
+		opacity: 0;
+		color: var(--sl-color-gray-3);
+		transition:
+			opacity 0.15s,
+			transform 0.2s ease-in-out;
+	}
+	summary:hover .caret,
+	summary:focus-visible .caret {
+		opacity: 1;
+	}
+	:global([dir='rtl']) .caret {
+		transform: rotateZ(180deg);
+	}
+	[open] > summary .caret {
+		transform: rotateZ(90deg);
+	}
+
+	.item {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		padding: 0.4rem 0.75rem;
+		border-radius: 0.5rem;
+		font-size: var(--sl-text-sm);
+		line-height: 1.35;
+		color: var(--sl-color-gray-2);
+		text-decoration: none;
+		transition:
+			background-color 0.12s,
+			color 0.12s;
+	}
+	.item:hover,
+	.item:focus-visible {
+		color: var(--sl-color-white);
+		background-color: var(--ch-hover-bg);
+	}
+	.item-icon {
+		flex-shrink: 0;
+		color: var(--sl-color-gray-3);
+		transition: color 0.12s;
+	}
+	.item:hover .item-icon {
+		color: var(--sl-color-gray-2);
+	}
+	.label {
+		min-width: 0;
+	}
+
+	.item[aria-current='page'],
+	.item[aria-current='page']:hover,
+	.item[aria-current='page']:focus-visible {
+		font-weight: 600;
+		color: var(--sl-color-text-accent);
+		background-color: var(--ch-pill-bg);
+	}
+	.item[aria-current='page'] .item-icon {
+		color: var(--sl-color-text-accent);
+	}
+
+	/* Bigger touch targets in the mobile drawer. */
+	@media (max-width: 49.99rem) {
+		.item {
+			padding: 0.5rem 0.75rem;
+			font-size: var(--sl-text-base);
+		}
+		.top-level > li + li {
+			margin-top: 1.25rem;
+		}
+	}
+</style>

--- a/docs/src/components/ThemeSelect.astro
+++ b/docs/src/components/ThemeSelect.astro
@@ -1,0 +1,109 @@
+---
+/**
+ * Theme toggle override: a compact three-way segmented control
+ * (light / system / dark) instead of Starlight's native <select>.
+ *
+ * It reads and writes the same `starlight-theme` localStorage key that
+ * Starlight's inline ThemeProvider script uses, so the choice is applied
+ * before first paint on the next page load and there is no flash.
+ */
+import { Icon } from '@astrojs/starlight/components';
+
+const options = [
+	{ value: 'light', label: 'Light theme', icon: 'sun' },
+	{ value: 'auto', label: 'System theme', icon: 'laptop' },
+	{ value: 'dark', label: 'Dark theme', icon: 'moon' },
+] as const;
+---
+
+<ch-theme-toggle>
+	<div class="seg" role="group" aria-label="Color theme">
+		{
+			options.map(({ value, label, icon }) => (
+				<button type="button" data-value={value} aria-label={label} title={label} aria-pressed="false">
+					<Icon name={icon} size="0.9rem" />
+				</button>
+			))
+		}
+	</div>
+</ch-theme-toggle>
+
+<script>
+	type Theme = 'auto' | 'dark' | 'light';
+	const storageKey = 'starlight-theme';
+
+	const parseTheme = (theme: unknown): Theme =>
+		theme === 'auto' || theme === 'dark' || theme === 'light' ? theme : 'auto';
+
+	const loadTheme = (): Theme =>
+		parseTheme(typeof localStorage !== 'undefined' && (localStorage.getItem(storageKey) || 'auto'));
+
+	const systemTheme = (): Theme =>
+		matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+
+	function paintButtons(theme: Theme) {
+		document.querySelectorAll<HTMLButtonElement>('ch-theme-toggle button').forEach((button) => {
+			button.setAttribute('aria-pressed', String(button.dataset.value === theme));
+		});
+	}
+
+	function applyTheme(theme: Theme) {
+		document.documentElement.dataset.theme = theme === 'auto' ? systemTheme() : theme;
+		if (typeof localStorage !== 'undefined') {
+			// Starlight stores an empty string for "auto"; keep that convention.
+			localStorage.setItem(storageKey, theme === 'auto' ? '' : theme);
+		}
+		paintButtons(theme);
+	}
+
+	matchMedia('(prefers-color-scheme: light)').addEventListener('change', () => {
+		if (loadTheme() === 'auto') applyTheme('auto');
+	});
+
+	class ChThemeToggle extends HTMLElement {
+		constructor() {
+			super();
+			paintButtons(loadTheme());
+			this.querySelectorAll<HTMLButtonElement>('button').forEach((button) => {
+				button.addEventListener('click', () => applyTheme(parseTheme(button.dataset.value)));
+			});
+		}
+	}
+	customElements.define('ch-theme-toggle', ChThemeToggle);
+</script>
+
+<style>
+	ch-theme-toggle {
+		display: inline-flex;
+	}
+	.seg {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+		padding: 2px;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 999px;
+		background-color: var(--sl-color-black);
+	}
+	button {
+		display: grid;
+		place-items: center;
+		width: 1.75rem;
+		height: 1.75rem;
+		border: 0;
+		border-radius: 999px;
+		background: transparent;
+		color: var(--sl-color-gray-3);
+		cursor: pointer;
+		transition:
+			background-color 0.12s,
+			color 0.12s;
+	}
+	button:hover {
+		color: var(--sl-color-white);
+	}
+	button[aria-pressed='true'] {
+		background-color: var(--sl-color-gray-5);
+		color: var(--sl-color-white);
+	}
+</style>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,50 +1,116 @@
 ---
-title: copperhead
+title: Welcome to copperhead
 description: Cursor for circuit boards. An AI agent that designs, documents, and validates real PCBs from a prompt, working directly on existing KiCad repositories.
-template: splash
 head:
   - tag: title
     content: copperhead
-hero:
-  title: copperhead
-  tagline: Cursor for circuit boards. An AI agent that designs, documents, and validates real PCBs from a prompt, working directly on existing KiCad repositories.
-  actions:
-    - text: Get started
-      link: /getting-started/quickstart/
-      icon: right-arrow
-    - text: CLI reference
-      link: /reference/cli/
-      variant: minimal
-    - text: copperhead.sh
-      link: https://copperhead.sh
-      variant: minimal
-      icon: external
-    - text: GitHub
-      link: https://github.com/copperheadhq/copperhead
-      variant: minimal
-      icon: github
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import JumpLink from '../../components/JumpLink.astro';
+import DocCards from '../../components/DocCards.astro';
+import DocCard from '../../components/DocCard.astro';
 
-<CardGrid>
-  <Card title="Edits the real files" icon="pencil">
-    Works on `.kicad_sch` and `.kicad_pcb` s-expression text in your own repo.
-    Your KiCad install stays the editor; there is no new format and no lock-in.
-  </Card>
-  <Card title="Spec-gated in" icon="document">
-    The agent cannot touch a KiCad file until a validated change proposal
-    exists. The edit tools are structurally absent from its tool list until
-    then, so every edit traces back to a documented intent.
-  </Card>
-  <Card title="Verification-gated out" icon="approve-check">
-    No mutation is done until `kicad-cli` ERC (and DRC, if the board changed)
-    passes. The agent reads its own errors back and repairs, or rolls back to
-    the git snapshot.
-  </Card>
-  <Card title="Docs as memory" icon="open-book">
-    Design docs are the agent's memory and its output. Decisions land in an
-    append-only DECISIONS.md, and every run writes a human-readable summary
-    next to its transcript.
-  </Card>
-</CardGrid>
+copperhead is an open-source CLI agent for KiCad. Give it a product brief or a one-line change request and it writes a change proposal, edits the `.kicad_sch` and `.kicad_pcb` files in your repository, runs ERC and DRC through `kicad-cli` until they pass, and records what it decided and why in your design docs.
+
+Your KiCad install stays the editor, git stays the safety net, and a human still signs off. It is not an autorouter and it does not introduce a new file format.
+
+## Jump right in
+
+<JumpLink
+  href="/getting-started/quickstart/"
+  icon="rocket"
+  title="Quickstart"
+  description="Install copperhead, choose a model backend, and run your first verified change."
+/>
+<JumpLink
+  href="/getting-started/agent-install/"
+  icon="puzzle"
+  title="Agent install"
+  description="Onboard from inside your AI coding assistant with a single pasteable prompt."
+/>
+
+## Keep exploring
+
+### copperhead basics
+
+<DocCards>
+  <DocCard
+    href="/getting-started/introduction/"
+    title="Introduction"
+    description="What copperhead is, how the agent works, and what it deliberately is not."
+  />
+  <DocCard
+    href="/concepts/agent-loop/"
+    title="The agent loop"
+    description="What one run actually does, from reading the docs to writing down why."
+  />
+  <DocCard
+    href="/concepts/guardrails/"
+    title="Guardrails"
+    description="The two invariants that gate edits in and verification out, and the ledger that keeps docs honest."
+  />
+  <DocCard
+    href="/concepts/docs-as-memory/"
+    title="Docs as memory"
+    description="The markdown in your repo is the agent's memory, its output, and the thing verification protects."
+  />
+</DocCards>
+
+### Get things done
+
+<DocCards>
+  <DocCard
+    href="/workflows/create-from-brief/"
+    title="Design from a brief"
+    description="From a markdown product brief to a full, verified design package."
+  />
+  <DocCard
+    href="/workflows/edit-existing-board/"
+    title="Edit an existing board"
+    description="One natural-language change request, one verified, committed change."
+  />
+  <DocCard
+    href="/workflows/verify-and-sync/"
+    title="Verify and sync"
+    description="Keep the KiCad files, the design docs, and the constraint registry agreeing, in CI and at commit time."
+  />
+  <DocCard
+    href="/getting-started/demo/"
+    title="Simple demo"
+    description="Run the create pipeline end to end against the USB-C power breakout brief."
+  />
+</DocCards>
+
+### Reference
+
+<DocCards>
+  <DocCard href="/reference/cli/" title="CLI" description="Every command, flag, and exit code." />
+  <DocCard
+    href="/reference/configuration/"
+    title="Configuration"
+    description="Config file keys, environment variables, model selection, and the files copperhead writes."
+  />
+  <DocCard
+    href="/reference/schematic-drafting/"
+    title="How schematics are drafted"
+    description="The deterministic drafting engine and how a netlist intent becomes a placed, readable sheet."
+  />
+  <DocCard
+    href="/reference/schematic-intent/"
+    title="The schematic intent file"
+    description="The full specification of schematic.intent.json, the drafting engine's only input."
+  />
+  <DocCard
+    href="/reference/schematic-legibility/"
+    title="Schematic legibility rules"
+    description="The drafting standard for generated schematics and the checks that enforce it."
+  />
+  <DocCard
+    href="https://github.com/copperheadhq/copperhead/blob/main/openspec/specs/SPEC.md"
+    title="Technical spec"
+    description="Architecture, tool schemas, safety rails, and the binary acceptance criteria."
+  />
+</DocCards>

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -49,7 +49,7 @@
 	--ch-on-accent: #1b1b1c;
 	--ch-accent-hover: #d48a48;
 
-	/* Type scale (GitBook-ish: h1 36px, h2 24px, h3 20px) */
+	/* Type scale (GitBook-ish: h1 34px, h2 24px, h3 20px) */
 	--sl-text-h1: 2.125rem;
 	--sl-text-h2: 1.5rem;
 	--sl-text-h3: 1.25rem;
@@ -256,8 +256,8 @@ starlight-toc a[aria-current='true'] {
 	color: var(--sl-color-text-accent);
 	background-color: var(--ch-pill-bg);
 }
-/* List only the headings, not the page title itself. */
-starlight-toc li:has(> a[href='#_top']) {
+/* List only the headings, not the page title itself (both TOC renderers). */
+:is(starlight-toc, mobile-starlight-toc) li:has(> a[href='#_top']) {
 	display: none;
 }
 
@@ -295,7 +295,7 @@ mobile-starlight-toc .toggle {
 	margin-top: 2rem;
 }
 
-.sl-markdown-content :is(p, li, td, dd, blockquote) > a:not(:where(.not-content *)) {
+.sl-markdown-content :is(p, li, td, dd, blockquote) a:not(:where(.not-content *)) {
 	color: var(--sl-color-text-accent);
 	text-decoration: underline;
 	text-decoration-color: color-mix(in srgb, currentColor 40%, transparent);
@@ -303,7 +303,7 @@ mobile-starlight-toc .toggle {
 	text-underline-offset: 0.2em;
 	transition: text-decoration-color 0.12s;
 }
-.sl-markdown-content :is(p, li, td, dd, blockquote) > a:hover:not(:where(.not-content *)) {
+.sl-markdown-content :is(p, li, td, dd, blockquote) a:hover:not(:where(.not-content *)) {
 	color: var(--sl-color-text-accent);
 	text-decoration-color: currentColor;
 }
@@ -371,23 +371,16 @@ mobile-starlight-toc .toggle {
 	outline-offset: -1px;
 }
 
-/* ---- Footer: pagination cards, then meta ------------------------------ */
+/* ---- Footer: pagination cards, then meta ------------------------------
+ * The order comes from the Footer.astro override, not CSS `order`, so that
+ * keyboard focus order follows what is on screen (WCAG 2.4.3).
+ * ---------------------------------------------------------------------- */
 
-footer.sl-flex {
-	gap: 1.25rem;
-}
-footer .meta {
-	order: 2;
-	margin-top: 0;
-	font-size: var(--sl-text-sm);
-	color: var(--sl-color-gray-3);
-}
 footer .meta a:hover {
 	color: var(--sl-color-white);
 }
 
 .pagination-links {
-	order: 1;
 	gap: 0.875rem;
 	margin-top: 3rem;
 }
@@ -438,4 +431,44 @@ footer .meta a:hover {
 .card {
 	border-color: var(--sl-color-gray-5);
 	border-radius: 0.75rem;
+}
+
+/* ---- Print -------------------------------------------------------------
+ * Starlight's print.css forces a light palette, but it is unlayered too, so
+ * it ties with this file's :root on specificity and loses on document order
+ * (it is linked first). Without this block a dark-mode reader prints light
+ * text on a near-black page. Listing [data-theme='dark'] as well keeps this
+ * ahead of the light-mode block below it.
+ * ---------------------------------------------------------------------- */
+
+@media print {
+	:root,
+	:root[data-theme='dark'] {
+		--sl-color-white: #1a1b1e;
+		--sl-color-gray-1: #2b2d32;
+		--sl-color-gray-2: #545962;
+		--sl-color-gray-3: #6d747f;
+		--sl-color-gray-4: #c2c8d2;
+		--sl-color-gray-5: #e3e7ed;
+		--sl-color-gray-6: #eff2f6;
+		--sl-color-gray-7: #f7f8fa;
+		--sl-color-black: #ffffff;
+
+		--sl-color-accent-low: #f8e9db;
+		--sl-color-accent: #a35d1f;
+		--sl-color-accent-high: #5d3411;
+
+		--sl-color-text: var(--sl-color-gray-1);
+		--sl-color-text-accent: #9a5619;
+		--sl-color-text-invert: #ffffff;
+		--sl-color-bg: var(--sl-color-black);
+		--sl-color-bg-nav: var(--sl-color-black);
+		--sl-color-bg-sidebar: var(--sl-color-black);
+		--sl-color-bg-inline-code: var(--sl-color-gray-6);
+
+		--ch-hover-bg: transparent;
+		--ch-pill-bg: transparent;
+		--ch-panel-ring: transparent;
+		--ch-on-accent: #ffffff;
+	}
 }

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,23 +1,441 @@
-/* Copper accent, matching the brand color #b87333. */
+/* ------------------------------------------------------------------------
+ * copperhead docs theme
+ *
+ * A neutral, near-black palette with the copper brand accent, in the style
+ * of a "clean" GitBook site: filled rounded sidebar panel, pill-highlighted
+ * navigation, a narrow content column, and quiet borders instead of shadows.
+ *
+ * Starlight names its gray scale from the dark palette, so in BOTH modes
+ * `--sl-color-white` is the strongest text colour and `--sl-color-black` is
+ * the page background. Everything here is unlayered on purpose: it beats
+ * Starlight's own layered rules without needing !important.
+ * ---------------------------------------------------------------------- */
+
 :root {
-  --sl-color-accent-low: #3a230f;
-  --sl-color-accent: #b87333;
-  --sl-color-accent-high: #eec9a5;
+	--sl-font: 'Inter Variable';
+	--sl-font-mono: 'IBM Plex Mono';
+
+	/* Dark palette */
+	--sl-color-white: #f7f8f8;
+	--sl-color-gray-1: #e3e5e8;
+	--sl-color-gray-2: #b3b8be;
+	--sl-color-gray-3: #8a9098;
+	--sl-color-gray-4: #4c4f53;
+	--sl-color-gray-5: #343638;
+	--sl-color-gray-6: #232425;
+	--sl-color-black: #1b1b1c;
+
+	--sl-color-accent-low: #3b2614;
+	--sl-color-accent: #c47a3a;
+	--sl-color-accent-high: #f2b57e;
+
+	--sl-color-text: var(--sl-color-gray-1);
+	--sl-color-text-accent: #e6a366;
+	--sl-color-text-invert: var(--sl-color-black);
+	--sl-color-bg: var(--sl-color-black);
+	--sl-color-bg-nav: var(--sl-color-black);
+	--sl-color-bg-sidebar: var(--sl-color-gray-6);
+	--sl-color-bg-inline-code: var(--sl-color-gray-6);
+	--sl-color-bg-accent: var(--sl-color-accent);
+	--sl-color-hairline-light: var(--sl-color-gray-5);
+	--sl-color-hairline: var(--sl-color-gray-5);
+	--sl-color-hairline-shade: var(--sl-color-gray-5);
+	--sl-color-backdrop-overlay: rgb(0 0 0 / 0.6);
+
+	/* Theme-specific helpers used by the components */
+	--ch-hover-bg: rgb(255 255 255 / 0.05);
+	--ch-pill-bg: color-mix(in srgb, var(--sl-color-accent) 16%, transparent);
+	--ch-panel-ring: rgb(255 255 255 / 0.04);
+	--ch-on-accent: #1b1b1c;
+	--ch-accent-hover: #d48a48;
+
+	/* Type scale (GitBook-ish: h1 36px, h2 24px, h3 20px) */
+	--sl-text-h1: 2.125rem;
+	--sl-text-h2: 1.5rem;
+	--sl-text-h3: 1.25rem;
+	--sl-text-h4: 1.0625rem;
+	--sl-text-h5: 1rem;
+	--sl-text-code: 0.875rem;
+	--sl-text-code-sm: 0.8125rem;
+	--sl-line-height: 1.65;
+	--sl-line-height-headings: 1.25;
+
+	/* Layout */
+	--sl-sidebar-width: 18rem;
+	--sl-content-width: 48rem;
+	--sl-main-pad: 0 0 4rem 0;
 }
 
 :root[data-theme='light'] {
-  --sl-color-accent-low: #f5e3d2;
-  --sl-color-accent: #9c5c22;
-  --sl-color-accent-high: #4d2e10;
+	--sl-color-white: #1a1b1e;
+	--sl-color-gray-1: #2b2d32;
+	--sl-color-gray-2: #545962;
+	--sl-color-gray-3: #6d747f;
+	--sl-color-gray-4: #c2c8d2;
+	--sl-color-gray-5: #e3e7ed;
+	--sl-color-gray-6: #eff2f6;
+	--sl-color-gray-7: #f7f8fa;
+	--sl-color-black: #ffffff;
+
+	--sl-color-accent-low: #f8e9db;
+	--sl-color-accent: #a35d1f;
+	--sl-color-accent-high: #5d3411;
+
+	--sl-color-text-accent: #9a5619;
+	--sl-color-text-invert: #ffffff;
+	--sl-color-bg-nav: #ffffff;
+	--sl-color-bg-sidebar: var(--sl-color-gray-7);
+	--sl-color-bg-inline-code: var(--sl-color-gray-6);
+	--sl-color-hairline-light: var(--sl-color-gray-5);
+	--sl-color-hairline: var(--sl-color-gray-5);
+	--sl-color-hairline-shade: var(--sl-color-gray-5);
+	--sl-color-backdrop-overlay: rgb(20 22 26 / 0.5);
+
+	--ch-hover-bg: rgb(0 0 0 / 0.045);
+	--ch-pill-bg: color-mix(in srgb, var(--sl-color-accent) 11%, transparent);
+	--ch-panel-ring: rgb(0 0 0 / 0.05);
+	--ch-on-accent: #ffffff;
+	--ch-accent-hover: #8f4f18;
 }
 
-/* The external-link arrow on copperhead.sh links inherits a muted gray and is
-   easy to miss; render it in the copper accent. */
-a[href='https://copperhead.sh'] svg {
-  color: var(--sl-color-accent);
+@media (min-width: 72rem) {
+	:root {
+		--sl-content-pad-x: 2rem;
+	}
 }
 
-/* On the hero action, also bump it past the stock 1.5rem icon size. */
-.hero a[href='https://copperhead.sh'] svg {
-  font-size: 1.75rem;
+/* ---- Base ------------------------------------------------------------- */
+
+body {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+::selection {
+	background-color: color-mix(in srgb, var(--sl-color-accent) 35%, transparent);
+}
+
+.sidebar-pane,
+.right-sidebar {
+	scrollbar-width: thin;
+	scrollbar-color: var(--sl-color-gray-5) transparent;
+}
+
+/* ---- Header ------------------------------------------------------------ */
+
+header.header {
+	border-bottom: 1px solid color-mix(in srgb, var(--sl-color-gray-5) 75%, transparent);
+}
+
+.site-title {
+	gap: 0.5rem;
+	font-size: 1.125rem;
+	font-weight: 600;
+	letter-spacing: -0.01em;
+	color: var(--sl-color-white);
+}
+.site-title img {
+	height: 1.375rem;
+	width: auto;
+}
+
+/* Search trigger */
+@media (min-width: 50rem) {
+	button[data-open-modal] {
+		height: 2.5rem;
+		width: 100%;
+		max-width: 30rem;
+		padding-inline: 0.75rem 0.5rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.75rem;
+		background-color: var(--sl-color-gray-6);
+		color: var(--sl-color-gray-3);
+		font-size: var(--sl-text-sm);
+		transition:
+			border-color 0.12s,
+			color 0.12s;
+	}
+	button[data-open-modal]:hover {
+		border-color: var(--sl-color-gray-4);
+		color: var(--sl-color-gray-1);
+		background-color: var(--sl-color-gray-6);
+	}
+	button[data-open-modal] > kbd {
+		gap: 0.25rem;
+		padding: 0;
+		background: transparent;
+	}
+	button[data-open-modal] > kbd > kbd {
+		padding: 0.05rem 0.35rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.3rem;
+		background-color: var(--sl-color-black);
+		font-family: var(--__sl-font-mono);
+		font-size: 0.6875rem;
+		color: var(--sl-color-gray-3);
+	}
+	dialog {
+		border-radius: 1rem;
+	}
+}
+
+/* ---- Sidebar ----------------------------------------------------------- */
+
+@media (min-width: 50rem) {
+	.sidebar-pane {
+		--ch-sidebar-inset: 1rem;
+		inset-block-start: calc(var(--sl-nav-height) + var(--ch-sidebar-inset));
+		inset-block-end: var(--ch-sidebar-inset);
+		inset-inline-start: var(--ch-sidebar-inset);
+		width: calc(var(--sl-sidebar-width) - var(--ch-sidebar-inset));
+		border-inline-end: 0;
+		border-radius: 1rem;
+		background-color: var(--sl-color-bg-sidebar);
+		box-shadow: inset 0 0 0 1px var(--ch-panel-ring);
+	}
+	.sidebar-content {
+		padding: 1rem 0.75rem 0;
+	}
+	.sidebar-content::after {
+		display: none;
+	}
+}
+
+/* Mobile drawer footer (social icons + theme toggle) */
+.mobile-preferences {
+	border-top-color: var(--sl-color-gray-5);
+}
+
+/* ---- Right rail (table of contents) ----------------------------------- */
+
+.right-sidebar {
+	border-inline-start: 0;
+}
+.right-sidebar-panel {
+	padding: 1.75rem 1rem;
+}
+.right-sidebar-panel h2 {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin-bottom: 0.5rem;
+	padding-inline: 0.625rem;
+	font-size: 0.6875rem;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--sl-color-gray-3);
+}
+.right-sidebar-panel h2::before {
+	content: '';
+	width: 0.875rem;
+	height: 0.875rem;
+	flex-shrink: 0;
+	background-color: currentColor;
+	-webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M4 6h16v2H4zm4 5h12v2H8zm-4 5h16v2H4z'/%3E%3C/svg%3E")
+		center / contain no-repeat;
+	mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M4 6h16v2H4zm4 5h12v2H8zm-4 5h16v2H4z'/%3E%3C/svg%3E")
+		center / contain no-repeat;
+}
+starlight-toc a {
+	--pad-inline: 0.625rem;
+	padding-block: 0.3rem;
+	border-radius: 0.375rem;
+	font-size: var(--sl-text-sm);
+	line-height: 1.35;
+	color: var(--sl-color-gray-3);
+	transition:
+		background-color 0.12s,
+		color 0.12s;
+}
+starlight-toc a:hover {
+	color: var(--sl-color-white);
+	background-color: var(--ch-hover-bg);
+}
+starlight-toc a[aria-current='true'] {
+	color: var(--sl-color-text-accent);
+	background-color: var(--ch-pill-bg);
+}
+/* List only the headings, not the page title itself. */
+starlight-toc li:has(> a[href='#_top']) {
+	display: none;
+}
+
+/* Mobile "On this page" bar */
+mobile-starlight-toc nav {
+	border-top-color: var(--sl-color-gray-5);
+}
+mobile-starlight-toc summary {
+	border-bottom-color: var(--sl-color-gray-5);
+}
+mobile-starlight-toc .toggle {
+	border-radius: 0.5rem;
+	border-color: var(--sl-color-gray-5);
+}
+
+/* ---- Content column ---------------------------------------------------- */
+
+.content-panel {
+	padding: 2rem var(--sl-content-pad-x) 0.5rem;
+}
+.content-panel + .content-panel {
+	border-top: 0;
+	padding-top: 0.75rem;
+}
+
+.sl-markdown-content :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
+	font-weight: 600;
+	letter-spacing: -0.015em;
+	text-wrap: balance;
+}
+.sl-markdown-content :not(h1, h2, h3, h4, h5, h6) + h2:not(:where(.not-content *)) {
+	margin-top: 2.75rem;
+}
+.sl-markdown-content :not(h1, h2, h3, h4, h5, h6) + h3:not(:where(.not-content *)) {
+	margin-top: 2rem;
+}
+
+.sl-markdown-content :is(p, li, td, dd, blockquote) > a:not(:where(.not-content *)) {
+	color: var(--sl-color-text-accent);
+	text-decoration: underline;
+	text-decoration-color: color-mix(in srgb, currentColor 40%, transparent);
+	text-decoration-thickness: 1px;
+	text-underline-offset: 0.2em;
+	transition: text-decoration-color 0.12s;
+}
+.sl-markdown-content :is(p, li, td, dd, blockquote) > a:hover:not(:where(.not-content *)) {
+	color: var(--sl-color-text-accent);
+	text-decoration-color: currentColor;
+}
+
+.sl-markdown-content code:not(:where(.not-content *)) {
+	padding: 0.1em 0.4em;
+	border-radius: 0.375rem;
+	box-shadow: inset 0 0 0 1px var(--sl-color-gray-5);
+	font-size: 0.875em;
+}
+
+.sl-markdown-content blockquote:not(:where(.not-content *)) {
+	border-inline-start: 2px solid var(--sl-color-gray-4);
+	color: var(--sl-color-gray-2);
+}
+
+.sl-markdown-content hr:not(:where(.not-content *)) {
+	border-color: var(--sl-color-gray-5);
+}
+
+.sl-markdown-content th:not(:where(.not-content *)) {
+	font-size: var(--sl-text-sm);
+	color: var(--sl-color-gray-2);
+}
+.sl-markdown-content :is(th, td):not(:where(.not-content *)) {
+	border-bottom-color: var(--sl-color-gray-5);
+}
+
+.sl-markdown-content kbd:not(:where(.not-content *)) {
+	padding: 0.1em 0.4em;
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.3rem;
+	background-color: var(--sl-color-gray-6);
+	font-family: var(--__sl-font-mono);
+	font-size: 0.8em;
+}
+
+/* Asides: rounded, quietly tinted cards instead of a heavy left border. */
+.starlight-aside {
+	padding: 1rem 1.125rem;
+	border: 1px solid color-mix(in srgb, var(--sl-color-asides-border) 28%, transparent);
+	border-radius: 0.75rem;
+	background-color: color-mix(in srgb, var(--sl-color-asides-border) 6%, transparent);
+	color: var(--sl-color-text);
+}
+.starlight-aside__title {
+	font-size: var(--sl-text-sm);
+	color: var(--sl-color-white);
+}
+.starlight-aside__icon {
+	color: var(--sl-color-asides-border);
+}
+.starlight-aside__content a {
+	color: var(--sl-color-text-accent);
+}
+
+/* Code blocks (Expressive Code) */
+.expressive-code .frame {
+	box-shadow: none;
+}
+
+/* Search dialog: copper focus ring on the query box instead of the browser default. */
+#starlight__search .pagefind-ui__search-input:focus {
+	outline: 2px solid var(--sl-color-accent);
+	outline-offset: -1px;
+}
+
+/* ---- Footer: pagination cards, then meta ------------------------------ */
+
+footer.sl-flex {
+	gap: 1.25rem;
+}
+footer .meta {
+	order: 2;
+	margin-top: 0;
+	font-size: var(--sl-text-sm);
+	color: var(--sl-color-gray-3);
+}
+footer .meta a:hover {
+	color: var(--sl-color-white);
+}
+
+.pagination-links {
+	order: 1;
+	gap: 0.875rem;
+	margin-top: 3rem;
+}
+.pagination-links a {
+	gap: 0.75rem;
+	padding: 0.875rem 1rem;
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.75rem;
+	box-shadow: none;
+	font-size: var(--sl-text-xs);
+	color: var(--sl-color-gray-3);
+	transition:
+		border-color 0.15s,
+		transform 0.15s;
+}
+.pagination-links a:hover {
+	border-color: var(--sl-color-accent);
+	transform: translateY(-1px);
+}
+.pagination-links svg {
+	font-size: 1.125rem;
+	color: var(--sl-color-gray-3);
+}
+.pagination-links .link-title {
+	font-size: var(--sl-text-base);
+	font-weight: 500;
+	color: var(--sl-color-white);
+	transition: color 0.15s;
+}
+.pagination-links a:hover .link-title {
+	color: var(--sl-color-text-accent);
+}
+
+/* ---- Built-in Starlight cards, if used in content ---------------------- */
+
+.sl-link-card {
+	border-color: var(--sl-color-gray-5);
+	border-radius: 0.75rem;
+	box-shadow: none;
+}
+.sl-link-card:hover {
+	background: transparent;
+	border-color: var(--sl-color-accent);
+}
+.sl-link-card .title {
+	font-size: var(--sl-text-base);
+}
+.card {
+	border-color: var(--sl-color-gray-5);
+	border-radius: 0.75rem;
 }


### PR DESCRIPTION
## What

Restyles docs.copperhead.sh after GitBook's "clean" theme (the look of docs.quilter.ai): a neutral near-black palette with the copper accent, a floating rounded sidebar with per-page icons and a tinted active pill, a wide header search box with a "Get started" button, a section eyebrow and lead paragraph above each page, and a landing page rebuilt as a "Welcome" doc page with "Jump right in" rows and "Keep exploring" card groups. Still Astro Starlight, so search, edit links, last-updated stamps, and the llms.txt plugin are unchanged.

## Why

The stock Starlight look (blue accent, splash hero, boxed sidebar) reads as a template. The docs are the first thing most people open, and the GitBook clean layout is a proven docs pattern: denser navigation, a narrow readable column, quiet borders instead of shadows, and a landing page that routes readers instead of pitching them.

## Design

Everything lives in `docs/`; no runtime code changes.

- [custom.css](docs/src/styles/custom.css) holds the palette, type scale, and layout. It is deliberately unlayered so it overrides Starlight's own cascade layers without `!important`. Starlight names its gray scale from the dark palette, so `--sl-color-white` is the strongest text colour and `--sl-color-black` the page background in both modes; the file documents this.
- Component overrides in [docs/src/components/](docs/src/components/): [Header.astro](docs/src/components/Header.astro), [Sidebar.astro](docs/src/components/Sidebar.astro) plus [SidebarSublist.astro](docs/src/components/SidebarSublist.astro), [PageTitle.astro](docs/src/components/PageTitle.astro), and [ThemeSelect.astro](docs/src/components/ThemeSelect.astro). The sidebar keeps Starlight's persister and restore points so open/closed state and scroll position survive navigation. The theme toggle writes the same `starlight-theme` storage key Starlight's inline provider reads, so there is no flash on load.
- Per-page sidebar icons are set in [astro.config.mjs](docs/astro.config.mjs) via `attrs: { 'data-icon': '<starlight icon>' }` and rendered by the sublist override.
- [JumpLink.astro](docs/src/components/JumpLink.astro), [DocCard.astro](docs/src/components/DocCard.astro), and [DocCards.astro](docs/src/components/DocCards.astro) are the landing-page building blocks used by [index.mdx](docs/src/content/docs/index.mdx).
- Fonts: Inter Variable and IBM Plex Mono via `@fontsource-variable/inter` and `@fontsource/ibm-plex-mono` (self-hosted, no third-party requests). The lockfile diff also drops `libc` fields from sharp's optional-dependency entries; that is npm 11 normalising the lockfile, not a dependency change.
- Theme still follows the system preference by default. Quilter forces dark; easy to flip if preferred.

Gotcha for anyone iterating locally: after changing the `expressiveCode` config, Astro's content-layer cache keeps the old code-block stylesheet link on unchanged `.md` pages, which 404s in a local preview. `astro build --force` (or deleting `docs/.astro`) fixes it; CI builds from a clean checkout and is unaffected.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | n/a (docs-only, no `src/` changes) |
| Build | `npm run build` | n/a (docs-only) |
| Unit + offline | `npm test` | n/a (docs-only) |
| Live-LLM (opt-in) | keyed on `<ENV_VAR>` | n/a |
| Markdown lint | `npm run lint:md` | pass |
| Docs build | `npm ci && npm run build` in `docs/` (fresh worktree from main) | pass, 17 pages |

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a, docs-only
- Commands run and outcome: built the site, served `docs/dist` locally, and screenshotted it with headless Chromium.

```text
$ npm --prefix docs run build
17 page(s) built, every page links the single emitted ec.*.css

Checked in the browser (1440, 1024, 820, and 390 px wide; dark and light):
  /                                   landing page, sidebar, right rail, pagination
  /getting-started/quickstart/        steps, terminal code frames, tip callout
  /reference/cli/ and /reference/configuration/   tables, inline code, highlighted JSON
  mobile drawer open, search dialog with results, theme toggle
```

## Docs

All changes are the docs site itself, under [docs/](docs/). No README, configuration reference, or CHANGELOG/DECISIONS entries touched.

---

## Invariant checklist

All N/A: this PR changes only the documentation site's theme and landing page, no runtime code.

- [ ] N/A **Spec-gated in**: `edit_file`/`write_file` stay structurally absent from the agent tool list until an OpenSpec proposal validates (gated by omission, not prompt text).
- [ ] N/A **Verification-gated out**: mutations still end in ERC (and DRC when the board changed) passing, with repair up to `maxRepairCycles` then rollback to the git snapshot.
- [ ] N/A **`check`/`verify` stays LLM-free and network-free**: nothing reachable from `src/commands/check` touches a provider, an API key, or the network.
- [ ] N/A **No sexp serialization**: the `src/kicad/` parser stays read-only; KiCad files are edited only via anchored exact-match text replace (no round-tripping).
- [ ] N/A **Sync-obligations ledger**: post-tool-call hooks keep feeding the ledger, and commit keeps refusing while obligations are open.
- [ ] N/A **Secrets**: transcripts and summaries redact `sk-[A-Za-z0-9_-]+` at write time; keys live only in env vars; `.gitignore` keeps `.env` and `.copperhead/runs/`.
- [ ] N/A **Spec coherence**: if spec-level behavior changed, SPEC.md and the change artifacts (`proposal.md`, `design.md`, delta specs, `tasks.md`) moved together and `openspec validate <change>` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
