### PR TITLE
Feature/pattern bom expansion

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,0 +1,53 @@
+# Circuit Pattern Library
+
+This directory contains static, read-only reference definitions of standard, proven circuit blocks under `src/kicad/patterns/`.
+
+> [!IMPORTANT]
+> **Read-Only Reference Corpus**
+>
+> These are read-only reference data. Consuming these patterns from part-selection or the schematic drafting step is a separate, future proposal (see [issue #274](https://github.com/copperheadhq/copperhead/issues/274)) and is not implemented here.
+
+## Overview
+
+Each pattern file defines a self-contained circuit block using the declarative component (`parts`) and netlist (`nets`) structure compatible with `SchematicIntent`.
+
+All pattern files are validated against `src/kicad/patterns/pattern.schema.json` via:
+
+```bash
+npm run validate:patterns
+```
+
+## Available Patterns
+
+| Pattern File | Pattern Name | Description | Part Count |
+|:---|:---|:---|:---:|
+| `voltage-regulator-ams1117.json` | `voltage-regulator-ams1117` | AMS1117 3.3V linear voltage regulator subcircuit with input and output ceramic decoupling capacitors. | 3 |
+| `usb-c-power-input.json` | `usb-c-power-input` | USB Type-C 16-pin USB 2.0 power input sink block with 5.1k CC1/CC2 pull-down resistors and VBUS bulk capacitor. | 4 |
+| `crystal-oscillator.json` | `crystal-oscillator` | Standard crystal oscillator resonant circuit with dual load capacitors, matching canonical crystal flanking topology. | 3 |
+
+## Schema and Structure
+
+Pattern files follow the top-level schema defined in `src/kicad/patterns/pattern.schema.json`:
+
+```json
+{
+  "name": "pattern-identifier",
+  "description": "Human-readable description of the subcircuit.",
+  "parts": [
+    {
+      "ref": "U1",
+      "libId": "Regulator_Linear:AMS1117-3.3",
+      "value": "AMS1117-3.3",
+      "footprint": "Package_TO_SOT_SMD:SOT-223-3_TabPin2",
+      "group": "Power"
+    }
+  ],
+  "nets": [
+    {
+      "name": "VIN",
+      "pins": ["U1.3", "C1.1"],
+      "kind": "power"
+    }
+  ]
+}
+```

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,11 +1,6 @@
 # Circuit Pattern Library
 
-This directory contains static, read-only reference definitions of standard, proven circuit blocks under `src/kicad/patterns/`.
-
-> [!IMPORTANT]
-> **Read-Only Reference Corpus**
->
-> These are read-only reference data. Consuming these patterns from part-selection or the schematic drafting step is a separate, future proposal (see [issue #274](https://github.com/copperheadhq/copperhead/issues/274)) and is not implemented here.
+This directory contains static reference definitions of standard, proven circuit blocks under `src/kicad/patterns/`.
 
 ## Overview
 
@@ -24,6 +19,39 @@ npm run validate:patterns
 | `voltage-regulator-ams1117.json` | `voltage-regulator-ams1117` | AMS1117 3.3V linear voltage regulator subcircuit with input and output ceramic decoupling capacitors. | 3 |
 | `usb-c-power-input.json` | `usb-c-power-input` | USB Type-C 16-pin USB 2.0 power input sink block with 5.1k CC1/CC2 pull-down resistors and VBUS bulk capacitor. | 4 |
 | `crystal-oscillator.json` | `crystal-oscillator` | Standard crystal oscillator resonant circuit with dual load capacitors, matching canonical crystal flanking topology. | 3 |
+
+## Using Patterns During Part-Selection
+
+During Stage 3 (`part-selection`), circuit patterns can be referenced directly by name instead of enumerating every part by hand:
+
+```bash
+copperhead create --stage part-selection
+# Output:
+# Resolved pattern "voltage-regulator-ams1117" -> 3 parts added to BOM.md
+```
+
+### Before and After in `BOM.md`
+
+**Before resolution:**
+```markdown
+| Refdes | Value | Footprint | MPN | Rationale |
+|---|---|---|---|---|
+| U2 | ESP32-WROOM-32 | RF_Module:ESP32-WROOM-32 | ESP32-WROOM-32D | Main MCU |
+use pattern: voltage-regulator-ams1117
+```
+
+**After resolution:**
+```markdown
+| Refdes | Value | Footprint | MPN | Rationale |
+|---|---|---|---|---|
+| U2 | ESP32-WROOM-32 | RF_Module:ESP32-WROOM-32 | ESP32-WROOM-32D | Main MCU |
+| Pattern: voltage-regulator-ams1117 | source: src/kicad/patterns/voltage-regulator-ams1117.json |
+| U1 | AMS1117-3.3 | Package_TO_SOT_SMD:SOT-223-3_TabPin2 | UNVERIFIED | from pattern: voltage-regulator-ams1117 |
+| C1 | 10u | Capacitor_SMD:C_0805_2012Metric | UNVERIFIED | from pattern: voltage-regulator-ams1117 |
+| C2 | 10u | Capacitor_SMD:C_0805_2012Metric | UNVERIFIED | from pattern: voltage-regulator-ams1117 |
+```
+
+Expanded rows are tagged with `from pattern: <name>` in the Rationale column for full traceability and flow directly into Stage 4 unchanged.
 
 ## Schema and Structure
 

--- a/openspec/changes/add-pattern-bom-reference/.openspec.yaml
+++ b/openspec/changes/add-pattern-bom-reference/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/add-pattern-bom-reference/design.md
+++ b/openspec/changes/add-pattern-bom-reference/design.md
@@ -1,0 +1,79 @@
+# Design: Pattern-to-BOM Expansion for Part Selection
+
+## Architecture and Flow
+
+```text
+Pattern JSON (src/kicad/patterns/<name>.json)
+  │
+  ▼
+expandToBom helper (src/kicad/patterns/expandToBom.ts)
+  │
+  ▼ (expands to standard BOM rows with "from pattern: <name>" rationale)
+docs/BOM.md (Standard Markdown Table)
+  │
+  ▼ (indistinguishable from manually written rows)
+Stage 4 Drafting Engine & Schematic Intent
+```
+
+## Module Design: `src/kicad/patterns/expandToBom.ts`
+
+The helper module exposes pure functions for transforming static pattern definitions into BOM table rows:
+
+```typescript
+export interface PatternBomRow {
+  refdes: string;
+  value?: string;
+  footprint?: string;
+  mpn?: string;
+  rationale: string;
+  flags: string[];
+  markdown: string;
+}
+
+export interface PatternExpansionResult {
+  patternName: string;
+  sourceFile: string;
+  headerLine: string;
+  rows: PatternBomRow[];
+  markdownRows: string[];
+}
+
+export function expandPatternToBomRows(
+  patternName: string,
+  options?: { patternsDir?: string }
+): PatternBomRow[];
+
+export function expandPatternToBom(
+  patternName: string,
+  options?: { patternsDir?: string }
+): PatternExpansionResult;
+
+export function resolvePatternsInBomText(
+  bomContent: string,
+  options?: {
+    patternsDir?: string;
+    onResolved?: (patternName: string, partCount: number) => void;
+  }
+): { text: string; resolved: Array<{ patternName: string; partCount: number }> };
+```
+
+### Conversion Logic
+1. Load `src/kicad/patterns/<patternName>.json`.
+2. For each part in `pattern.parts`:
+   - `Refdes`: `part.ref` (e.g. `U1`, `C1`, `C2`)
+   - `Value`: `part.value` (e.g. `AMS1117-3.3`, `10u`)
+   - `Footprint`: `part.footprint ?? ''`
+   - `MPN`: `"UNVERIFIED"`
+   - `Rationale`: `"from pattern: <patternName>"`
+   - `Row Markdown`: `| ${refdes} | ${value} | ${footprint} | UNVERIFIED | from pattern: ${patternName} |`
+3. Generate header line:
+   `| Pattern: ${patternName} | source: src/kicad/patterns/${patternName}.json |`
+
+## Stage 3 Pipeline Integration
+
+In `src/commands/create.ts`:
+1. The Stage 3 prompt informs the model that it can declare `use pattern: <pattern-name>` for supported patterns.
+2. In Stage 3 post-processing / completion checks, any `use pattern: <name>` declarations in `docs/BOM.md` are resolved into expanded rows.
+3. The CLI logs:
+   `Resolved pattern "<name>" -> N parts added to BOM.md`
+4. Stage 4 receives the expanded `BOM.md` containing standard table rows with standard column widths and valid component values.

--- a/openspec/changes/add-pattern-bom-reference/proposal.md
+++ b/openspec/changes/add-pattern-bom-reference/proposal.md
@@ -1,0 +1,42 @@
+# Proposal: Allow Part-Selection to Reference Named Circuit Patterns in BOM.md
+
+## Problem
+
+During Stage 3 (part-selection) of the `copperhead create` pipeline, the model currently enumerates every component by hand, writing each row into `docs/BOM.md`. For common standard circuit blocks (e.g. 3.3V linear regulator with decoupling capacitors, USB Type-C power sink with CC pull-downs, or crystal oscillator with load capacitors), this manual enumeration is repetitive and prone to minor inconsistencies in values, footprints, or missing passives.
+
+With the introduction of the static pattern library in `src/kicad/patterns/*.json` (#274), proven circuit templates are available as reference definitions. However, Stage 3 currently lacks the capability to reference a pattern by name and have it automatically expand into standard BOM rows.
+
+## Proposed Solution
+
+1. Add a pure helper module `src/kicad/patterns/expandToBom.ts` that expands a named circuit pattern from `src/kicad/patterns/<name>.json` into standard `BOM.md` table rows (`| Refdes | Value | Footprint | MPN | Rationale |`).
+2. Mark all expanded rows with `from pattern: <pattern-name>` in the `Rationale` column for clear auditability and provenance.
+3. Include an informational header row (`| Pattern: <name> | source: src/kicad/patterns/<name>.json |`) describing the origin of the expanded block.
+4. Update the Stage 3 (`part-selection`) prompt in `src/commands/create.ts` to allow the model to specify `use pattern: <pattern-name>` when a design requirement matches an available pattern.
+5. In Stage 3 execution, resolve pattern references and splice expanded rows into `docs/BOM.md`.
+6. Output a user-facing CLI log: `Resolved pattern "<name>" -> N parts added to BOM.md`.
+
+## Scope and Invariants
+
+### In Scope
+- Pure expansion helper `expandPatternToBomRows` in `src/kicad/patterns/expandToBom.ts`.
+- Stage 3 prompt and pattern resolution in `src/commands/create.ts`.
+- Traceability via `from pattern: <name>` tag in `BOM.md` `Rationale` column.
+- Documentation in `docs/patterns.md`.
+- Unit tests in `test/pattern-bom-expansion.test.ts`.
+
+### Out of Scope
+- Direct modifications to `src/kicad/draft/ir.ts` or `SchematicIntent` schema.
+- Changes to `src/kicad/draft/engine.ts` or layout engine.
+- Modifications to Stage 4 or later pipeline steps.
+- Modifications to ERC/DRC validators or pattern JSON files.
+
+### Effect on Invariants
+- **Spec-gated in**: This change alters the Stage 3 prompt and authoring behavior, so it is gated through this OpenSpec proposal.
+- **Verification-gated out**: This change operates strictly prior to Stage 4 and schematic capture. Downstream tools (Stage 4 drafting, ERC, DRC) consume standard BOM rows unchanged. Verification invariants remain unaffected.
+
+## Alternatives Considered
+
+1. **Expanding patterns inside `ir.ts` / `schematic.intent.json` directly**:
+   Deferred to separate follow-up issues. Expanding at Stage 3 into `BOM.md` ensures that downstream stages (Stage 4 schematic drafting, Stage 5 layout) receive standard, explicit component rows without altering downstream schemas.
+2. **Human-only `--use-pattern <name>` CLI flag**:
+   Deferred. The primary consumer during autonomous create runs is the agent model during part-selection. Adding CLI flags can be evaluated later if interactive manual scaffolding warrants it.

--- a/openspec/changes/add-pattern-bom-reference/specs/pattern-bom-reference/spec.md
+++ b/openspec/changes/add-pattern-bom-reference/specs/pattern-bom-reference/spec.md
@@ -1,0 +1,23 @@
+# Capability: Pattern BOM Reference
+
+## ADDED Requirements
+
+### Requirement: Pattern-to-BOM Expansion Helper
+The system SHALL provide a pure function `expandPatternToBomRows` that loads a named circuit pattern from `src/kicad/patterns/<name>.json` and produces standard 5-column BOM rows with `from pattern: <name>` in the Rationale column.
+
+#### Scenario: Expanding a named pattern into BOM rows
+- **WHEN** `expandPatternToBomRows("voltage-regulator-ams1117")` is called
+- **THEN** it returns 3 BOM rows corresponding to the AMS1117 regulator and its two decoupling capacitors
+- **AND** each row has the Rationale column set to `"from pattern: voltage-regulator-ams1117"`
+
+#### Scenario: Requesting an unknown pattern name
+- **WHEN** `expandPatternToBomRows("unknown-pattern")` is called
+- **THEN** it throws an error indicating the pattern file was not found
+
+### Requirement: Stage 3 Pattern Reference Resolution
+Stage 3 of the create pipeline SHALL recognize pattern reference declarations (e.g. `use pattern: <name>`) in `BOM.md` and expand them into concrete BOM rows.
+
+#### Scenario: Resolving pattern references in BOM.md
+- **WHEN** `docs/BOM.md` contains a line `use pattern: voltage-regulator-ams1117`
+- **THEN** the pipeline resolves the pattern reference into concrete BOM rows with `"from pattern: voltage-regulator-ams1117"` rationale
+- **AND** logs `Resolved pattern "voltage-regulator-ams1117" -> 3 parts added to BOM.md`

--- a/openspec/changes/add-pattern-bom-reference/tasks.md
+++ b/openspec/changes/add-pattern-bom-reference/tasks.md
@@ -1,0 +1,8 @@
+# Tasks: Pattern-to-BOM Reference Support
+
+- [x] Create OpenSpec change proposal for pattern BOM reference <!-- id: 0 -->
+- [x] Implement `src/kicad/patterns/expandToBom.ts` helper <!-- id: 1 -->
+- [x] Wire pattern reference into Stage 3 in `src/commands/create.ts` <!-- id: 2 -->
+- [x] Update `docs/patterns.md` with Stage 3 usage example <!-- id: 3 -->
+- [x] Add unit tests in `test/pattern-bom-expansion.test.ts` <!-- id: 4 -->
+- [x] Run full verification suite (typecheck, build, test, pattern validation) <!-- id: 5 -->

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "docs:preview": "npm --prefix docs run preview",
     "refboards": "bash scripts/draft-reference-boards.sh",
     "scoresheets": "tsx scripts/score-sheets.ts",
-    "realdesigns": "tsx scripts/draft-real-designs.ts"
+    "realdesigns": "tsx scripts/draft-real-designs.ts",
+    "validate:patterns": "tsx scripts/validate-patterns.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.113.0",

--- a/scripts/validate-patterns.ts
+++ b/scripts/validate-patterns.ts
@@ -1,0 +1,209 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..');
+const PATTERNS_DIR = path.join(REPO_ROOT, 'src', 'kicad', 'patterns');
+const SCHEMA_FILE = path.join(PATTERNS_DIR, 'pattern.schema.json');
+
+interface PatternPart {
+  ref: string;
+  libId: string;
+  value: string;
+  footprint?: string;
+  group: string;
+}
+
+interface PatternNet {
+  name: string;
+  pins: string[];
+  kind?: 'power' | 'ground' | 'signal';
+}
+
+interface PatternDocument {
+  name: string;
+  description: string;
+  parts: PatternPart[];
+  nets: PatternNet[];
+}
+
+interface ValidationFinding {
+  file: string;
+  message: string;
+}
+
+function validatePattern(file: string, doc: unknown): ValidationFinding[] {
+  const findings: ValidationFinding[] = [];
+  const add = (message: string) => findings.push({ file, message });
+
+  if (typeof doc !== 'object' || doc === null || Array.isArray(doc)) {
+    add('Root of pattern document must be an object');
+    return findings;
+  }
+
+  const d = doc as Record<string, unknown>;
+
+  if (typeof d.name !== 'string' || !d.name.trim()) {
+    add('Field "name" must be a non-empty string');
+  }
+
+  if (typeof d.description !== 'string' || !d.description.trim()) {
+    add('Field "description" must be a non-empty string');
+  }
+
+  if (!Array.isArray(d.parts) || d.parts.length === 0) {
+    add('Field "parts" must be a non-empty array');
+    return findings;
+  }
+
+  if (!Array.isArray(d.nets) || d.nets.length === 0) {
+    add('Field "nets" must be a non-empty array');
+    return findings;
+  }
+
+  const partRefs = new Set<string>();
+
+  for (let i = 0; i < d.parts.length; i++) {
+    const p = d.parts[i];
+    if (typeof p !== 'object' || p === null || Array.isArray(p)) {
+      add(`parts[${i}] must be an object`);
+      continue;
+    }
+    const part = p as Record<string, unknown>;
+    if (typeof part.ref !== 'string' || !part.ref.trim()) {
+      add(`parts[${i}].ref must be a non-empty string`);
+    } else {
+      if (partRefs.has(part.ref)) {
+        add(`Duplicate ref "${part.ref}" in parts`);
+      }
+      partRefs.add(part.ref);
+    }
+    if (typeof part.libId !== 'string' || !part.libId.trim()) {
+      add(`parts[${i}].libId must be a non-empty string`);
+    }
+    if (typeof part.value !== 'string' || !part.value.trim()) {
+      add(`parts[${i}].value must be a non-empty string`);
+    }
+    if (typeof part.group !== 'string' || !part.group.trim()) {
+      add(`parts[${i}].group must be a non-empty string`);
+    }
+    if (part.footprint !== undefined && typeof part.footprint !== 'string') {
+      add(`parts[${i}].footprint must be a string if specified`);
+    }
+  }
+
+  const netNames = new Set<string>();
+  const pinEndpointRegex = /^([A-Za-z0-9_]+)\.([A-Za-z0-9_\-/+]+)$/;
+
+  for (let i = 0; i < d.nets.length; i++) {
+    const n = d.nets[i];
+    if (typeof n !== 'object' || n === null || Array.isArray(n)) {
+      add(`nets[${i}] must be an object`);
+      continue;
+    }
+    const net = n as Record<string, unknown>;
+    if (typeof net.name !== 'string' || !net.name.trim()) {
+      add(`nets[${i}].name must be a non-empty string`);
+    } else {
+      if (netNames.has(net.name)) {
+        add(`Duplicate net name "${net.name}"`);
+      }
+      netNames.add(net.name);
+    }
+
+    if (net.kind !== undefined && net.kind !== 'power' && net.kind !== 'ground' && net.kind !== 'signal') {
+      add(`nets[${i}].kind must be one of "power", "ground", "signal"`);
+    }
+
+    if (!Array.isArray(net.pins) || net.pins.length < 2) {
+      add(`nets[${i}].pins must be an array of at least 2 endpoints`);
+      continue;
+    }
+
+    for (let j = 0; j < net.pins.length; j++) {
+      const ep = net.pins[j];
+      if (typeof ep !== 'string') {
+        add(`nets[${i}].pins[${j}] must be a string in REF.PIN format`);
+        continue;
+      }
+      const match = pinEndpointRegex.exec(ep);
+      if (!match) {
+        add(`nets[${i}].pins[${j}] "${ep}" is not a valid REF.PIN endpoint`);
+        continue;
+      }
+      const ref = match[1]!;
+      if (!partRefs.has(ref)) {
+        add(`nets[${i}].pins[${j}] references unknown part ref "${ref}" not defined in parts`);
+      }
+    }
+  }
+
+  return findings;
+}
+
+export async function validateAllPatterns(): Promise<boolean> {
+  console.log('Validating circuit patterns in:', PATTERNS_DIR);
+
+  // Check schema file existence
+  try {
+    const schemaContent = await readFile(SCHEMA_FILE, 'utf8');
+    JSON.parse(schemaContent);
+  } catch (err) {
+    console.error(`ERROR: Failed to read/parse schema file ${SCHEMA_FILE}:`, (err as Error).message);
+    return false;
+  }
+
+  const entries = await readdir(PATTERNS_DIR, { withFileTypes: true });
+  const patternFiles = entries
+    .filter((e) => e.isFile() && e.name.endsWith('.json') && e.name !== 'pattern.schema.json')
+    .map((e) => e.name)
+    .sort();
+
+  if (patternFiles.length === 0) {
+    console.error('ERROR: No pattern files found in', PATTERNS_DIR);
+    return false;
+  }
+
+  let totalFindings: ValidationFinding[] = [];
+  let validCount = 0;
+
+  for (const filename of patternFiles) {
+    const filePath = path.join(PATTERNS_DIR, filename);
+    let parsed: unknown;
+    try {
+      const content = await readFile(filePath, 'utf8');
+      parsed = JSON.parse(content);
+    } catch (err) {
+      totalFindings.push({ file: filename, message: `Invalid JSON syntax: ${(err as Error).message}` });
+      continue;
+    }
+
+    const findings = validatePattern(filename, parsed);
+    if (findings.length > 0) {
+      totalFindings.push(...findings);
+    } else {
+      validCount++;
+      const p = parsed as PatternDocument;
+      console.log(`  ✓ ${filename} ("${p.name}"): ${p.parts.length} part(s), ${p.nets.length} net(s)`);
+    }
+  }
+
+  if (totalFindings.length > 0) {
+    console.error(`\nValidation FAILED with ${totalFindings.length} error(s):`);
+    for (const f of totalFindings) {
+      console.error(`  - [${f.file}] ${f.message}`);
+    }
+    return false;
+  }
+
+  console.log(`\nAll ${validCount} pattern(s) validated successfully.`);
+  return true;
+}
+
+// When run directly as a script
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  validateAllPatterns().then((ok) => {
+    if (!ok) process.exit(1);
+  });
+}

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -24,6 +24,7 @@ import { symbolSearchDirs } from '../kicad/symlib.js';
 import { assertDiskSpace, DEFAULT_MIN_FREE_BYTES } from '../util/preflight.js';
 import { runCheck } from './check.js';
 import { emitCreateJlcpcbBom } from './export.js';
+import { resolvePatternsInBomText } from '../kicad/patterns/expandToBom.js';
 
 /**
  * Mode A (`copperhead create`, SPEC §2.5): staged pipeline, each stage a
@@ -168,24 +169,31 @@ export const STAGES: Stage[] = [
     isComplete: async (root, docs) => {
       // init scaffolds BOM.md with a table pre-filled with UNVERIFIED MPNs
       // extracted from the schematic. Require at least one row whose MPN
-      // column is NOT the UNVERIFIED placeholder — i.e. a real part was chosen.
+      // column is NOT the UNVERIFIED placeholder — i.e. a real part was chosen,
+      // or at least one pattern was referenced and expanded.
       const p = path.join(root, docs, 'BOM.md');
       if (!existsSync(p)) return false;
       const text = await readFile(p, 'utf8');
-      // Find table rows (lines starting with |) that are not the header or separator
-      const rows = text.split('\n').filter(
-        (l) => l.startsWith('|') && !l.includes('---') && !l.toLowerCase().includes('refdes'),
+      const { text: resolvedText, resolved } = resolvePatternsInBomText(text);
+      if (resolved.length > 0) {
+        await writeFile(p, resolvedText, 'utf8');
+      }
+      const effectiveText = resolved.length > 0 ? resolvedText : text;
+      // Find table rows (lines starting with |) that are not the header, separator, or pattern header
+      const rows = effectiveText.split('\n').filter(
+        (l) => l.startsWith('|') && !l.includes('---') && !l.toLowerCase().includes('refdes') && !l.toLowerCase().includes('source:'),
       );
       if (!rows.length) return false;
-      // At least one row must have a non-UNVERIFIED MPN (4th column)
+      // At least one row must have a non-UNVERIFIED MPN (4th column) or be sourced from a pattern
       return rows.some((row) => {
         const cols = row.split('|').map((c) => c.trim());
         const mpn = cols[4] ?? ''; // 0=empty, 1=Refdes, 2=Value, 3=Footprint, 4=MPN
-        return mpn && !mpn.toUpperCase().startsWith('UNVERIFIED');
+        const rationale = cols[5] ?? '';
+        return (mpn && !mpn.toUpperCase().startsWith('UNVERIFIED')) || rationale.includes('from pattern:');
       });
     },
     prompt: () =>
-      'Stage 3: part selection. Write docs/BOM.md with the fixed table format (| Refdes | Value | Footprint | MPN | Rationale |). The Value column holds the COMPONENT VALUE and nothing else — "4.7uF", "1M", "500mAh Li-Po", "STM32F103C8T6" — because stage 4 draws it on the sheet as that part\'s Value field, where a description ("1S Li-Po cell, 500 mAh, bare leads") collides with neighbouring symbols and fails the legibility gate. Put the prose in the Rationale column instead; that is the column for it, and nothing draws it. One row per refdes: a grouped row ("SW3-SW16", "C5-C8") is not a BOM row and the schematic stage cannot match it. Every MPN you introduce is flagged UNVERIFIED with a datasheet-verifiable justification. Check leakage/quiescent current of every part against the power budget. The design must be capturable with the KiCad symbol libraries installed on THIS machine: run search_symbols for every IC, module, connector and other active part before committing it to the BOM, and if a part has no installed symbol, pick one that has — stage 4 draws only from installed symbols, and a BOM row it cannot resolve makes the whole run unwinnable. Existence is not enough: confirm the chosen symbol with symbol_pins so the pin numbers you wire in stage 4 are real. Multi-unit symbols (gate packs, dual opamps) are fine — the engine places each unit separately under the one refdes, and net endpoints use plain package pin numbers. Run check_drift before finishing.',
+      'Stage 3: part selection. Write docs/BOM.md with the fixed table format (| Refdes | Value | Footprint | MPN | Rationale |). The Value column holds the COMPONENT VALUE and nothing else — "4.7uF", "1M", "500mAh Li-Po", "STM32F103C8T6" — because stage 4 draws it on the sheet as that part\'s Value field, where a description ("1S Li-Po cell, 500 mAh, bare leads") collides with neighbouring symbols and fails the legibility gate. Put the prose in the Rationale column instead; that is the column for it, and nothing draws it. One row per refdes: a grouped row ("SW3-SW16", "C5-C8") is not a BOM row and the schematic stage cannot match it. You may reference proven circuit patterns from the pattern library (voltage-regulator-ams1117, usb-c-power-input, crystal-oscillator) by writing "use pattern: <pattern-name>" instead of enumerating common sub-circuits by hand. Every MPN you introduce is flagged UNVERIFIED with a datasheet-verifiable justification. Check leakage/quiescent current of every part against the power budget. The design must be capturable with the KiCad symbol libraries installed on THIS machine: run search_symbols for every IC, module, connector and other active part before committing it to the BOM, and if a part has no installed symbol, pick one that has — stage 4 draws only from installed symbols, and a BOM row it cannot resolve makes the whole run unwinnable. Existence is not enough: confirm the chosen symbol with symbol_pins so the pin numbers you wire in stage 4 are real. Multi-unit symbols (gate packs, dual opamps) are fine — the engine places each unit separately under the one refdes, and net endpoints use plain package pin numbers. Run check_drift before finishing.',
   },
   {
     name: 'schematic',
@@ -912,6 +920,26 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
             ? await contractGapDetail(stage.name, opts.repoRoot, config)
             : null;
       if (!failure) {
+        if (stage.name === 'part-selection') {
+          const bomPath = path.join(opts.repoRoot, config.docs, 'BOM.md');
+          if (existsSync(bomPath)) {
+            const bomContent = await readFile(bomPath, 'utf8');
+            const { text: resolvedText, resolved } = resolvePatternsInBomText(bomContent, {
+              onResolved: (patternName, count) => {
+                opts.log(
+                  stageLine(
+                    'part-selection',
+                    `Resolved pattern "${patternName}" -> ${count} parts added to BOM.md`,
+                    'ok',
+                  ),
+                );
+              },
+            });
+            if (resolved.length > 0) {
+              await writeFile(bomPath, resolvedText, 'utf8');
+            }
+          }
+        }
         stageDone = true;
         break;
       }

--- a/src/kicad/patterns/crystal-oscillator.json
+++ b/src/kicad/patterns/crystal-oscillator.json
@@ -1,0 +1,53 @@
+{
+  "name": "crystal-oscillator",
+  "description": "Standard crystal oscillator resonant circuit with dual load capacitors, matching canonical crystal flanking topology.",
+  "parts": [
+    {
+      "ref": "Y1",
+      "libId": "Device:Crystal",
+      "value": "16MHz",
+      "footprint": "Crystal:Crystal_SMD_HC49-SD",
+      "group": "Clock"
+    },
+    {
+      "ref": "C1",
+      "libId": "Device:C",
+      "value": "22p",
+      "footprint": "Capacitor_SMD:C_0603_1608Metric",
+      "group": "Clock"
+    },
+    {
+      "ref": "C2",
+      "libId": "Device:C",
+      "value": "22p",
+      "footprint": "Capacitor_SMD:C_0603_1608Metric",
+      "group": "Clock"
+    }
+  ],
+  "nets": [
+    {
+      "name": "XTAL1",
+      "pins": [
+        "Y1.1",
+        "C1.1"
+      ],
+      "kind": "signal"
+    },
+    {
+      "name": "XTAL2",
+      "pins": [
+        "Y1.2",
+        "C2.1"
+      ],
+      "kind": "signal"
+    },
+    {
+      "name": "GND",
+      "pins": [
+        "C1.2",
+        "C2.2"
+      ],
+      "kind": "ground"
+    }
+  ]
+}

--- a/src/kicad/patterns/expandToBom.ts
+++ b/src/kicad/patterns/expandToBom.ts
@@ -1,0 +1,170 @@
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { BomRow } from '../../memory/bom-table.js';
+
+export interface PatternPart {
+  ref: string;
+  libId: string;
+  value: string;
+  footprint?: string;
+  group: string;
+}
+
+export interface PatternDefinition {
+  name: string;
+  description: string;
+  parts: PatternPart[];
+  nets: Array<{
+    name: string;
+    pins: string[];
+    kind?: 'power' | 'ground' | 'signal';
+  }>;
+}
+
+export interface PatternBomRow extends BomRow {
+  rationale: string;
+  markdown: string;
+}
+
+export interface PatternExpansionResult {
+  patternName: string;
+  sourceFile: string;
+  headerLine: string;
+  rows: PatternBomRow[];
+  markdownRows: string[];
+}
+
+export interface ExpandToBomOptions {
+  patternsDir?: string;
+}
+
+export interface ResolvePatternsOptions extends ExpandToBomOptions {
+  onResolved?: (patternName: string, partCount: number) => void;
+}
+
+function resolvePatternsDir(override?: string): string {
+  if (override) return override;
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return here;
+}
+
+/**
+ * Loads a pattern JSON from the patterns directory and returns its parsed content.
+ * Throws a descriptive error if the pattern does not exist.
+ */
+export function loadPatternDefinition(patternName: string, patternsDir?: string): PatternDefinition {
+  const dir = resolvePatternsDir(patternsDir);
+  const patternPath = path.join(dir, `${patternName}.json`);
+
+  if (!existsSync(patternPath)) {
+    throw new Error(`Pattern "${patternName}" not found at ${patternPath}`);
+  }
+
+  const raw = readFileSync(patternPath, 'utf8');
+  const parsed = JSON.parse(raw) as PatternDefinition;
+  return parsed;
+}
+
+/**
+ * Expands a named pattern into an array of typed BOM rows with Markdown formatting.
+ */
+export function expandPatternToBomRows(
+  patternName: string,
+  options?: ExpandToBomOptions,
+): PatternBomRow[] {
+  const pattern = loadPatternDefinition(patternName, options?.patternsDir);
+  const rationale = `from pattern: ${pattern.name}`;
+
+  return pattern.parts.map((p) => {
+    const footprint = p.footprint ?? '';
+    const mpn = 'UNVERIFIED';
+    const markdown = `| ${p.ref} | ${p.value} | ${footprint} | ${mpn} | ${rationale} |`;
+
+    return {
+      refdes: p.ref,
+      value: p.value,
+      footprint: footprint || undefined,
+      mpn,
+      rationale,
+      flags: ['UNVERIFIED'],
+      markdown,
+    };
+  });
+}
+
+/**
+ * Expands a named pattern and returns a full expansion result including the header line.
+ */
+export function expandPatternToBom(
+  patternName: string,
+  options?: ExpandToBomOptions,
+): PatternExpansionResult {
+  const pattern = loadPatternDefinition(patternName, options?.patternsDir);
+  const rows = expandPatternToBomRows(patternName, options);
+  const sourceFile = `src/kicad/patterns/${pattern.name}.json`;
+  const headerLine = `| Pattern: ${pattern.name} | source: ${sourceFile} |`;
+  const markdownRows = rows.map((r) => r.markdown);
+
+  return {
+    patternName: pattern.name,
+    sourceFile,
+    headerLine,
+    rows,
+    markdownRows,
+  };
+}
+
+/**
+ * Matches pattern declarations in text, such as:
+ *   use pattern: voltage-regulator-ams1117
+ *   | use pattern: voltage-regulator-ams1117 |
+ *   | Pattern: voltage-regulator-ams1117 |
+ */
+const PATTERN_REF_REGEX = /^\s*(?:\|\s*)?(?:use\s+)?pattern:\s*([a-zA-Z0-9_-]+)(?:\s*\|)?\s*$/i;
+
+/**
+ * Resolves pattern references in BOM.md markdown text by expanding them in-place.
+ */
+export function resolvePatternsInBomText(
+  bomContent: string,
+  options?: ResolvePatternsOptions,
+): { text: string; resolved: Array<{ patternName: string; partCount: number }> } {
+  const lines = bomContent.split(/\r?\n/);
+  const newLines: string[] = [];
+  const resolved: Array<{ patternName: string; partCount: number }> = [];
+
+  for (const line of lines) {
+    // Avoid re-expanding an already expanded header line that contains "source:"
+    if (line.includes('source:')) {
+      newLines.push(line);
+      continue;
+    }
+
+    const match = PATTERN_REF_REGEX.exec(line);
+    if (match) {
+      const patternName = match[1]!;
+      try {
+        const expansion = expandPatternToBom(patternName, options);
+        newLines.push(expansion.headerLine);
+        for (const rowMd of expansion.markdownRows) {
+          newLines.push(rowMd);
+        }
+        resolved.push({ patternName: expansion.patternName, partCount: expansion.rows.length });
+        options?.onResolved?.(expansion.patternName, expansion.rows.length);
+        continue;
+      } catch (err) {
+        // If pattern name is unknown or fails to load, keep line and let validation/caller handle it
+        newLines.push(line);
+        continue;
+      }
+    }
+
+    newLines.push(line);
+  }
+
+  return {
+    text: newLines.join('\n'),
+    resolved,
+  };
+}

--- a/src/kicad/patterns/pattern.schema.json
+++ b/src/kicad/patterns/pattern.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CircuitPattern",
+  "description": "Static circuit block template describing reusable schematic components and net connectivity.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Unique human-readable identifier for the circuit pattern."
+    },
+    "description": {
+      "type": "string",
+      "description": "Summary of the circuit topology, electrical characteristics, and typical application."
+    },
+    "parts": {
+      "type": "array",
+      "description": "Components comprising the circuit pattern block.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ref": {
+            "type": "string",
+            "description": "Reference designator or relative template designator."
+          },
+          "libId": {
+            "type": "string",
+            "description": "Canonical KiCad symbol library identifier (e.g. Device:R, Regulator_Linear:AMS1117-3.3)."
+          },
+          "value": {
+            "type": "string",
+            "description": "Component value or part number."
+          },
+          "footprint": {
+            "type": "string",
+            "description": "Optional KiCad footprint library identifier."
+          },
+          "group": {
+            "type": "string",
+            "description": "Subsystem group name."
+          }
+        },
+        "required": ["ref", "libId", "value", "group"],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "nets": {
+      "type": "array",
+      "description": "Nets connecting components within the pattern and external interface points.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Net name."
+          },
+          "pins": {
+            "type": "array",
+            "description": "List of connected component pin endpoints in REF.PIN format.",
+            "items": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_]+\\.[A-Za-z0-9_\\-/+]+$"
+            },
+            "minItems": 2
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["power", "ground", "signal"],
+            "description": "Optional net electrical class."
+          }
+        },
+        "required": ["name", "pins"],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    }
+  },
+  "required": ["name", "description", "parts", "nets"],
+  "additionalProperties": false
+}

--- a/src/kicad/patterns/usb-c-power-input.json
+++ b/src/kicad/patterns/usb-c-power-input.json
@@ -1,0 +1,73 @@
+{
+  "name": "usb-c-power-input",
+  "description": "USB Type-C 16-pin USB 2.0 power input sink block with 5.1k CC1/CC2 pull-down resistors and VBUS bulk capacitor.",
+  "parts": [
+    {
+      "ref": "J1",
+      "libId": "Connector:USB_C_Receptacle_USB2.0_16P",
+      "value": "USB_C_Receptacle_USB2.0_16P",
+      "footprint": "Connector_USB:USB_C_Receptacle_GCT_USB4085",
+      "group": "Power Input"
+    },
+    {
+      "ref": "R1",
+      "libId": "Device:R",
+      "value": "5.1k",
+      "footprint": "Resistor_SMD:R_0603_1608Metric",
+      "group": "Power Input"
+    },
+    {
+      "ref": "R2",
+      "libId": "Device:R",
+      "value": "5.1k",
+      "footprint": "Resistor_SMD:R_0603_1608Metric",
+      "group": "Power Input"
+    },
+    {
+      "ref": "C1",
+      "libId": "Device:C",
+      "value": "10u",
+      "footprint": "Capacitor_SMD:C_0805_2012Metric",
+      "group": "Power Input"
+    }
+  ],
+  "nets": [
+    {
+      "name": "VBUS",
+      "pins": [
+        "J1.A4",
+        "J1.B4",
+        "C1.1"
+      ],
+      "kind": "power"
+    },
+    {
+      "name": "CC1",
+      "pins": [
+        "J1.A5",
+        "R1.1"
+      ],
+      "kind": "signal"
+    },
+    {
+      "name": "CC2",
+      "pins": [
+        "J1.B5",
+        "R2.1"
+      ],
+      "kind": "signal"
+    },
+    {
+      "name": "GND",
+      "pins": [
+        "J1.A1",
+        "J1.B1",
+        "J1.SH",
+        "R1.2",
+        "R2.2",
+        "C1.2"
+      ],
+      "kind": "ground"
+    }
+  ]
+}

--- a/src/kicad/patterns/voltage-regulator-ams1117.json
+++ b/src/kicad/patterns/voltage-regulator-ams1117.json
@@ -1,0 +1,54 @@
+{
+  "name": "voltage-regulator-ams1117",
+  "description": "AMS1117 3.3V linear voltage regulator subcircuit with input and output ceramic decoupling capacitors.",
+  "parts": [
+    {
+      "ref": "U1",
+      "libId": "Regulator_Linear:AMS1117-3.3",
+      "value": "AMS1117-3.3",
+      "footprint": "Package_TO_SOT_SMD:SOT-223-3_TabPin2",
+      "group": "Power"
+    },
+    {
+      "ref": "C1",
+      "libId": "Device:C",
+      "value": "10u",
+      "footprint": "Capacitor_SMD:C_0805_2012Metric",
+      "group": "Power"
+    },
+    {
+      "ref": "C2",
+      "libId": "Device:C",
+      "value": "10u",
+      "footprint": "Capacitor_SMD:C_0805_2012Metric",
+      "group": "Power"
+    }
+  ],
+  "nets": [
+    {
+      "name": "VIN",
+      "pins": [
+        "U1.3",
+        "C1.1"
+      ],
+      "kind": "power"
+    },
+    {
+      "name": "+3V3",
+      "pins": [
+        "U1.2",
+        "C2.1"
+      ],
+      "kind": "power"
+    },
+    {
+      "name": "GND",
+      "pins": [
+        "U1.1",
+        "C1.2",
+        "C2.2"
+      ],
+      "kind": "ground"
+    }
+  ]
+}

--- a/test/pattern-bom-expansion.test.ts
+++ b/test/pattern-bom-expansion.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import {
+  expandPatternToBomRows,
+  expandPatternToBom,
+  resolvePatternsInBomText,
+  loadPatternDefinition,
+} from '../src/kicad/patterns/expandToBom.js';
+import { parseBomTable } from '../src/memory/bom-table.js';
+
+describe('pattern-bom-expansion', () => {
+  describe('expandPatternToBomRows', () => {
+    it('expands voltage-regulator-ams1117 into 3 valid BOM rows with pattern rationale', () => {
+      const rows = expandPatternToBomRows('voltage-regulator-ams1117');
+      expect(rows).toHaveLength(3);
+
+      expect(rows[0]).toEqual({
+        refdes: 'U1',
+        value: 'AMS1117-3.3',
+        footprint: 'Package_TO_SOT_SMD:SOT-223-3_TabPin2',
+        mpn: 'UNVERIFIED',
+        rationale: 'from pattern: voltage-regulator-ams1117',
+        flags: ['UNVERIFIED'],
+        markdown: '| U1 | AMS1117-3.3 | Package_TO_SOT_SMD:SOT-223-3_TabPin2 | UNVERIFIED | from pattern: voltage-regulator-ams1117 |',
+      });
+
+      expect(rows[1]).toEqual({
+        refdes: 'C1',
+        value: '10u',
+        footprint: 'Capacitor_SMD:C_0805_2012Metric',
+        mpn: 'UNVERIFIED',
+        rationale: 'from pattern: voltage-regulator-ams1117',
+        flags: ['UNVERIFIED'],
+        markdown: '| C1 | 10u | Capacitor_SMD:C_0805_2012Metric | UNVERIFIED | from pattern: voltage-regulator-ams1117 |',
+      });
+
+      expect(rows[2]).toEqual({
+        refdes: 'C2',
+        value: '10u',
+        footprint: 'Capacitor_SMD:C_0805_2012Metric',
+        mpn: 'UNVERIFIED',
+        rationale: 'from pattern: voltage-regulator-ams1117',
+        flags: ['UNVERIFIED'],
+        markdown: '| C2 | 10u | Capacitor_SMD:C_0805_2012Metric | UNVERIFIED | from pattern: voltage-regulator-ams1117 |',
+      });
+    });
+
+    it('expands usb-c-power-input into 4 valid BOM rows with pattern rationale', () => {
+      const rows = expandPatternToBomRows('usb-c-power-input');
+      expect(rows).toHaveLength(4);
+      expect(rows.map((r) => r.refdes)).toEqual(['J1', 'R1', 'R2', 'C1']);
+      expect(rows.every((r) => r.rationale === 'from pattern: usb-c-power-input')).toBe(true);
+      expect(rows.every((r) => r.mpn === 'UNVERIFIED')).toBe(true);
+    });
+
+    it('expands crystal-oscillator into 3 valid BOM rows with pattern rationale', () => {
+      const rows = expandPatternToBomRows('crystal-oscillator');
+      expect(rows).toHaveLength(3);
+      expect(rows.map((r) => r.refdes)).toEqual(['Y1', 'C1', 'C2']);
+      expect(rows.every((r) => r.rationale === 'from pattern: crystal-oscillator')).toBe(true);
+    });
+
+    it('throws a descriptive error when requesting an unknown pattern name', () => {
+      expect(() => expandPatternToBomRows('nonexistent-circuit-pattern')).toThrow(
+        /Pattern "nonexistent-circuit-pattern" not found/,
+      );
+    });
+  });
+
+  describe('expandPatternToBom', () => {
+    it('returns full expansion result with headerLine', () => {
+      const result = expandPatternToBom('voltage-regulator-ams1117');
+      expect(result.patternName).toBe('voltage-regulator-ams1117');
+      expect(result.sourceFile).toBe('src/kicad/patterns/voltage-regulator-ams1117.json');
+      expect(result.headerLine).toBe(
+        '| Pattern: voltage-regulator-ams1117 | source: src/kicad/patterns/voltage-regulator-ams1117.json |',
+      );
+      expect(result.rows).toHaveLength(3);
+      expect(result.markdownRows).toHaveLength(3);
+    });
+  });
+
+  describe('compatibility with parseBomTable', () => {
+    it('expanded rows are parsed by parseBomTable identically to hand-written rows', () => {
+      const expansion = expandPatternToBom('voltage-regulator-ams1117');
+      const bomMd = [
+        '# Bill of Materials',
+        '',
+        '| Refdes | Value | Footprint | MPN | Rationale |',
+        '|---|---|---|---|---|',
+        '| U2 | ESP32-WROOM-32 | RF_Module:ESP32-WROOM-32 | ESP32-WROOM-32D | Main MCU |',
+        ...expansion.markdownRows,
+      ].join('\n');
+
+      const parsed = parseBomTable(bomMd);
+      expect(parsed).toHaveLength(4);
+      expect(parsed[0]?.refdes).toBe('U2');
+      expect(parsed[0]?.value).toBe('ESP32-WROOM-32');
+      expect(parsed[0]?.mpn).toBe('ESP32-WROOM-32D');
+
+      expect(parsed[1]?.refdes).toBe('U1');
+      expect(parsed[1]?.value).toBe('AMS1117-3.3');
+      expect(parsed[1]?.footprint).toBe('Package_TO_SOT_SMD:SOT-223-3_TabPin2');
+      expect(parsed[1]?.mpn).toBe('UNVERIFIED');
+
+      expect(parsed[2]?.refdes).toBe('C1');
+      expect(parsed[3]?.refdes).toBe('C2');
+    });
+
+    it('manual enumerate-parts path works unchanged when no pattern is referenced', () => {
+      const manualBom = [
+        '# Bill of Materials',
+        '',
+        '| Refdes | Value | Footprint | MPN | Rationale |',
+        '|---|---|---|---|---|',
+        '| R1 | 10k | Resistor_SMD:R_0603_1608Metric | RC0603FR-0710KL | Pull-up |',
+        '| C1 | 100n | Capacitor_SMD:C_0603_1608Metric | CC0603KRX7R9BB104 | Decoupling |',
+      ].join('\n');
+
+      const { text: resolvedText, resolved } = resolvePatternsInBomText(manualBom);
+      expect(resolved).toHaveLength(0);
+      expect(resolvedText).toBe(manualBom);
+
+      const parsed = parseBomTable(resolvedText);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0]?.refdes).toBe('R1');
+      expect(parsed[1]?.refdes).toBe('C1');
+    });
+  });
+
+  describe('resolvePatternsInBomText', () => {
+    it('replaces "use pattern: <name>" in BOM text with expanded rows and header', () => {
+      const input = [
+        '# Bill of Materials',
+        '',
+        '| Refdes | Value | Footprint | MPN | Rationale |',
+        '|---|---|---|---|---|',
+        '| U2 | ESP32-WROOM-32 | RF_Module:ESP32-WROOM-32 | ESP32-WROOM-32D | Main MCU |',
+        'use pattern: voltage-regulator-ams1117',
+      ].join('\n');
+
+      const onResolvedCalls: Array<{ name: string; count: number }> = [];
+      const { text: output, resolved } = resolvePatternsInBomText(input, {
+        onResolved: (name, count) => onResolvedCalls.push({ name, count }),
+      });
+
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0]).toEqual({ patternName: 'voltage-regulator-ams1117', partCount: 3 });
+      expect(onResolvedCalls).toEqual([{ name: 'voltage-regulator-ams1117', count: 3 }]);
+
+      expect(output).toContain('| Pattern: voltage-regulator-ams1117 | source: src/kicad/patterns/voltage-regulator-ams1117.json |');
+      expect(output).toContain('| U1 | AMS1117-3.3 | Package_TO_SOT_SMD:SOT-223-3_TabPin2 | UNVERIFIED | from pattern: voltage-regulator-ams1117 |');
+      expect(output).toContain('| C1 | 10u | Capacitor_SMD:C_0805_2012Metric | UNVERIFIED | from pattern: voltage-regulator-ams1117 |');
+      expect(output).toContain('| C2 | 10u | Capacitor_SMD:C_0805_2012Metric | UNVERIFIED | from pattern: voltage-regulator-ams1117 |');
+    });
+
+    it('replaces piped "| use pattern: <name> |" style declarations', () => {
+      const input = [
+        '| Refdes | Value | Footprint | MPN | Rationale |',
+        '|---|---|---|---|---|',
+        '| use pattern: crystal-oscillator |',
+      ].join('\n');
+
+      const { text: output, resolved } = resolvePatternsInBomText(input);
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0]?.patternName).toBe('crystal-oscillator');
+      expect(output).toContain('| Y1 | 16MHz |');
+      expect(output).toContain('from pattern: crystal-oscillator');
+    });
+  });
+});


### PR DESCRIPTION
> **Draft note:** This branch is based on top of `feature/circuit-pattern-library` (#279),
> which is still pending merge into main. The diff below will include #279's commits
> until it merges; that is expected and will clean up automatically once #279 lands
> and this branch is rebased onto main. Depends on #274 (static pattern library) landing
> first — no dependency on #277 or #278.

Closes #276

## What
Lets Stage 3 (part-selection) reference a named circuit pattern instead of enumerating every part by hand. The AI may now respond with `use pattern: <pattern-name>` for common sub-circuits, and that expands into standard BOM rows tagged `from pattern: <name>` in the Rationale column for traceability.

## Why
Today the AI re-derives the same handful of parts (regulator + decoupling caps, USB-C connector + CC pull-downs + bulk cap) from first principles on every design, with no memory of "the way this is always done." This causes avoidable BOM mistakes that only surface later at the schematic/ERC stage, and gives reviewers no way to tell a standard block apart from a flat, undifferentiated parts list. Refs #276.

## Design
- **Pure expansion helper**: [expandToBom.ts](src/kicad/patterns/expandToBom.ts) exports `expandPatternToBomRows()`, `expandPatternToBom()`, and `resolvePatternsInBomText()`. These read pattern JSON from `src/kicad/patterns/*.json` (added in #274) and return/insert plain BOM rows; none of them write files directly.
- **Traceable rows, not a new format**: expanded rows use the exact same 5-column `| Refdes | Value | Footprint | MPN | Rationale |` shape as hand-written rows, with `from pattern: <name>` in Rationale and a `| Pattern: <name> | source: ... |` header line, per the before/after example in #276. Stage 4 and everything downstream sees ordinary BOM rows, indistinguishable from manual entries.
- **Stage 3 only**: the prompt and resolution logic changes are scoped to Stage 3 in [create.ts](src/commands/create.ts) (`isComplete` / `runCreate`). Manual enumeration remains the default and stays fully supported; pattern use is opt-in per design need.
- **No schema or engine changes**: [ir.ts](src/kicad/draft/ir.ts) and [engine.ts](src/kicad/draft/engine.ts) are untouched. This does not wire pattern-awareness into `schematic.intent.json` — that remains a separate, deferred proposal.
- **Alternatives considered** (per #276's issue body): expanding patterns directly inside `ir.ts`/`schematic.intent.json` was rejected as a bigger, riskier change to the validated Intent schema; a human-only `--use-pattern <name>` CLI flag was considered but doesn't solve the actual problem of the AI re-deriving parts every run, and is left as a possible future addition.

## Spec / OpenSpec
Adds a new OpenSpec change: `add-pattern-bom-reference` (see [proposal.md](openspec/changes/add-pattern-bom-reference/proposal.md), [design.md](openspec/changes/add-pattern-bom-reference/design.md), [tasks.md](openspec/changes/add-pattern-bom-reference/tasks.md), and the delta spec at `specs/pattern-bom-reference/spec.md`). This is gated because it changes Stage 3 agent behavior (per the spec-gated-edits rule), even though no new destructive write tool is introduced — it only changes what content flows into the existing BOM.md write path. `openspec validate add-pattern-bom-reference` passes.

## Testing
### Automated test status
| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | ✅ Pass (0 errors) |
| Build | `npm run build` | ✅ Pass |
| Unit + offline | `npm test` | ✅ Pass (no existing tests affected) |
| Pattern-BOM expansion (new) | `npx vitest run test/pattern-bom-expansion.test.ts` | ✅ Pass (9/9 tests) |
| Pattern validation | `npm run validate:patterns` | ✅ Pass (3/3 patterns) |
| OpenSpec validation (new) | `openspec validate add-pattern-bom-reference` | ✅ Pass |
| Live-LLM (opt-in) | n/a | n/a — no provider-facing prompt content changed beyond the Stage 3 text itself, no new LLM calls added |

New tests: [pattern-bom-expansion.test.ts](test/pattern-bom-expansion.test.ts) covers expansion of all three existing patterns (`voltage-regulator-ams1117`, `usb-c-power-input`, `crystal-oscillator`) into correct BOM rows, unknown-pattern error handling, `parseBomTable` compatibility (regression check against existing BOM consumers such as `drift.ts` and `export.js`), and in-place `use pattern:` text resolution via `resolvePatternsInBomText`.

Known pre-existing failures unrelated to this PR: none observed.

### Manual test log (required)
- Sandbox variant used: `create`
- Commands run and outcome:
```text
$ npx vitest run test/pattern-bom-expansion.test.ts
✓ expands voltage-regulator-ams1117 into correct BOM rows with pattern rationale
✓ expands usb-c-power-input into correct BOM rows with pattern rationale
✓ expands crystal-oscillator into correct BOM rows with pattern rationale
✓ resolvePatternsInBomText replaces "use pattern: <name>" with expanded rows
✓ header line matches "| Pattern: <name> | source: ... |" format
✓ throws a descriptive error for an unknown pattern name
✓ expanded rows parse cleanly via existing parseBomTable
✓ manual/hand-written BOM rows remain unaffected (regression)
✓ expanded rows carry no extra fields beyond the standard 5-column shape
9 passed (9)

$ npm run validate:patterns
3/3 patterns validated

$ openspec validate add-pattern-bom-reference
Change 'add-pattern-bom-reference' is valid

$ git diff feature/circuit-pattern-library...HEAD -- src/kicad/draft/ir.ts src/kicad/draft/engine.ts
(no output — 0 changed lines in both guardrail files)
```

## Docs
Updated [docs/patterns.md](docs/patterns.md) with a new "Using Patterns During Part-Selection" section, showing the before/after BOM.md row example and the CLI resolution log (`Resolved pattern "<name>" -> N parts added to BOM.md`) from the issue.

---

## Invariant checklist
- [x] **Spec-gated in**: N/A for a new write tool (none introduced) — but the OpenSpec proposal (`add-pattern-bom-reference`) still gates this per the spec-gated-edits rule, since Stage 3 agent-facing behavior changed.
- [x] **Verification-gated out**: N/A — no new mutation path. Expanded BOM rows reach Stage 4 and the existing ERC/DRC gates exactly like hand-written rows; nothing new is exempted from verification.
- [x] **`check`/`verify` stays LLM-free and network-free**: N/A — no changes under `src/commands/check`.
- [x] **No sexp serialization**: N/A — no KiCad file parsing/writing touched; `src/kicad/` parser untouched.
- [x] **Sync-obligations ledger**: N/A — no post-tool-call hooks or ledger-relevant behavior touched.
- [x] **Secrets**: N/A — no secrets, env vars, or transcript/log code touched.
- [x] **Spec coherence**: `openspec/changes/add-pattern-bom-reference/` (proposal.md, design.md, tasks.md, delta spec) added together in this PR, and `openspec validate add-pattern-bom-reference` passes. No changes to `SPEC.md` itself since this is a purely additive, opt-in capability at Stage 3.