### PR TITLE
test: add deterministic create pipeline end-to-end replay

### DIFF
--- a/docs/findings-create-e2e.md
+++ b/docs/findings-create-e2e.md
@@ -1,0 +1,33 @@
+# Create pipeline E2E bounty #66 — initial findings
+
+This report is intentionally limited to findings grounded in the current source and deterministic harness. A real KiCad/provider run must be appended before final bounty delivery.
+
+## DEFECT — P1 — no single test proves all eight create stages reach final completion
+
+**Where:** `src/commands/create.ts` exports the eight-stage state machine; existing tests exercise stage budgets and resilience branches independently.
+
+**Symptom:** Existing coverage can prove partial progression and failure/retry behavior without one durable test asserting the full `spec-seed → architecture → part-selection → schematic → layout-draft → outputs → firmware → devplan` arc.
+
+**Suggested:** Add a deterministic `runCreate` replay fixture that satisfies each stage's real completion contract and asserts the final `ok` result plus the exact eight-stage completion list.
+
+**Status:** Harness authored in `test/create-pipeline-e2e.test.ts`.
+
+## DEFECT — P1 — false-green ERC alone is insufficient proof of a schematic
+
+**Where:** schematic completion contract in `src/commands/create.ts`.
+
+**Symptom:** A blank/zero-symbol sheet may be electrically “clean” in a tool-level sense. The completion contract correctly checks symbol presence before ERC, but the end-to-end regression suite did not prove that this ordering remains enforced.
+
+**Suggested:** Add a regression case where ERC reports `ok: true` while `listSymbols()` returns no symbols; the pipeline must stop at stage 4 and must not advance.
+
+**Status:** Harness authored.
+
+## DEFECT — P1 — final-stage omission needs an end-to-end regression assertion
+
+**Where:** stage 8 `devplan` completion contract and `runCreate` final result.
+
+**Symptom:** A successful agent turn is not sufficient if `DEVPLAN.md` is absent or empty. A future regression could mistakenly treat provider success as pipeline success.
+
+**Suggested:** Replay stages 1–7 successfully, deliberately omit the stage-8 artifact, and assert `ok === false` with only seven completed stages.
+
+**Status:** Harness authored.

--- a/test/create-pipeline-e2e.test.ts
+++ b/test/create-pipeline-e2e.test.ts
@@ -3,9 +3,16 @@ import path from 'node:path';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { execa } from 'execa';
 import type { RunOptions, RunResult } from '../src/agent/loop.js';
+import type { Provider, Turn } from '../src/agent/types.js';
 import { tempFixtureRepo } from './helpers.js';
 
 const mockRunAgentLoop = vi.hoisted(() => vi.fn<(opts: RunOptions) => Promise<RunResult>>());
+const mockMakeProvider = vi.hoisted(() =>
+  vi.fn(async () => ({
+    name: 'scripted-diagnosis',
+    chat: async () => ({ text: null, toolCalls: [], usage: { inputTokens: 0, outputTokens: 0 } }),
+  })),
+);
 const mockListSymbols = vi.hoisted(() => vi.fn());
 const mockRunErc = vi.hoisted(() => vi.fn());
 const mockCheckDrift = vi.hoisted(() => vi.fn());
@@ -14,6 +21,13 @@ const mockCheckLegibility = vi.hoisted(() => vi.fn());
 vi.mock('../src/agent/loop.js', async (importOriginal) => ({
   ...(await importOriginal<object>()),
   runAgentLoop: mockRunAgentLoop,
+  makeProvider: mockMakeProvider,
+}));
+vi.mock('../src/agent/recovery.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  diagnoseStageFailure: vi.fn(async () => ({ verdict: 'abort', reason: 'deterministic test stop' })),
+  transcriptExcerpt: vi.fn(async () => ''),
+  symbolAvailabilityFacts: vi.fn(async () => ''),
 }));
 vi.mock('../src/kicad/sexp.js', async (importOriginal) => ({ ...(await importOriginal<object>()), listSymbols: mockListSymbols }));
 vi.mock('../src/kicad/cli.js', async (importOriginal) => ({ ...(await importOriginal<object>()), runErc: mockRunErc }));
@@ -25,8 +39,8 @@ vi.mock('../src/commands/export.js', async (importOriginal) => ({ ...(await impo
 
 import { runCreate } from '../src/commands/create.js';
 
-function ok(commit: string | null = null): RunResult {
-  return { outcome: 'success', exitPath: 'done', summary: 'deterministic replay', transcriptDir: '', filesTouched: [], commit,
+function ok(): RunResult {
+  return { outcome: 'success', exitPath: 'done', summary: 'deterministic replay', transcriptDir: '', filesTouched: [], commit: null,
     stats: { exitPath: 'done', turnsUsed: 1, maxTurns: 40, repairCyclesUsed: 0, maxRepairCycles: 5, tokensIn: 0, tokensOut: 0, perTurn: [], durationMs: 1 }, cacheHits: 1 };
 }
 
@@ -65,17 +79,24 @@ async function satisfyStage(repo: string, request: string, includeDevplan = true
   }
 }
 
-async function commitStage(repo: string, request: string): Promise<RunResult> {
-  const stage = request.match(/create pipeline stage:\s*([\w-]+)/)?.[1] ?? 'unknown';
-  await execa('git', ['add', '-A'], { cwd: repo });
-  await execa('git', ['commit', '-q', '-m', `create: ${stage}`], { cwd: repo });
-  const { stdout } = await execa('git', ['rev-parse', 'HEAD'], { cwd: repo });
-  return ok(stdout.trim());
+function scriptedProvider(turns: Partial<Turn>[]): Provider {
+  let i = 0;
+  return {
+    name: 'scripted',
+    async chat(): Promise<Turn> {
+      const t = turns[Math.min(i, turns.length - 1)]!;
+      i++;
+      return {
+        text: t.text ?? null,
+        toolCalls: (t.toolCalls ?? []).map((c, j) => ({ ...c, id: `call-${i}-${j}` })),
+        usage: t.usage ?? { inputTokens: 1, outputTokens: 1 },
+      };
+    },
+  };
 }
 
 beforeEach(() => {
-  mockRunAgentLoop.mockReset(); mockListSymbols.mockReset(); mockRunErc.mockReset(); mockCheckDrift.mockReset(); mockCheckLegibility.mockReset();
-  // The bootstrapped schematic is intentionally incomplete until the schematic turn runs.
+  mockRunAgentLoop.mockReset(); mockMakeProvider.mockClear(); mockListSymbols.mockReset(); mockRunErc.mockReset(); mockCheckDrift.mockReset(); mockCheckLegibility.mockReset();
   mockListSymbols.mockResolvedValue([]);
   mockRunErc.mockResolvedValue({ ok: true, output: '' });
   mockCheckDrift.mockResolvedValue([]);
@@ -83,26 +104,18 @@ beforeEach(() => {
 });
 
 describe('create pipeline deterministic end-to-end replay (#66)', () => {
-  it('reaches and commits the final 8th stage from a non-trivial brief', async () => {
+  it('reaches the final 8th stage from a non-trivial brief', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
-      const { stdout: before } = await execa('git', ['rev-list', '--count', 'HEAD'], { cwd: repo });
       const briefPath = await seedRepo(repo);
-      const stageCommits: string[] = [];
       mockRunAgentLoop.mockImplementation(async (opts) => {
         await satisfyStage(opts.repoRoot, opts.request);
-        const result = await commitStage(opts.repoRoot, opts.request);
-        stageCommits.push(result.commit!);
-        return result;
+        return ok();
       });
       const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
-      const { stdout: after } = await execa('git', ['rev-list', '--count', 'HEAD'], { cwd: repo });
       expect(res.ok).toBe(true);
       expect(res.completed).toEqual(['spec-seed','architecture','part-selection','schematic','layout-draft','outputs','firmware','devplan']);
       expect(mockRunAgentLoop).toHaveBeenCalledTimes(8);
-      expect(stageCommits).toHaveLength(8);
-      expect(new Set(stageCommits).size).toBe(8);
-      expect(Number(after) - Number(before)).toBe(8);
     } finally { await cleanup(); }
   });
 
@@ -118,10 +131,11 @@ describe('create pipeline deterministic end-to-end replay (#66)', () => {
         }
         return ok();
       });
-      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', maxStageRetries: 0, log: () => {} });
+      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
       expect(res.ok).toBe(false);
       expect(res.completed).toEqual(['spec-seed','architecture','part-selection']);
       expect(mockRunErc).not.toHaveBeenCalled();
+      expect(mockMakeProvider).toHaveBeenCalledTimes(1);
     } finally { await cleanup(); }
   });
 
@@ -130,9 +144,38 @@ describe('create pipeline deterministic end-to-end replay (#66)', () => {
     try {
       const briefPath = await seedRepo(repo);
       mockRunAgentLoop.mockImplementation(async (opts) => { await satisfyStage(opts.repoRoot, opts.request, false); return ok(); });
-      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', maxStageRetries: 0, log: () => {} });
+      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
       expect(res.ok).toBe(false);
       expect(res.completed).toEqual(['spec-seed','architecture','part-selection','schematic','layout-draft','outputs','firmware']);
+      expect(mockMakeProvider).toHaveBeenCalledTimes(1);
+    } finally { await cleanup(); }
+  });
+
+  it('uses the real agent loop for the production commit path', async () => {
+    const { runAgentLoop: realRunAgentLoop } = await vi.importActual<typeof import('../src/agent/loop.js')>('../src/agent/loop.js');
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const { stdout: before } = await execa('git', ['rev-list', '--count', 'HEAD'], { cwd: repo });
+      const provider = scriptedProvider([
+        { toolCalls: [
+          { name: 'propose_change', args: { id: 'e2e-commit-proof', why: 'exercise the real production commit path', what_changes: '- add deterministic proof note', tasks: '- [x] add note' } },
+          { name: 'validate_change', args: {} },
+        ] },
+        { toolCalls: [{ name: 'write_file', args: { path: 'E2E-COMMIT-PROOF.md', content: '# E2E commit proof\n\nProduced through the real agent loop.\n' } }] },
+        { toolCalls: [{ name: 'finish', args: { outcome: 'done', summary: 'production loop commit proof complete' } }] },
+      ]);
+      const res = await realRunAgentLoop({
+        repoRoot: repo,
+        request: 'write deterministic E2E commit proof',
+        model: 'gpt-5',
+        provider,
+        maxTurns: 4,
+        log: () => {},
+      });
+      const { stdout: after } = await execa('git', ['rev-list', '--count', 'HEAD'], { cwd: repo });
+      expect(res.outcome).toBe('success');
+      expect(res.commit).toMatch(/^[0-9a-f]{40}$/);
+      expect(Number(after) - Number(before)).toBe(1);
     } finally { await cleanup(); }
   });
 });

--- a/test/create-pipeline-e2e.test.ts
+++ b/test/create-pipeline-e2e.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import path from 'node:path';
 import { mkdir, writeFile } from 'node:fs/promises';
+import { execa } from 'execa';
 import type { RunOptions, RunResult } from '../src/agent/loop.js';
 import { tempFixtureRepo } from './helpers.js';
 
@@ -24,8 +25,8 @@ vi.mock('../src/commands/export.js', async (importOriginal) => ({ ...(await impo
 
 import { runCreate } from '../src/commands/create.js';
 
-function ok(): RunResult {
-  return { outcome: 'success', exitPath: 'done', summary: 'deterministic replay', transcriptDir: '', filesTouched: [], commit: null,
+function ok(commit: string | null = null): RunResult {
+  return { outcome: 'success', exitPath: 'done', summary: 'deterministic replay', transcriptDir: '', filesTouched: [], commit,
     stats: { exitPath: 'done', turnsUsed: 1, maxTurns: 40, repairCyclesUsed: 0, maxRepairCycles: 5, tokensIn: 0, tokensOut: 0, perTurn: [], durationMs: 1 }, cacheHits: 1 };
 }
 
@@ -64,6 +65,14 @@ async function satisfyStage(repo: string, request: string, includeDevplan = true
   }
 }
 
+async function commitStage(repo: string, request: string): Promise<RunResult> {
+  const stage = request.match(/create pipeline stage:\s*([\w-]+)/)?.[1] ?? 'unknown';
+  await execa('git', ['add', '-A'], { cwd: repo });
+  await execa('git', ['commit', '-q', '-m', `create: ${stage}`], { cwd: repo });
+  const { stdout } = await execa('git', ['rev-parse', 'HEAD'], { cwd: repo });
+  return ok(stdout.trim());
+}
+
 beforeEach(() => {
   mockRunAgentLoop.mockReset(); mockListSymbols.mockReset(); mockRunErc.mockReset(); mockCheckDrift.mockReset(); mockCheckLegibility.mockReset();
   // The bootstrapped schematic is intentionally incomplete until the schematic turn runs.
@@ -74,15 +83,26 @@ beforeEach(() => {
 });
 
 describe('create pipeline deterministic end-to-end replay (#66)', () => {
-  it('reaches the final 8th stage from a non-trivial brief', async () => {
+  it('reaches and commits the final 8th stage from a non-trivial brief', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
+      const { stdout: before } = await execa('git', ['rev-list', '--count', 'HEAD'], { cwd: repo });
       const briefPath = await seedRepo(repo);
-      mockRunAgentLoop.mockImplementation(async (opts) => { await satisfyStage(opts.repoRoot, opts.request); return ok(); });
+      const stageCommits: string[] = [];
+      mockRunAgentLoop.mockImplementation(async (opts) => {
+        await satisfyStage(opts.repoRoot, opts.request);
+        const result = await commitStage(opts.repoRoot, opts.request);
+        stageCommits.push(result.commit!);
+        return result;
+      });
       const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
+      const { stdout: after } = await execa('git', ['rev-list', '--count', 'HEAD'], { cwd: repo });
       expect(res.ok).toBe(true);
       expect(res.completed).toEqual(['spec-seed','architecture','part-selection','schematic','layout-draft','outputs','firmware','devplan']);
       expect(mockRunAgentLoop).toHaveBeenCalledTimes(8);
+      expect(stageCommits).toHaveLength(8);
+      expect(new Set(stageCommits).size).toBe(8);
+      expect(Number(after) - Number(before)).toBe(8);
     } finally { await cleanup(); }
   });
 

--- a/test/create-pipeline-e2e.test.ts
+++ b/test/create-pipeline-e2e.test.ts
@@ -118,7 +118,7 @@ describe('create pipeline deterministic end-to-end replay (#66)', () => {
         }
         return ok();
       });
-      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
+      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', maxStageRetries: 0, log: () => {} });
       expect(res.ok).toBe(false);
       expect(res.completed).toEqual(['spec-seed','architecture','part-selection']);
       expect(mockRunErc).not.toHaveBeenCalled();
@@ -130,7 +130,7 @@ describe('create pipeline deterministic end-to-end replay (#66)', () => {
     try {
       const briefPath = await seedRepo(repo);
       mockRunAgentLoop.mockImplementation(async (opts) => { await satisfyStage(opts.repoRoot, opts.request, false); return ok(); });
-      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
+      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', maxStageRetries: 0, log: () => {} });
       expect(res.ok).toBe(false);
       expect(res.completed).toEqual(['spec-seed','architecture','part-selection','schematic','layout-draft','outputs','firmware']);
     } finally { await cleanup(); }

--- a/test/create-pipeline-e2e.test.ts
+++ b/test/create-pipeline-e2e.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'node:path';
+import { mkdir, writeFile } from 'node:fs/promises';
+import type { RunOptions, RunResult } from '../src/agent/loop.js';
+import { tempFixtureRepo } from './helpers.js';
+
+const mockRunAgentLoop = vi.hoisted(() => vi.fn<(opts: RunOptions) => Promise<RunResult>>());
+const mockListSymbols = vi.hoisted(() => vi.fn());
+const mockRunErc = vi.hoisted(() => vi.fn());
+const mockCheckDrift = vi.hoisted(() => vi.fn());
+const mockCheckLegibility = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/agent/loop.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  runAgentLoop: mockRunAgentLoop,
+}));
+
+vi.mock('../src/kicad/sexp.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  listSymbols: mockListSymbols,
+}));
+
+vi.mock('../src/kicad/cli.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  runErc: mockRunErc,
+}));
+
+vi.mock('../src/memory/drift.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  checkDrift: mockCheckDrift,
+}));
+
+vi.mock('../src/kicad/legibility.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  checkLegibility: mockCheckLegibility,
+}));
+
+vi.mock('../src/openspec/cli.js', () => ({
+  openspecInit: async () => ({ ok: true, output: '' }),
+}));
+
+vi.mock('../src/commands/check.js', () => ({
+  runCheck: async () => ({ ok: true }),
+}));
+
+vi.mock('../src/commands/export.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  emitCreateJlcpcbBom: async () => null,
+}));
+
+import { runCreate } from '../src/commands/create.js';
+
+function ok(): RunResult {
+  return {
+    outcome: 'success',
+    exitPath: 'done',
+    summary: 'deterministic replay',
+    transcriptDir: '',
+    filesTouched: [],
+    commit: null,
+    stats: {
+      exitPath: 'done',
+      turnsUsed: 1,
+      maxTurns: 40,
+      repairCyclesUsed: 0,
+      maxRepairCycles: 5,
+      tokensIn: 0,
+      tokensOut: 0,
+      perTurn: [],
+      durationMs: 1,
+    },
+    cacheHits: 1,
+  };
+}
+
+async function seedRepo(repo: string): Promise<string> {
+  await mkdir(path.join(repo, '.copperhead'), { recursive: true });
+  const briefPath = path.join(repo, 'brief.md');
+  await writeFile(
+    briefPath,
+    '# USB-C power breakout\n\nExpose VBUS and GND with a protected 5 V output.\n',
+    'utf8',
+  );
+  return briefPath;
+}
+
+async function satisfyStage(repo: string, request: string, includeDevplan = true): Promise<void> {
+  const docs = path.join(repo, 'docs');
+  await mkdir(docs, { recursive: true });
+
+  if (request.includes('spec-seed')) {
+    await writeFile(
+      path.join(docs, 'SPEC.md'),
+      '# USB-C breakout\n\n## Budgets\n\n- input_voltage: 5 V\n- output_current: 500 mA\n',
+      'utf8',
+    );
+    return;
+  }
+
+  if (request.includes('architecture')) {
+    await writeFile(
+      path.join(docs, 'SUBSYSTEMS.md'),
+      '# Subsystems\n\n## Power\n\nUSB-C VBUS feeds a protected 5 V output.\n',
+      'utf8',
+    );
+    return;
+  }
+
+  if (request.includes('part-selection')) {
+    await writeFile(
+      path.join(docs, 'BOM.md'),
+      [
+        '# BOM',
+        '',
+        '| Refdes | Value | Footprint | MPN | Rationale |',
+        '|---|---|---|---|---|',
+        '| R1 | 5.1k | R_0603 | RC0603FR-075K1L | CC pull-down |',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    return;
+  }
+
+  if (request.includes('schematic')) {
+    // bootstrapKicadProject creates the actual slugged project before this turn.
+    await writeFile(
+      path.join(repo, 'usb-c-power-breakout.kicad_sch'),
+      '(kicad_sch (version 20231120) (generator "test"))\n',
+      'utf8',
+    );
+    return;
+  }
+
+  if (request.includes('layout-draft')) {
+    await writeFile(
+      path.join(repo, 'usb-c-power-breakout.kicad_pcb'),
+      '(kicad_pcb (version 20240108) (footprint "Connector_USB:USB_C"))\n',
+      'utf8',
+    );
+    await writeFile(
+      path.join(docs, 'LAYOUT.md'),
+      '# Layout\n\n## Draft quality\n\nConnector is edge-aligned; routing is intentionally minimal.\n',
+      'utf8',
+    );
+    return;
+  }
+
+  if (request.includes('outputs package')) {
+    await mkdir(path.join(repo, 'outputs'), { recursive: true });
+    await writeFile(path.join(repo, 'outputs', 'usb-c-power-breakout-F_Cu.gbr'), 'G04 replay fixture*\n', 'utf8');
+    return;
+  }
+
+  if (request.includes('firmware scaffold')) {
+    await mkdir(path.join(repo, 'firmware'), { recursive: true });
+    await writeFile(path.join(repo, 'firmware', 'main.c'), 'int main(void) { return 0; }\n', 'utf8');
+    return;
+  }
+
+  if (request.includes('DEVPLAN.md') && includeDevplan) {
+    await writeFile(
+      path.join(docs, 'DEVPLAN.md'),
+      '# Development plan\n\n## Bring-up\n\n1. Verify 5 V and ground before attaching a load.\n',
+      'utf8',
+    );
+  }
+}
+
+beforeEach(() => {
+  mockRunAgentLoop.mockReset();
+  mockListSymbols.mockReset();
+  mockRunErc.mockReset();
+  mockCheckDrift.mockReset();
+  mockCheckLegibility.mockReset();
+
+  mockListSymbols.mockResolvedValue([{ ref: 'R1' }]);
+  mockRunErc.mockResolvedValue({ ok: true, output: '' });
+  mockCheckDrift.mockResolvedValue([]);
+  mockCheckLegibility.mockResolvedValue({
+    counts: { error: 0, warning: 0, info: 0 },
+    findings: [],
+  });
+});
+
+describe('create pipeline deterministic end-to-end replay (#66)', () => {
+  it('reaches and commits the final 8th stage from a non-trivial brief', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo);
+      mockRunAgentLoop.mockImplementation(async (opts) => {
+        await satisfyStage(opts.repoRoot, opts.request);
+        return ok();
+      });
+
+      const res = await runCreate({
+        repoRoot: repo,
+        briefPath,
+        model: 'gpt-5',
+        log: () => {},
+      });
+
+      expect(res.ok).toBe(true);
+      expect(res.completed).toEqual([
+        'spec-seed',
+        'architecture',
+        'part-selection',
+        'schematic',
+        'layout-draft',
+        'outputs',
+        'firmware',
+        'devplan',
+      ]);
+      expect(mockRunAgentLoop).toHaveBeenCalledTimes(8);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('rejects a false-green schematic with no symbols even when ERC reports clean', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo);
+      mockListSymbols.mockResolvedValue([]);
+      mockRunAgentLoop.mockImplementation(async (opts) => {
+        await satisfyStage(opts.repoRoot, opts.request);
+        return ok();
+      });
+
+      const res = await runCreate({
+        repoRoot: repo,
+        briefPath,
+        model: 'gpt-5',
+        log: () => {},
+      });
+
+      expect(res.ok).toBe(false);
+      expect(res.completed).toEqual(['spec-seed', 'architecture', 'part-selection']);
+      expect(mockRunErc).not.toHaveBeenCalled();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('fails loudly when the final stage is not produced', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    try {
+      const briefPath = await seedRepo(repo);
+      mockRunAgentLoop.mockImplementation(async (opts) => {
+        await satisfyStage(opts.repoRoot, opts.request, false);
+        return ok();
+      });
+
+      const res = await runCreate({
+        repoRoot: repo,
+        briefPath,
+        model: 'gpt-5',
+        log: () => {},
+      });
+
+      expect(res.ok).toBe(false);
+      expect(res.completed).toEqual([
+        'spec-seed',
+        'architecture',
+        'part-selection',
+        'schematic',
+        'layout-draft',
+        'outputs',
+        'firmware',
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/test/create-pipeline-e2e.test.ts
+++ b/test/create-pipeline-e2e.test.ts
@@ -131,11 +131,11 @@ describe('create pipeline deterministic end-to-end replay (#66)', () => {
         }
         return ok();
       });
-      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
+      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {}, maxStageRetries: 0 });
       expect(res.ok).toBe(false);
       expect(res.completed).toEqual(['spec-seed','architecture','part-selection']);
       expect(mockRunErc).not.toHaveBeenCalled();
-      expect(mockMakeProvider).toHaveBeenCalledTimes(1);
+      expect(mockMakeProvider).toHaveBeenCalledTimes(0);
     } finally { await cleanup(); }
   });
 
@@ -144,10 +144,10 @@ describe('create pipeline deterministic end-to-end replay (#66)', () => {
     try {
       const briefPath = await seedRepo(repo);
       mockRunAgentLoop.mockImplementation(async (opts) => { await satisfyStage(opts.repoRoot, opts.request, false); return ok(); });
-      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
+      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {}, maxStageRetries: 0 });
       expect(res.ok).toBe(false);
       expect(res.completed).toEqual(['spec-seed','architecture','part-selection','schematic','layout-draft','outputs','firmware']);
-      expect(mockMakeProvider).toHaveBeenCalledTimes(1);
+      expect(mockMakeProvider).toHaveBeenCalledTimes(0);
     } finally { await cleanup(); }
   });
 
@@ -162,6 +162,7 @@ describe('create pipeline deterministic end-to-end replay (#66)', () => {
           { name: 'validate_change', args: {} },
         ] },
         { toolCalls: [{ name: 'write_file', args: { path: 'E2E-COMMIT-PROOF.md', content: '# E2E commit proof\n\nProduced through the real agent loop.\n' } }] },
+        { toolCalls: [{ name: 'check_drift', args: {} }] },
         { toolCalls: [{ name: 'finish', args: { outcome: 'done', summary: 'production loop commit proof complete' } }] },
       ]);
       const res = await realRunAgentLoop({
@@ -169,7 +170,7 @@ describe('create pipeline deterministic end-to-end replay (#66)', () => {
         request: 'write deterministic E2E commit proof',
         model: 'gpt-5',
         provider,
-        maxTurns: 4,
+        maxTurns: 5,
         log: () => {},
       });
       const { stdout: after } = await execa('git', ['rev-list', '--count', 'HEAD'], { cwd: repo });

--- a/test/create-pipeline-e2e.test.ts
+++ b/test/create-pipeline-e2e.test.ts
@@ -14,262 +14,105 @@ vi.mock('../src/agent/loop.js', async (importOriginal) => ({
   ...(await importOriginal<object>()),
   runAgentLoop: mockRunAgentLoop,
 }));
-
-vi.mock('../src/kicad/sexp.js', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  listSymbols: mockListSymbols,
-}));
-
-vi.mock('../src/kicad/cli.js', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  runErc: mockRunErc,
-}));
-
-vi.mock('../src/memory/drift.js', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  checkDrift: mockCheckDrift,
-}));
-
-vi.mock('../src/kicad/legibility.js', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  checkLegibility: mockCheckLegibility,
-}));
-
-vi.mock('../src/openspec/cli.js', () => ({
-  openspecInit: async () => ({ ok: true, output: '' }),
-}));
-
-vi.mock('../src/commands/check.js', () => ({
-  runCheck: async () => ({ ok: true }),
-}));
-
-vi.mock('../src/commands/export.js', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  emitCreateJlcpcbBom: async () => null,
-}));
+vi.mock('../src/kicad/sexp.js', async (importOriginal) => ({ ...(await importOriginal<object>()), listSymbols: mockListSymbols }));
+vi.mock('../src/kicad/cli.js', async (importOriginal) => ({ ...(await importOriginal<object>()), runErc: mockRunErc }));
+vi.mock('../src/memory/drift.js', async (importOriginal) => ({ ...(await importOriginal<object>()), checkDrift: mockCheckDrift }));
+vi.mock('../src/kicad/legibility.js', async (importOriginal) => ({ ...(await importOriginal<object>()), checkLegibility: mockCheckLegibility }));
+vi.mock('../src/openspec/cli.js', () => ({ openspecInit: async () => ({ ok: true, output: '' }) }));
+vi.mock('../src/commands/check.js', () => ({ runCheck: async () => ({ ok: true }) }));
+vi.mock('../src/commands/export.js', async (importOriginal) => ({ ...(await importOriginal<object>()), emitCreateJlcpcbBom: async () => null }));
 
 import { runCreate } from '../src/commands/create.js';
 
 function ok(): RunResult {
-  return {
-    outcome: 'success',
-    exitPath: 'done',
-    summary: 'deterministic replay',
-    transcriptDir: '',
-    filesTouched: [],
-    commit: null,
-    stats: {
-      exitPath: 'done',
-      turnsUsed: 1,
-      maxTurns: 40,
-      repairCyclesUsed: 0,
-      maxRepairCycles: 5,
-      tokensIn: 0,
-      tokensOut: 0,
-      perTurn: [],
-      durationMs: 1,
-    },
-    cacheHits: 1,
-  };
+  return { outcome: 'success', exitPath: 'done', summary: 'deterministic replay', transcriptDir: '', filesTouched: [], commit: null,
+    stats: { exitPath: 'done', turnsUsed: 1, maxTurns: 40, repairCyclesUsed: 0, maxRepairCycles: 5, tokensIn: 0, tokensOut: 0, perTurn: [], durationMs: 1 }, cacheHits: 1 };
 }
 
 async function seedRepo(repo: string): Promise<string> {
   await mkdir(path.join(repo, '.copperhead'), { recursive: true });
   const briefPath = path.join(repo, 'brief.md');
-  await writeFile(
-    briefPath,
-    '# USB-C power breakout\n\nExpose VBUS and GND with a protected 5 V output.\n',
-    'utf8',
-  );
+  await writeFile(briefPath, '# USB-C power breakout\n\nExpose VBUS and GND with a protected 5 V output.\n', 'utf8');
   return briefPath;
 }
 
 async function satisfyStage(repo: string, request: string, includeDevplan = true): Promise<void> {
   const docs = path.join(repo, 'docs');
   await mkdir(docs, { recursive: true });
+  const stage = request.match(/create pipeline stage:\s*([\w-]+)/)?.[1];
 
-  if (request.includes('spec-seed')) {
-    await writeFile(
-      path.join(docs, 'SPEC.md'),
-      '# USB-C breakout\n\n## Budgets\n\n- input_voltage: 5 V\n- output_current: 500 mA\n',
-      'utf8',
-    );
-    return;
-  }
-
-  if (request.includes('architecture')) {
-    await writeFile(
-      path.join(docs, 'SUBSYSTEMS.md'),
-      '# Subsystems\n\n## Power\n\nUSB-C VBUS feeds a protected 5 V output.\n',
-      'utf8',
-    );
-    return;
-  }
-
-  if (request.includes('part-selection')) {
-    await writeFile(
-      path.join(docs, 'BOM.md'),
-      [
-        '# BOM',
-        '',
-        '| Refdes | Value | Footprint | MPN | Rationale |',
-        '|---|---|---|---|---|',
-        '| R1 | 5.1k | R_0603 | RC0603FR-075K1L | CC pull-down |',
-        '',
-      ].join('\n'),
-      'utf8',
-    );
-    return;
-  }
-
-  if (request.includes('schematic')) {
-    // bootstrapKicadProject creates the actual slugged project before this turn.
-    await writeFile(
-      path.join(repo, 'usb-c-power-breakout.kicad_sch'),
-      '(kicad_sch (version 20231120) (generator "test"))\n',
-      'utf8',
-    );
-    return;
-  }
-
-  if (request.includes('layout-draft')) {
-    await writeFile(
-      path.join(repo, 'usb-c-power-breakout.kicad_pcb'),
-      '(kicad_pcb (version 20240108) (footprint "Connector_USB:USB_C"))\n',
-      'utf8',
-    );
-    await writeFile(
-      path.join(docs, 'LAYOUT.md'),
-      '# Layout\n\n## Draft quality\n\nConnector is edge-aligned; routing is intentionally minimal.\n',
-      'utf8',
-    );
-    return;
-  }
-
-  if (request.includes('outputs package')) {
+  if (stage === 'spec-seed') {
+    await writeFile(path.join(docs, 'SPEC.md'), '# USB-C breakout\n\n## Budgets\n\n- input_voltage: 5 V\n- output_current: 500 mA\n', 'utf8');
+  } else if (stage === 'architecture') {
+    await writeFile(path.join(docs, 'SUBSYSTEMS.md'), '# Subsystems\n\n## Power\n\nUSB-C VBUS feeds a protected 5 V output.\n', 'utf8');
+  } else if (stage === 'part-selection') {
+    await writeFile(path.join(docs, 'BOM.md'), '# BOM\n\n| Refdes | Value | Footprint | MPN | Rationale |\n|---|---|---|---|---|\n| R1 | 5.1k | R_0603 | RC0603FR-075K1L | CC pull-down |\n', 'utf8');
+  } else if (stage === 'schematic') {
+    await writeFile(path.join(repo, 'usb-c-power-breakout.kicad_sch'), '(kicad_sch (version 20231120) (generator "test"))\n', 'utf8');
+    mockListSymbols.mockResolvedValue([{ ref: 'R1' }]);
+  } else if (stage === 'layout-draft') {
+    await writeFile(path.join(repo, 'usb-c-power-breakout.kicad_pcb'), '(kicad_pcb (version 20240108) (footprint "Connector_USB:USB_C"))\n', 'utf8');
+    await writeFile(path.join(docs, 'LAYOUT.md'), '# Layout\n\n## Draft quality\n\nConnector is edge-aligned; routing is intentionally minimal.\n', 'utf8');
+  } else if (stage === 'outputs') {
     await mkdir(path.join(repo, 'outputs'), { recursive: true });
     await writeFile(path.join(repo, 'outputs', 'usb-c-power-breakout-F_Cu.gbr'), 'G04 replay fixture*\n', 'utf8');
-    return;
-  }
-
-  if (request.includes('firmware scaffold')) {
+  } else if (stage === 'firmware') {
     await mkdir(path.join(repo, 'firmware'), { recursive: true });
     await writeFile(path.join(repo, 'firmware', 'main.c'), 'int main(void) { return 0; }\n', 'utf8');
-    return;
-  }
-
-  if (request.includes('DEVPLAN.md') && includeDevplan) {
-    await writeFile(
-      path.join(docs, 'DEVPLAN.md'),
-      '# Development plan\n\n## Bring-up\n\n1. Verify 5 V and ground before attaching a load.\n',
-      'utf8',
-    );
+  } else if (stage === 'devplan' && includeDevplan) {
+    await writeFile(path.join(docs, 'DEVPLAN.md'), '# Development plan\n\n## Bring-up\n\n1. Verify 5 V and ground before attaching a load.\n', 'utf8');
   }
 }
 
 beforeEach(() => {
-  mockRunAgentLoop.mockReset();
-  mockListSymbols.mockReset();
-  mockRunErc.mockReset();
-  mockCheckDrift.mockReset();
-  mockCheckLegibility.mockReset();
-
-  mockListSymbols.mockResolvedValue([{ ref: 'R1' }]);
+  mockRunAgentLoop.mockReset(); mockListSymbols.mockReset(); mockRunErc.mockReset(); mockCheckDrift.mockReset(); mockCheckLegibility.mockReset();
+  // The bootstrapped schematic is intentionally incomplete until the schematic turn runs.
+  mockListSymbols.mockResolvedValue([]);
   mockRunErc.mockResolvedValue({ ok: true, output: '' });
   mockCheckDrift.mockResolvedValue([]);
-  mockCheckLegibility.mockResolvedValue({
-    counts: { error: 0, warning: 0, info: 0 },
-    findings: [],
-  });
+  mockCheckLegibility.mockResolvedValue({ counts: { error: 0, warning: 0, info: 0 }, findings: [] });
 });
 
 describe('create pipeline deterministic end-to-end replay (#66)', () => {
-  it('reaches and commits the final 8th stage from a non-trivial brief', async () => {
+  it('reaches the final 8th stage from a non-trivial brief', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       const briefPath = await seedRepo(repo);
-      mockRunAgentLoop.mockImplementation(async (opts) => {
-        await satisfyStage(opts.repoRoot, opts.request);
-        return ok();
-      });
-
-      const res = await runCreate({
-        repoRoot: repo,
-        briefPath,
-        model: 'gpt-5',
-        log: () => {},
-      });
-
+      mockRunAgentLoop.mockImplementation(async (opts) => { await satisfyStage(opts.repoRoot, opts.request); return ok(); });
+      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
       expect(res.ok).toBe(true);
-      expect(res.completed).toEqual([
-        'spec-seed',
-        'architecture',
-        'part-selection',
-        'schematic',
-        'layout-draft',
-        'outputs',
-        'firmware',
-        'devplan',
-      ]);
+      expect(res.completed).toEqual(['spec-seed','architecture','part-selection','schematic','layout-draft','outputs','firmware','devplan']);
       expect(mockRunAgentLoop).toHaveBeenCalledTimes(8);
-    } finally {
-      await cleanup();
-    }
+    } finally { await cleanup(); }
   });
 
   it('rejects a false-green schematic with no symbols even when ERC reports clean', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       const briefPath = await seedRepo(repo);
-      mockListSymbols.mockResolvedValue([]);
       mockRunAgentLoop.mockImplementation(async (opts) => {
-        await satisfyStage(opts.repoRoot, opts.request);
+        if (opts.request.includes('create pipeline stage: schematic')) {
+          await writeFile(path.join(opts.repoRoot, 'usb-c-power-breakout.kicad_sch'), '(kicad_sch (version 20231120) (generator "test"))\n', 'utf8');
+        } else {
+          await satisfyStage(opts.repoRoot, opts.request);
+        }
         return ok();
       });
-
-      const res = await runCreate({
-        repoRoot: repo,
-        briefPath,
-        model: 'gpt-5',
-        log: () => {},
-      });
-
+      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
       expect(res.ok).toBe(false);
-      expect(res.completed).toEqual(['spec-seed', 'architecture', 'part-selection']);
+      expect(res.completed).toEqual(['spec-seed','architecture','part-selection']);
       expect(mockRunErc).not.toHaveBeenCalled();
-    } finally {
-      await cleanup();
-    }
+    } finally { await cleanup(); }
   });
 
   it('fails loudly when the final stage is not produced', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
       const briefPath = await seedRepo(repo);
-      mockRunAgentLoop.mockImplementation(async (opts) => {
-        await satisfyStage(opts.repoRoot, opts.request, false);
-        return ok();
-      });
-
-      const res = await runCreate({
-        repoRoot: repo,
-        briefPath,
-        model: 'gpt-5',
-        log: () => {},
-      });
-
+      mockRunAgentLoop.mockImplementation(async (opts) => { await satisfyStage(opts.repoRoot, opts.request, false); return ok(); });
+      const res = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: () => {} });
       expect(res.ok).toBe(false);
-      expect(res.completed).toEqual([
-        'spec-seed',
-        'architecture',
-        'part-selection',
-        'schematic',
-        'layout-draft',
-        'outputs',
-        'firmware',
-      ]);
-    } finally {
-      await cleanup();
-    }
+      expect(res.completed).toEqual(['spec-seed','architecture','part-selection','schematic','layout-draft','outputs','firmware']);
+    } finally { await cleanup(); }
   });
 });


### PR DESCRIPTION
## What

Adds a deterministic end-to-end replay test for the full eight-stage `create` pipeline, plus regressions for two false-green conditions: a zero-symbol schematic and a missing final `DEVPLAN.md`.

## Why

Closes #66. Existing tests cover stage budgets and resilience branches, but there was no single durable regression proving `spec-seed -> architecture -> part-selection -> schematic -> layout-draft -> outputs -> firmware -> devplan` reaches the final successful result while honoring each stage completion contract.

## Design

The new test mocks provider-facing and KiCad execution surfaces while still calling the real `runCreate` orchestration and satisfying the real stage completion contracts through filesystem artifacts. It does not change the agent loop, provider implementation, KiCad parser, safety gates, or runtime behavior.

A companion findings report records the uncovered E2E gaps and the intended regression coverage.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | not run locally |
| Build | `npm run build` | not run locally |
| Unit + offline | `npm test` | pending repository CI approval/run |
| Live-LLM (opt-in) | keyed on provider env var | n/a, deterministic offline test |

New tests added in [`test/create-pipeline-e2e.test.ts`](test/create-pipeline-e2e.test.ts):

- full eight-stage successful replay
- zero-symbol schematic cannot advance even when ERC reports clean
- omitted `DEVPLAN.md` keeps the pipeline unsuccessful after seven stages

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a
- Commands run and outcome: n/a, this PR adds deterministic test coverage only and does not change CLI/runtime behavior.

```text
n/a: test-only change, no runtime behavior modified
```

## Docs

Adds [`docs/findings-create-e2e.md`](docs/findings-create-e2e.md) with the initial E2E findings for bounty #66.

---

## Invariant checklist

- [x] **Spec-gated in**: N/A, test-only change; tool gating is not modified.
- [x] **Verification-gated out**: N/A, test-only change; mutation verification and rollback behavior are not modified.
- [x] **`check`/`verify` stays LLM-free and network-free**: N/A, no `check` or `verify` implementation change.
- [x] **No sexp serialization**: N/A, KiCad parser/serialization code is not modified.
- [x] **Sync-obligations ledger**: N/A, ledger hooks and commit gating are not modified.
- [x] **Secrets**: N/A, no secret handling or transcript code is modified.
- [x] **Spec coherence**: N/A, this PR changes test coverage only and does not change spec-level behavior.
