### PR TITLE
fix(agent): close skill-run providers and stop reporting unverifiable as failure

### DIFF
--- a/openspec/changes/formalize-tool-registry/specs/cli-surface/spec.md
+++ b/openspec/changes/formalize-tool-registry/specs/cli-surface/spec.md
@@ -3,7 +3,7 @@
 ## ADDED Requirements
 
 ### Requirement: `skill` command
-The CLI SHALL provide `copperhead skill list` and `copperhead skill run <name>`. `skill list` SHALL print registered skills and whether each would be present in `registry.list(ctx)` for the current repo, make zero LLM calls, make zero network calls, and create no transcript or run directory. `skill run <name>` SHALL invoke that skill's nested sub-run with the same definition the model catalog uses and print the resulting envelope. A missing API key on `skill run` SHALL exit non-zero with a message naming the missing env var and without a stack trace. An unknown skill name SHALL exit non-zero naming the name.
+The CLI SHALL provide `copperhead skill list` and `copperhead skill run <name>`. `skill list` SHALL print registered skills and whether each would be present in `registry.list(ctx)` for the current repo, make zero LLM calls, make zero network calls, and create no transcript or run directory. `skill run <name>` SHALL invoke that skill's nested sub-run with the same definition the model catalog uses and print the resulting envelope. A missing API key on `skill run` SHALL exit non-zero with a message naming the missing env var and without a stack trace. An unknown skill name SHALL exit non-zero naming the name. `skill run` SHALL close the provider it created before the process exits, on the success, failure, and throw paths alike, so no saved-login working directory or subprocess outlives the command.
 
 #### Scenario: Help lists skill
 - **WHEN** `copperhead --help` is run
@@ -24,3 +24,7 @@ The CLI SHALL provide `copperhead skill list` and `copperhead skill run <name>`.
 #### Scenario: unknown skill
 - **WHEN** `copperhead skill run does-not-exist` is invoked
 - **THEN** the process exits non-zero and the message contains `does-not-exist`
+
+#### Scenario: run releases its provider
+- **WHEN** `copperhead skill run <name>` finishes, whether the report succeeded, the provider threw, or the skill name was unknown
+- **THEN** the provider it created has been closed before the process exits, and a provider whose `close` itself throws yields a warning rather than losing the run result

--- a/openspec/changes/formalize-tool-registry/specs/tool-registry/spec.md
+++ b/openspec/changes/formalize-tool-registry/specs/tool-registry/spec.md
@@ -47,6 +47,10 @@ Every tool and skill invocation SHALL return a `ToolResult` of the form `{ ok, s
 - **WHEN** an unsuccessful domain-result envelope has `detail` but no typed invocation `error`
 - **THEN** flattening includes both its summary and detail
 
+#### Scenario: Unverifiable is not failure
+- **WHEN** a diagnostic's findings are all "could not check" rather than divergences, as `verify_symbols` reports on a machine where the referenced libraries are not installed
+- **THEN** the envelope has `ok: true`, because the tool found zero issues to reconcile, and the renderer does not show a failure glyph for it
+
 ### Requirement: Predicate gating
 Each catalog entry SHALL declare `gate: (ctx) => boolean`. An entry whose gate returns false SHALL be absent from `registry.list(ctx)` and SHALL NOT appear in the tool list sent to the provider. A boolean `requiresUnlock` field SHALL NOT exist on the catalog type.
 

--- a/openspec/changes/formalize-tool-registry/tasks.md
+++ b/openspec/changes/formalize-tool-registry/tasks.md
@@ -62,3 +62,12 @@
 - [x] 8.4 Keep `skill list` filesystem-side-effect-free and give off-list skill calls an accurate unavailable reason
 - [x] 8.5 Clone registry entries before binding default gates; cover weak gates, singleton isolation, refusal, JSON, no-provider, nudge, exception, retry, timeout, partial, and repeated-result paths
 - [x] 8.6 Re-run typecheck, focused tests, full offline suite, build, and `openspec validate formalize-tool-registry`; document environment-only failures honestly
+
+## 9. PR #255 second-round review fixes
+
+- [x] 9.1 Close the provider `skill run` created on every exit path (`runSkillCli`), so no saved-login working directory or subprocess outlives the command
+- [x] 9.2 `verify_symbols` reports `ok` from real mismatches, not from the unverifiable `no-library` bucket
+- [x] 9.3 Conformance asserts the property that matters — a skill present in `registry.list(ctx)` has every declared tool's gate open — instead of the declared `ownGate`
+- [x] 9.4 Availability test brackets its singleton gate swap so no assertion can leak it; drop the dead `isRetryableToolKind` export (retry policy stays pinned by the 429/exception dispatch test)
+- [x] 9.5 One `MAX_TURN_TIMEOUTS` constant shared by the main loop and the nested sub-run
+- [x] 9.6 Re-run typecheck, build, full offline suite, and `openspec validate formalize-tool-registry`

--- a/src/agent/envelope.ts
+++ b/src/agent/envelope.ts
@@ -113,10 +113,6 @@ export function textResult(text: string, viewHint: ViewHint): ToolResult {
   return okResult(text, viewHint);
 }
 
-export function isRetryableToolKind(kind: ToolErrorKind): boolean {
-  return kind === 'exception';
-}
-
 export function unavailable(name: string, editsUnlocked: boolean, reason?: string): ToolResult {
   const suffix = reason
     ? ` (${reason})`

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -5,7 +5,7 @@ import type { Msg, Provider, Turn } from './types.js';
 import { availableTools, dispatchToolResult, type RunContext } from './tools.js';
 import { flatten } from './envelope.js';
 import { CachingProvider } from './response-cache.js';
-import { withTimeout, TurnTimeoutError } from './recovery.js';
+import { withTimeout, TurnTimeoutError, MAX_TURN_TIMEOUTS } from './recovery.js';
 import { buildSystemPrompt } from './prompts.js';
 import { loadConstraints, reopenDeferredAffects } from '../memory/constraints.js';
 import { isCreateProducedRepo, isEngineAuthoredSchematic } from '../kicad/fab.js';
@@ -350,7 +350,7 @@ async function runWithProviders(opts: RunOptions, providers: Set<Provider>): Pro
   let plan: string | null = null;
   let nudges = 0;
   let turnTimeouts = 0;
-  const maxTurnTimeouts = 3;
+  const maxTurnTimeouts = MAX_TURN_TIMEOUTS;
 
   const stats = (exitPath: ExitPath): RunStats => ({
     exitPath,

--- a/src/agent/recovery.ts
+++ b/src/agent/recovery.ts
@@ -4,6 +4,12 @@ import path from 'node:path';
 import type { Msg, Provider } from './types.js';
 import { resolveLibrarySymbol, searchInstalledSymbols, symbolSearchDirs, listInstalledLibraries } from '../kicad/symlib.js';
 
+/**
+ * How many times a hung provider turn is retried before the run gives up. One
+ * policy, two turn loops: the main agent loop and the nested skill sub-run.
+ */
+export const MAX_TURN_TIMEOUTS = 3;
+
 /** Thrown when a single provider turn blows past its watchdog deadline. */
 export class TurnTimeoutError extends Error {
   constructor(public readonly ms: number) {

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -3,7 +3,7 @@ import { corruptionError } from '../capabilities/helpers.js';
 import { flatten, failResult, seal, unavailable, type ToolResult } from './envelope.js';
 import { registry } from './registry.js';
 import { withRetry, isRateLimit } from '../util/retry.js';
-import { TurnTimeoutError, withTimeout } from './recovery.js';
+import { MAX_TURN_TIMEOUTS, TurnTimeoutError, withTimeout } from './recovery.js';
 import type { RunContext } from './context.js';
 import type { Msg, Provider, Turn } from './types.js';
 
@@ -83,7 +83,7 @@ export async function runSkillSubRun(opts: {
           );
           break;
         } catch (err) {
-          if (err instanceof TurnTimeoutError && timeoutRetries++ < 3) {
+          if (err instanceof TurnTimeoutError && timeoutRetries++ < MAX_TURN_TIMEOUTS) {
             await ctx.transcript.event('skill-turn-timeout', {
               skill: skill.name,
               ms: ctx.config.turnTimeoutMs,

--- a/src/capabilities/handlers.ts
+++ b/src/capabilities/handlers.ts
@@ -373,9 +373,13 @@ export const HANDLERS: HandlerDef[] = [
         return { ok: true, text: `verify_symbols: ${checked} symbol(s) match the installed KiCad library. No divergences.` };
       }
       const lines = findings.map((f) => `  - [${f.kind}] ${f.detail}`);
+      // 'no-library' is the *unverifiable* bucket (counted in `skipped`), not a
+      // divergence: a machine without the library installed has nothing to
+      // reconcile. Failing on it would report a red for "0 issue(s)" — the
+      // mirror of the false-green glyph this outcome plumbing exists to fix.
       const mismatches = findings.filter((f) => f.kind !== 'no-library').length;
       return {
-        ok: false,
+        ok: mismatches === 0,
         text: `verify_symbols: ${checked} verified, ${skipped} unverifiable (library not installed), ${mismatches} issue(s) to reconcile:\n${lines.join('\n')}`,
       };
     },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -349,21 +349,26 @@ skillCmd
   .action(async (name: string, opts: { model?: string; scope?: string }) => {
     const repo = repoOf(program.opts());
     const json = Boolean(program.opts().json);
+    // `process.exit` skips pending finally blocks, so the provider close has to
+    // finish before the exit call — hence the code is carried out, not exited on.
+    let code = 1;
     try {
-      const { runSkill, providerForSkillRun, formatSkillEnvelope } = await import('./commands/skill.js');
+      const { runSkillCli, providerForSkillRun } = await import('./commands/skill.js');
       const { provider } = await providerForSkillRun(repo, opts.model);
-      const result = await runSkill({
+      const res = await runSkillCli({
         repoRoot: repo,
         name,
         args: { scope: opts.scope === 'power' ? 'power' : 'all' },
         provider,
+        json,
       });
-      console.log(formatSkillEnvelope(result, json));
-      process.exit(result.ok ? 0 : 1);
+      console.log(res.text);
+      code = res.code;
     } catch (err) {
       console.error((err as Error).message);
-      process.exit(1);
+      code = 1;
     }
+    process.exit(code);
   });
 
 program

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -64,6 +64,42 @@ export function formatSkillEnvelope(result: ToolResult, json: boolean): string {
   return result.ok ? body : `error: ${body}`;
 }
 
+/**
+ * One skill run plus the provider's lifecycle. A saved-login provider owns a
+ * `mkdtemp` working directory (and, on some backends, an in-flight subprocess);
+ * `runAgentLoop` closes it in a `finally` because leaving it behind orphans the
+ * process and fills the disk (I8). `skill run` has no agent loop to inherit that
+ * from, so the close lives here — around the throw path too, since an unknown or
+ * unavailable skill must not leak the provider it already built. Returns the text
+ * to print and the exit code, so the CLI's only job is `console.log` + `exit`.
+ */
+export async function runSkillCli(opts: {
+  repoRoot: string;
+  name: string;
+  args?: Record<string, unknown>;
+  provider: Provider;
+  json: boolean;
+  warn?: (line: string) => void;
+}): Promise<{ text: string; code: number }> {
+  try {
+    const result = await runSkill({
+      repoRoot: opts.repoRoot,
+      name: opts.name,
+      ...(opts.args ? { args: opts.args } : {}),
+      provider: opts.provider,
+    });
+    return { text: formatSkillEnvelope(result, opts.json), code: result.ok ? 0 : 1 };
+  } finally {
+    try {
+      await opts.provider.close?.();
+    } catch (err) {
+      (opts.warn ?? ((l: string) => console.error(l)))(
+        `warning: ${opts.provider.name} provider cleanup failed (${(err as Error).message})`,
+      );
+    }
+  }
+}
+
 async function minimalCtx(repoRoot: string, initializeTranscript = true): Promise<RunContext> {
   const transcript = new Transcript(repoRoot);
   if (initializeTranscript) await transcript.init();

--- a/test/capability-conformance.test.ts
+++ b/test/capability-conformance.test.ts
@@ -75,9 +75,15 @@ describe('capability conformance', () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       const ctx = await lockedCtx(repo);
+      // The property is about what `list` HANDS OUT, not about the declared
+      // gate: a skill declaring edit_file legitimately has an open ownGate
+      // (defineSkill defaults it to `() => true`) and is correctly absent while
+      // locked. Asserting on ownGate would fail that skill the day someone adds
+      // one; asserting on membership fails only the case that actually matters —
+      // a listed skill whose declared tools are not all open.
+      const listed = new Set(registry.list(ctx).map((e) => e.name));
       for (const s of registry.skills()) {
-        const conj = registry.conjunction(s.tools, ctx);
-        if (s.ownGate(ctx)) expect(conj, s.name).toBe(true);
+        if (listed.has(s.name)) expect(registry.conjunction(s.tools, ctx), s.name).toBe(true);
       }
     } finally {
       await cleanup();

--- a/test/envelope.test.ts
+++ b/test/envelope.test.ts
@@ -7,7 +7,6 @@ import {
   seal,
   textResult,
   unavailable,
-  isRetryableToolKind,
 } from '../src/agent/envelope.js';
 import { toolLine } from '../src/agent/theme.js';
 
@@ -31,13 +30,6 @@ describe('ToolResult envelope', () => {
     expect(r.error?.kind).toBe('unavailable');
     expect(flatten(r)).toContain('not available');
     expect(flatten(r)).toContain('unlock');
-  });
-
-  it('only exception kinds are retryable', () => {
-    expect(isRetryableToolKind('exception')).toBe(true);
-    expect(isRetryableToolKind('validation')).toBe(false);
-    expect(isRetryableToolKind('refusal')).toBe(false);
-    expect(isRetryableToolKind('unavailable')).toBe(false);
   });
 
   it('textResult maps error: prefixes to validation (not retried)', () => {

--- a/test/tool-registry.test.ts
+++ b/test/tool-registry.test.ts
@@ -10,6 +10,7 @@ import { defineSkill } from '../src/capabilities/define.js';
 import { ToolRegistry } from '../src/agent/registry.js';
 import {
   runSkill,
+  runSkillCli,
   listSkills,
   catalogNameFromCli,
   providerForSkillRun,
@@ -247,6 +248,28 @@ describe('tool-registry catalog', () => {
     }
   });
 
+  it('verify_symbols stays ok when the only findings are uninstalled libraries', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const ctx = await makeCtx(repo);
+      // One lib_symbols entry from a library that cannot exist on any machine:
+      // findings is non-empty but every entry is 'no-library', the unverifiable
+      // bucket. verifySchematicSymbols documents that absence of a library is
+      // never a mismatch, so the tool must not report failure for "0 issue(s)".
+      await writeFile(
+        path.join(repo, ctx.config.schematic),
+        '(kicad_sch (version 20231120) (generator "test") (lib_symbols (symbol "NoSuchLib9x:Widget" ' +
+          '(pin passive line (at 0 0 0) (length 2.54) (name "A") (number "1")))))\n',
+      );
+      const env = await dispatchToolResult(ctx, 'verify_symbols', {});
+      expect(flatten(env)).toContain('0 issue(s) to reconcile');
+      expect(env.ok).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('a thrown 429 retries through withRetry; a plain exception surfaces once (design D10)', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
@@ -462,6 +485,66 @@ describe('skill CLI', () => {
     }
   });
 
+  it('closes the provider after a skill run, on both the ok and the failing path', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      // A saved-login provider owns a temp working directory; leaving it behind
+      // is the I8 disk-fill mode runAgentLoop's finally exists to prevent, and
+      // `skill run` has no agent loop to inherit that from.
+      let closes = 0;
+      const provider: Provider = {
+        name: 'closable',
+        async chat() {
+          throw new Error('provider 502');
+        },
+        async close() {
+          closes++;
+        },
+      };
+      const failed = await runSkillCli({ repoRoot: repo, name: 'generate-report', provider, json: false });
+      expect(failed.code).toBe(1);
+      expect(failed.text).toContain('provider 502');
+      expect(closes).toBe(1);
+
+      // The throw path (unknown skill) must not leak the provider it already built.
+      await expect(
+        runSkillCli({ repoRoot: repo, name: 'banana', provider, json: false }),
+      ).rejects.toThrow(/unknown skill/);
+      expect(closes).toBe(2);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('a provider whose close throws still yields the run result', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      await runInit({ repoRoot: repo });
+      const warnings: string[] = [];
+      const provider: Provider = {
+        name: 'grumpy',
+        async chat() {
+          return { text: 'done', toolCalls: [], usage: { inputTokens: 1, outputTokens: 1 } };
+        },
+        async close() {
+          throw new Error('cleanup exploded');
+        },
+      };
+      const res = await runSkillCli({
+        repoRoot: repo,
+        name: 'generate-report',
+        provider,
+        json: false,
+        warn: (l) => warnings.push(l),
+      });
+      expect(res.code).toBe(1);
+      expect(warnings.join('\n')).toContain('cleanup exploded');
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('formats the JSON skill envelope', () => {
     const text = formatSkillEnvelope({ ok: true, summary: 'report', viewHint: 'diagnostic' }, true);
     expect(JSON.parse(text)).toMatchObject({ ok: true, summary: 'report' });
@@ -479,12 +562,15 @@ describe('skill CLI', () => {
     }
   });
 
+  // `runSkill` resolves through the module singleton by design, so closing a
+  // gate on it is the only seam that reaches the "unavailable" branch. Capture
+  // and restore bracket the whole body — including the fixture — so no assertion
+  // can leave the singleton (or a temp repo) behind for the next test.
   it('names a registered skill that is unavailable in the current repo', async () => {
-    const { repo, cleanup } = await tempFixtureRepo();
     const skill = registry.get('generate_report');
-    expect(skill?.kind).toBe('skill');
-    if (skill?.kind !== 'skill') return;
+    if (skill?.kind !== 'skill') throw new Error('generate_report is not a registered skill');
     const gate = skill.gate;
+    const { repo, cleanup } = await tempFixtureRepo();
     try {
       await runInit({ repoRoot: repo });
       skill.gate = () => false;
@@ -495,6 +581,7 @@ describe('skill CLI', () => {
       skill.gate = gate;
       await cleanup();
     }
+    expect(registry.get('generate_report')?.gate).toBe(gate);
   });
 
   it('run without a key names the missing env', async () => {


### PR DESCRIPTION
## What

Six follow-up fixes to the two-tier tool catalog merged in #255 (`26d9b51`): one medium (a provider handle `copperhead skill run` never closed) and five low. No new features; `check`, `create` stages, and spec-gated edits are unchanged.

## Why

These are the findings from the [second automated review pass](https://github.com/copperheadhq/copperhead/pull/255#issuecomment-5560861628) on #255. They were non-blocking, so #255 merged without them; the patch could not be pushed to the contributor's fork branch, so it lands here instead.

## Design

**`skill run` now owns its provider's lifecycle.** `providerForSkillRun` built a provider and the command exited without closing it. `close()` is what removes the saved-login backend's `mkdtemp` working directory and aborts its subprocess — `runAgentLoop` does it in a `finally` for exactly that reason (the I8 disk-fill mode; see the comment on `close()` in [claude-code.ts](src/agent/providers/claude-code.ts)), and `skill run` had no agent loop to inherit it from. `sweepStaleTempDirs` only runs from `create`, so the directories accumulated until some later `create` happened to reclaim them, age-gated at 2h.

New [`runSkillCli`](src/commands/skill.ts) brackets the run — including the unknown-skill throw path, so a provider that was already built is not leaked — and warns rather than losing the result when `close()` itself throws. [cli.ts](src/cli.ts) carries an exit code out instead of calling `process.exit` inside the `try`, since `process.exit` skips pending `finally` blocks.

**`verify_symbols` stops reporting unverifiable as failure.** It returned `ok: false` for any non-empty findings array, but `no-library` is the *unverifiable* bucket — counted into `skipped`, excluded from `mismatches`, and documented on `verifySchematicSymbols` as "never treated as a mismatch". On a machine without the referenced libraries it printed `0 issue(s) to reconcile` under a failure glyph: the mirror of the false-green glyph #255 fixed. Now reports from the mismatch count.

Also:

- The surviving conformance assertion (`if (s.ownGate(ctx)) expect(conj).toBe(true)`) became a latent false positive once `ownGate` stopped being rebound to the conjunction — it would fail the first legitimate mutation skill someone adds, even though `registry.list` correctly omits it. Now asserts the property that matters: present in `registry.list(ctx)` ⇒ every declared tool's gate open.
- The availability test's singleton `gate` swap is bracketed so no assertion can leak it.
- The two hardcoded turn-timeout budgets become one shared `MAX_TURN_TIMEOUTS` in [recovery.ts](src/agent/recovery.ts).
- Dead `isRetryableToolKind` dropped; the dispatch 429/exception test still pins the real retry policy. `protocolVersion` **stays** — `specs/tool-registry/spec.md` requires the registry to expose it.

## Spec / OpenSpec

Change: `formalize-tool-registry` (`openspec validate formalize-tool-registry` passes). `cli-surface` gains the provider-release guarantee for `skill run`; `tool-registry` gains an "unverifiable is not failure" scenario; `tasks.md` gains §9.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Unit + offline | `npm test` | pass (892 pass, 0 fail, 21 skip) |
| OpenSpec | `openspec validate formalize-tool-registry` | valid |

Three new regression tests: provider closed on both the failing and the unknown-skill throw path; a provider whose `close` throws still yields the run result; `verify_symbols` stays `ok` when every finding is `no-library`.

Note on the suite: a bare `npm test` on a machine with a user-level KiCad `sym-lib-table` shows 3 environmental failures (`init-check`, `stage-completion`, `gating-sync`) from `lib_symbol_mismatch` ERC warnings on the open-key fixture. Run with an isolated `KICAD_CONFIG_HOME` containing only `10.0/fp-lib-table` to reproduce CI, where the suite is fully green.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): `edit` (temp copy of `test/fixtures/open-key`, then `init`)
- Commands run and outcome:

```text
$ node --import tsx src/cli.ts --repo <sandbox> skill list
· generate-report  Read-only report of the current design: ERC, DRC (if a board exists), drift, nets, and an optional SVG path. Does not edit files.
exit 0
$ ls -a <sandbox>/.copperhead
(no .copperhead)          # skill list still creates no run directory

$ node --import tsx src/cli.ts --repo <sandbox> skill run banana
exit 1 (no stack trace)

$ env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u COPPERHEAD_MODEL \
    node --import tsx src/cli.ts --repo <sandbox> skill run generate-report
no model configured: ... skill run needs OPENAI_API_KEY, ANTHROPIC_API_KEY, or --model for a saved-login provider (codex, claude-code, cursor).
exit 1 (no stack trace)
```

## Docs

No user-facing doc change: `skill list` / `skill run` are documented in README.md as of #255, and their behavior is unchanged apart from releasing the provider.

---

## Invariant checklist

- [x] **Spec-gated in**: `edit_file`/`write_file` stay structurally absent from the agent tool list until an OpenSpec proposal validates (gated by omission, not prompt text). Untouched by this PR.
- [x] **Verification-gated out**: mutations still end in ERC (and DRC when the board changed) passing, with repair up to `maxRepairCycles` then rollback. Untouched; `verify_symbols` is a diagnostic and its `ok` does not gate `finish`.
- [x] **`check`/`verify` stays LLM-free and network-free**: `src/commands/check.ts` and its import graph are untouched; the module-graph guard still passes.
- [N/A] **No sexp serialization**: the `src/kicad/` parser and edit path are untouched.
- [x] **Sync-obligations ledger**: post-tool-call hooks keep feeding the ledger and commit keeps refusing while obligations are open. Untouched.
- [x] **Secrets**: redaction at transcript write time and at envelope construction unchanged; `.gitignore` keeps `.env` and `.copperhead/runs/`.
- [x] **Spec coherence**: the `formalize-tool-registry` delta specs and `tasks.md` move with the code and `openspec validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
