### PR TITLE
fix: create regression guards and partial offline integration coverage

### DIFF
--- a/openspec/changes/build-copperhead-phase-1/tasks.md
+++ b/openspec/changes/build-copperhead-phase-1/tasks.md
@@ -89,6 +89,7 @@
 - [x] 9.6 Stage 7: firmware scaffold + pins.h generated from PINOUT.md; vendor toolchain build gate with explicit "not compiled here" fallback in DEVPLAN.md
 - [x] 9.7 Stage 8: DEVPLAN.md (bring-up steps, test points, risk list, prototype order plan)
 - [ ] 9.8 Interactive mode: spec-approval and pre-export gates re-enabled with --interactive; resumability test (kill after BOM stage, re-run continues)
+- [x] 9.9 Stop resume when managed-work commit fails or unrelated dirty files prevent it; deterministic orchestration tests preserve files and reject a false-success result (not live KiCad acceptance)
 
 ## 10. `sync` command (full-state verify and resolve)
 

--- a/openspec/specs/SPEC.md
+++ b/openspec/specs/SPEC.md
@@ -175,6 +175,12 @@ brief.md
 
 Each stage is a `do`-loop run with a stage-specific prompt. State lives in the repo (docs + files), so `create` is resumable: kill it at any stage, re-run, it continues from the docs.
 
+On resume, already-complete but uncommitted stage artifacts must be protected
+before advancing. If the managed-work commit fails, or unrelated dirty files
+prevent that commit, the pipeline stops with an unsuccessful result and leaves
+the files intact for human review. That stage is not reported as completed;
+later stages must not run against unprotected work.
+
 ### First-draft layout (explicitly non-optimal, explicitly useful)
 
 The agent produces an **initial placement and routing plan** — correct, not optimal — and says so:

--- a/reports/create-e2e-findings.md
+++ b/reports/create-e2e-findings.md
@@ -1,0 +1,106 @@
+# Create pipeline investigation: partial findings
+
+Baseline: `c1be00db831f49d8ec6d8e9da54057e6ef789c2c`.
+Investigation date: 2026-09-08. AI-assisted contribution.
+
+This report does **not** establish completion of bounty #66. No live attempt
+completed all eight stages. No successful end-to-end replay is supplied.
+The scripted integration tests are regression evidence, not live acceptance.
+
+## DEFECT / P1: unusable artifacts satisfy completion probes
+
+- Where: `src/commands/create.ts`, `dirHasFiles`.
+- Symptom: empty Gerber/source files and dangling symlinks counted as completed
+  outputs or firmware. Four reproductions failed before the correction.
+- Suggested: require nonempty regular files and continue past unusable entries.
+- Status: corrected in `b99c5f8`, with negative and positive regression cases.
+  This is a remaining instance of #23, not a claim to close that broader issue.
+  Nonempty files still do not prove a complete export package or compilable firmware.
+
+## DEFECT / P1: rejected resume commit still advances the pipeline
+
+- Where: `commitResumedStage` and the resume branch of `runCreate`.
+- Symptom: a real rejecting pre-commit hook left work uncommitted while the
+  mocked-stage reproduction returned success and eight completed stage names.
+- Suggested: propagate the commit failure and stop without advancing or
+  discarding the working files. Also stop on unrelated dirty work.
+- Status: corrected in `e461f2d`. The Git rejection is real; stage probes and
+  final KiCad checks are mocked in this targeted reproduction. Related #21
+  concerns bootstrap hook policy; this correction does not bypass that hook.
+
+## DEFECT / P1: compatible-provider timeout does not cancel its request
+
+- Where: watchdog cleanup in `src/agent/loop.ts`, `providers/openai.ts`.
+- Symptom: the loop calls optional `provider.close()` and reports cancellation,
+  but the compatible provider had no close method. A held SDK request remained
+  pending after the watchdog cleanup. The baseline regression failed.
+- Suggested: register an AbortController per request; abort pending requests
+  on close and allow later calls to use fresh controllers.
+- Status: corrected in `15c59e7`. A loopback HTTP test verifies two concurrent
+  SDK calls reject with APIUserAbortError, both server connections close, and
+  a subsequent call succeeds. This does not prove every inference server stops
+  its computation immediately when a client disconnects.
+
+## DEFECT / P2: Windows resolver fixtures depend on macOS installations
+
+- Where: `test/kicad-cli-resolve.test.ts`.
+- Symptom: after installing KiCad, five Windows resolver fixtures selected the
+  real macOS bundle instead of their injected candidates.
+- Suggested: restrict generated Windows fallback candidates to fixture roots.
+- Status: corrected in `41b6d34`; all 18 resolver tests passed.
+
+## DEFECT / P2: REPL log tests send input before the next prompt is ready
+
+- Where: the two session-log tests in `test/repl.test.ts`.
+- Symptom: fixed 30 ms sleeps intermittently lost `/quit`. Isolated reproduction:
+  34 passed, one 60000 ms timeout. The full run had two failures in these tests.
+- Suggested: synchronize on observable prompt output rather than elapsed time.
+- Status: corrected in `5b47df3`; ten focused repetitions passed, and a separate
+  full-file run passed 35 tests. Secret-redaction assertions are unchanged.
+
+## BLOCKER / P1: local model attempts do not complete spec-seed
+
+- Where: actual `create --brief brief.md` runs using the unmodified repository
+  `examples/simple/usb-c-breakout.md`, KiCad 10.0.6 and local Ollama.
+- Symptom: Qwen2.5 7B repeated proposals or emitted invalid tool arguments.
+  A fresh 16k-context attempt additionally timed out. Both were explicitly
+  interrupted, not recorded as naturally completed runs.
+- Symptom: a separate Qwen3 8B / 16k-context attempt took 22m20s, produced a
+  commit with no touched files, and failed the spec-seed artifact predicate.
+  Its diagnostic requested a retry; the operator interrupted that retry.
+- Evidence: the Qwen3 transcript records `finish` acceptance followed by
+  `stage spec-seed: the run finished but the stage completion contract is not
+  met`. It also records a proposed numeric bound of 1000 under
+  `usb.cc_pull_down_resistor_ohm` although the brief supplies no such bound.
+- Suggested: retain these as failed attempts; do not manufacture artifacts,
+  weaken gates, or present unsupported model parameters as brief requirements.
+- Status: unresolved. No eight-stage completion, successful replay, fabrication
+  readiness, reward approval, or payment is claimed.
+
+## NOTE / P1: regression coverage is still incomplete
+
+- Where: `test/create-pipeline-scripted.integration.test.ts`.
+- Symptom: existing tests mock the agent loop or check individual predicates.
+- Suggested: exercise real pipeline, agent loop, dispatch, transcript and Git
+  with an offline scripted provider; add recorded replay only after a real run.
+- Status: `431f7cb` covers a stalled first stage and actual clean ERC on a
+  zero-symbol scaffold being refused. Stage retries are disabled in these tests;
+  the provider cannot fall back to a network model. Ten combined integration
+  and resilience tests passed. Missing-final-stage and full success coverage
+  remain open: the existing open-key PCB fixture contains no footprints and
+  cannot substantiate a completed layout.
+
+## Validation scope
+
+- Typecheck and build passed for the cancellation correction; typecheck passed
+  with the new integration seam. Targeted tests passed as described above.
+- An earlier complete suite passed 933 tests with 21 skips. After cancellation
+  coverage was added, a complete run had 932 passes, two REPL failures and
+  21 skips. The complete run at `431f7cb` after the REPL correction passed:
+  936 passed, zero failed, 21 skipped (957 total, exit 0).
+- Tests use an isolated KiCad configuration with the shipped footprint table.
+  They do not compare pinned fixture symbols against the newer host global
+  symbol library. Live attempts used both installed library tables.
+- No ERC/DRC predicate was disabled to obtain a successful design.
+- This checkout exposes `typecheck` and `lint:md`, but no `npm run lint` script.
+  The bounty's named lint command is therefore not reported as passing.

--- a/src/agent/providers/openai.ts
+++ b/src/agent/providers/openai.ts
@@ -13,6 +13,7 @@ export class OpenAIProvider implements Provider {
   readonly name: string;
   private readonly apiKey: string | undefined;
   private readonly baseURL: string | undefined;
+  private readonly activeRequests = new Set<AbortController>();
 
   constructor(
     private readonly model = 'gpt-5',
@@ -40,58 +41,72 @@ export class OpenAIProvider implements Provider {
   }
 
   async chat(messages: Msg[], tools: ToolSchema[], opts: ChatOpts = {}): Promise<Turn> {
-    const { default: OpenAI } = await import('openai');
-    const client = new OpenAI({
-      // A local endpoint may legitimately have no key, but the client still
-      // wants a non-empty string, so send a placeholder it will never check.
-      apiKey: this.apiKey ?? 'no-key-required',
-      ...(this.baseURL ? { baseURL: this.baseURL } : {}),
-    });
-    const res = await client.chat.completions.create({
-      model: this.model,
-      max_completion_tokens: opts.maxTokens ?? 8192,
-      messages: messages.map((m) => {
-        switch (m.role) {
-          case 'system':
-            return { role: 'system' as const, content: m.content };
-          case 'user':
-            return { role: 'user' as const, content: m.content };
-          case 'assistant':
-            return {
-              role: 'assistant' as const,
-              content: m.content,
-              ...(m.toolCalls?.length
-                ? {
-                    tool_calls: m.toolCalls.map(serializeToolCall),
-                  }
-                : {}),
-            };
-          case 'tool':
-            return { role: 'tool' as const, tool_call_id: m.toolCallId, content: m.content };
-        }
-      }),
-      ...(tools.length
-        ? {
-            tools: tools.map((t) => ({
-              type: 'function' as const,
-              function: { name: t.name, description: t.description, parameters: t.parameters },
-            })),
-          }
-        : {}),
-    });
-    const choice = res.choices[0];
-    // Capture any non-standard properties returned by the API (e.g. Gemini thought
-    // signatures) so they can be echoed back on subsequent turns. Dropping them
-    // causes reasoning-model backends to reject the follow-up request with 400.
-    const toolCalls = ((choice?.message.tool_calls ?? []) as unknown as Record<string, unknown>[]).map(parseToolCall);
-    return {
-      text: choice?.message.content ?? null,
-      toolCalls,
-      usage: {
-        inputTokens: res.usage?.prompt_tokens ?? 0,
-        outputTokens: res.usage?.completion_tokens ?? 0,
-      },
-    };
+    const controller = new AbortController();
+    this.activeRequests.add(controller);
+    try {
+      const { default: OpenAI } = await import('openai');
+      const client = new OpenAI({
+        // A local endpoint may legitimately have no key, but the client still
+        // wants a non-empty string, so send a placeholder it will never check.
+        apiKey: this.apiKey ?? 'no-key-required',
+        ...(this.baseURL ? { baseURL: this.baseURL } : {}),
+      });
+      const res = await client.chat.completions.create(
+        {
+          model: this.model,
+          max_completion_tokens: opts.maxTokens ?? 8192,
+          messages: messages.map((m) => {
+            switch (m.role) {
+              case 'system':
+                return { role: 'system' as const, content: m.content };
+              case 'user':
+                return { role: 'user' as const, content: m.content };
+              case 'assistant':
+                return {
+                  role: 'assistant' as const,
+                  content: m.content,
+                  ...(m.toolCalls?.length
+                    ? {
+                        tool_calls: m.toolCalls.map(serializeToolCall),
+                      }
+                    : {}),
+                };
+              case 'tool':
+                return { role: 'tool' as const, tool_call_id: m.toolCallId, content: m.content };
+            }
+          }),
+          ...(tools.length
+            ? {
+                tools: tools.map((t) => ({
+                  type: 'function' as const,
+                  function: { name: t.name, description: t.description, parameters: t.parameters },
+                })),
+              }
+            : {}),
+        },
+        { signal: controller.signal },
+      );
+      const choice = res.choices[0];
+      // Capture any non-standard properties returned by the API (e.g. Gemini thought
+      // signatures) so they can be echoed back on subsequent turns. Dropping them
+      // causes reasoning-model backends to reject the follow-up request with 400.
+      const toolCalls = ((choice?.message.tool_calls ?? []) as unknown as Record<string, unknown>[]).map(parseToolCall);
+      return {
+        text: choice?.message.content ?? null,
+        toolCalls,
+        usage: {
+          inputTokens: res.usage?.prompt_tokens ?? 0,
+          outputTokens: res.usage?.completion_tokens ?? 0,
+        },
+      };
+    } finally {
+      this.activeRequests.delete(controller);
+    }
+  }
+
+  async close(): Promise<void> {
+    for (const controller of this.activeRequests) controller.abort();
+    this.activeRequests.clear();
   }
 }
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -393,9 +393,10 @@ function isManagedPath(f: string, config: CopperheadConfig): boolean {
  * Strictly gated: only when every dirty path is copperhead-managed, so a user's
  * unrelated working changes are never swept into a copperhead commit; if any
  * foreign path is dirty, leave the whole thing for the human and say so.
+ * Return false when work could not be protected; later stages must not run.
  */
-async function commitResumedStage(opts: CreateOptions, config: CopperheadConfig, stageName: string): Promise<void> {
-  if (!(await isDirty(opts.repoRoot))) return;
+async function commitResumedStage(opts: CreateOptions, config: CopperheadConfig, stageName: string): Promise<boolean> {
+  if (!(await isDirty(opts.repoRoot))) return true;
   const dirty = await changedFiles(opts.repoRoot, 'HEAD');
   const foreign = dirty.filter((f) => !isManagedPath(f, config));
   if (foreign.length) {
@@ -407,7 +408,7 @@ async function commitResumedStage(opts: CreateOptions, config: CopperheadConfig,
         'warn',
       ),
     );
-    return;
+    return false;
   }
   try {
     const sha = await commitAll(opts.repoRoot, `copperhead: resume — commit completed stage ${stageName}`);
@@ -418,8 +419,10 @@ async function commitResumedStage(opts: CreateOptions, config: CopperheadConfig,
         'ok',
       ),
     );
+    return true;
   } catch (e) {
     opts.log(stageLine(stageName, `could not commit resumed work (${(e as Error).message})`, 'err'));
+    return false;
   }
 }
 
@@ -803,7 +806,12 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
     }
     if (await stage.isComplete(opts.repoRoot, config.docs)) {
       opts.log(stageLine(stage.name, 'already complete (resuming past it)', 'ok'));
-      await commitResumedStage(opts, config, stage.name);
+      if (!(await commitResumedStage(opts, config, stage.name))) {
+        logResumePoint(opts, stage, i);
+        printCostTable(opts, stageCosts);
+        await writeRunReport(opts, stageCosts);
+        return { ok: false, completed };
+      }
       completed.push(stage.name);
       if (stage.name === 'spec-seed') {
         try {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -308,6 +308,8 @@ export interface CreateOptions {
   briefPath: string;
   model: string;
   interactive?: boolean;
+  /** Test seam: provide a deterministic provider for each stage attempt. */
+  providerFactory?: (stage: string, attempt: number) => Provider;
   /** Forwarded to each stage's run (attended continue-on-exhaustion prompt). */
   onBudgetExhausted?: (stats: BudgetExhaustedStats) => Promise<number>;
   log: (s: string) => void;
@@ -895,6 +897,7 @@ export async function runCreate(opts: CreateOptions): Promise<{ ok: boolean; com
           : `${basePrompt}${dossierBlock}`,
         interactive: opts.interactive ?? false,
         allowDirty: true, // stages build on each other's uncommitted state within the pipeline
+        ...(opts.providerFactory ? { provider: opts.providerFactory(stage.name, attempt) } : {}),
         ...(stageTurns !== undefined ? { maxTurns: stageTurns } : {}),
         ...(opts.onBudgetExhausted ? { onBudgetExhausted: opts.onBudgetExhausted } : {}),
         log: opts.log,

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { existsSync } from 'node:fs';
-import { readFile, mkdir, writeFile, readdir } from 'node:fs/promises';
+import { readFile, mkdir, writeFile, readdir, lstat } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { loadConfig, resolveCompatSettings } from '../config.js';
 import { bootstrapKicadProject, markCreateOrigin } from '../kicad/bootstrap.js';
@@ -86,7 +86,7 @@ sha256: ${briefMeta.sha256}
 }
 
 /**
- * Returns true when a directory exists and contains at least one file
+ * Returns true when a directory exists and contains at least one nonempty regular file
  * matching the optional glob-style extension list (case-insensitive).
  * No extension list = any file.
  */
@@ -96,8 +96,15 @@ async function dirHasFiles(dirPath: string, exts?: string[]): Promise<boolean> {
     for (const entry of await readdir(dir, { withFileTypes: true })) {
       if (entry.isDirectory()) {
         if (await walk(path.join(dir, entry.name))) return true;
-      } else if (!exts || exts.some((e) => entry.name.toLowerCase().endsWith(e))) {
-        return true;
+      } else if (entry.isFile() && (!exts || exts.some((e) => entry.name.toLowerCase().endsWith(e)))) {
+        // An interrupted export can leave a zero-byte file; a name alone is
+        // not evidence that this stage produced an artifact.
+        try {
+          const artifact = await lstat(path.join(dir, entry.name));
+          if (artifact.isFile() && artifact.size > 0) return true;
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        }
       }
     }
     return false;

--- a/test/create-pipeline-scripted.integration.test.ts
+++ b/test/create-pipeline-scripted.integration.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi, type TestContext } from 'vitest';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execa } from 'execa';
+import type { Msg, Provider, ToolCall, ToolSchema, Turn } from '../src/agent/types.js';
+import { KicadCliMissingError, kicadCliVersion } from '../src/kicad/cli.js';
+import { listSymbols } from '../src/kicad/sexp.js';
+
+// Keep this an offline integration test. It exercises the real create pipeline,
+// agent loop, tool dispatch, stage contracts, rollback, and git commits. Only
+// OpenSpec workspace initialization is suppressed because it is unrelated and
+// may invoke an optional external CLI.
+vi.mock('../src/openspec/cli.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  openspecInit: async () => ({ ok: true, output: 'mocked for offline pipeline test' }),
+}));
+
+import { runCreate, writeBriefHash } from '../src/commands/create.js';
+
+const usage = { inputTokens: 1, outputTokens: 1 };
+
+function turn(...toolCalls: ToolCall[]): Turn {
+  return { text: null, toolCalls, usage };
+}
+
+function call(id: string, name: string, args: Record<string, unknown> = {}): ToolCall {
+  return { id, name, args };
+}
+
+/** Deterministic mock model. Exhaustion is an assertion failure, never a fallback. */
+class ScriptedProvider implements Provider {
+  readonly name = 'scripted-offline-mock';
+  readonly seenTools: string[][] = [];
+  private index = 0;
+
+  constructor(private readonly turns: Turn[]) {}
+
+  async chat(_messages: Msg[], tools: ToolSchema[]): Promise<Turn> {
+    const next = this.turns[this.index++];
+    if (!next) throw new Error('script exhausted: an unplanned provider call cannot fall back to the network');
+    const offered = new Set(tools.map((tool) => tool.name));
+    for (const toolCall of next.toolCalls) {
+      if (!offered.has(toolCall.name)) throw new Error(`script requested unavailable tool: ${toolCall.name}`);
+    }
+    this.seenTools.push([...offered]);
+    return next;
+  }
+
+  get calls(): number {
+    return this.index;
+  }
+}
+
+interface Invocation {
+  stage: string;
+  attempt: number;
+  provider: ScriptedProvider;
+}
+
+function providerFactoryFor(scripts: Record<string, Turn[]>, invocations: Invocation[]) {
+  return (stage: string, attempt: number): Provider => {
+    const script = scripts[stage];
+    if (!script) throw new Error(`unexpected stage requested a provider: ${stage}`);
+    if (attempt !== 1) throw new Error(`unexpected retry could reach a provider: ${stage} attempt ${attempt}`);
+    const provider = new ScriptedProvider(script);
+    invocations.push({ stage, attempt, provider });
+    return provider;
+  };
+}
+
+async function initGitRepo(repo: string): Promise<void> {
+  await execa('git', ['init', '-q'], { cwd: repo });
+  await execa('git', ['config', 'user.email', 'test@copperhead.local'], { cwd: repo });
+  await execa('git', ['config', 'user.name', 'copperhead-test'], { cwd: repo });
+}
+
+async function commitSetup(repo: string, message = 'scripted pipeline fixture'): Promise<void> {
+  await execa('git', ['add', '-A'], { cwd: repo });
+  await execa('git', ['commit', '-q', '--no-verify', '-m', message], { cwd: repo });
+}
+
+async function configureOfflineCreate(repo: string): Promise<void> {
+  const configPath = path.join(repo, '.copperhead', 'config.json');
+  await mkdir(path.dirname(configPath), { recursive: true });
+  const current = await readFile(configPath, 'utf8').catch(() => '{}');
+  await writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        ...JSON.parse(current),
+        origin: 'create',
+        maxTurns: 10,
+        maxStageRetries: 0,
+        turnTimeoutMs: 1_000,
+        heartbeatMs: 0,
+        llmCache: false,
+      },
+      null,
+      2,
+    ) + '\n',
+    'utf8',
+  );
+}
+
+async function makeEmptyRepo(): Promise<{ repo: string; briefPath: string; cleanup: () => Promise<void> }> {
+  const repo = await mkdtemp(path.join(tmpdir(), 'copperhead-scripted-empty-'));
+  await initGitRepo(repo);
+  await writeFile(path.join(repo, '.gitignore'), '.env\n.copperhead/runs/\n.history/\n', 'utf8');
+  const briefPath = path.join(repo, 'brief.md');
+  await writeFile(briefPath, '# Offline scripted pipeline test\n', 'utf8');
+  await configureOfflineCreate(repo);
+  return { repo, briefPath, cleanup: () => rm(repo, { recursive: true, force: true }) };
+}
+
+async function seedCompletedDocStages(repo: string): Promise<void> {
+  const docs = path.join(repo, 'docs');
+  await mkdir(docs, { recursive: true });
+  await writeFile(path.join(docs, 'SPEC.md'), '# Spec\n\n## Budgets\n\n- current_mA: 100\n', 'utf8');
+  await writeFile(path.join(docs, 'SUBSYSTEMS.md'), '# Subsystems\n\n## Core\n\nInput and control logic.\n', 'utf8');
+  await writeFile(
+    path.join(docs, 'BOM.md'),
+    '# BOM\n\n| Refdes | Value | Footprint | MPN | Rationale |\n|---|---|---|---|---|\n| R1 | 10k | R_0603 | TEST-MPN | fixture part |\n',
+    'utf8',
+  );
+}
+
+async function transcriptEvents(repo: string): Promise<Array<{ type: string; data: Record<string, unknown> }>> {
+  const runs = path.join(repo, '.copperhead', 'runs');
+  const files = await readdir(runs, { recursive: true });
+  const transcript = files.find((file) => file.endsWith('transcript.jsonl'));
+  if (!transcript) throw new Error('missing transcript.jsonl');
+  return (await readFile(path.join(runs, transcript), 'utf8'))
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { type: string; data: Record<string, unknown> });
+}
+
+async function requireKicad(context: TestContext): Promise<boolean> {
+  try {
+    await kicadCliVersion();
+    return true;
+  } catch (error) {
+    if (!(error instanceof KicadCliMissingError)) throw error;
+    context.skip('requires kicad-cli for real ERC/export verification');
+    return false;
+  }
+}
+
+describe('create pipeline with a deterministic scripted provider (mocked, offline)', () => {
+  it('stops and rolls back when the first stage wedges for three consecutive tool-less turns', async () => {
+    const { repo, briefPath, cleanup } = await makeEmptyRepo();
+    try {
+      await commitSetup(repo);
+      const invocations: Invocation[] = [];
+      const providerFactory = providerFactoryFor(
+        {
+          'spec-seed': [
+            { text: 'thinking', toolCalls: [], usage },
+            { text: 'still thinking', toolCalls: [], usage },
+            { text: 'stuck', toolCalls: [], usage },
+          ],
+        },
+        invocations,
+      );
+
+      const before = (await execa('git', ['rev-parse', 'HEAD'], { cwd: repo })).stdout;
+      const result = await runCreate({ repoRoot: repo, briefPath, model: 'network-must-not-run', providerFactory, log: () => {} });
+
+      expect(result).toEqual({ ok: false, completed: [] });
+      expect(invocations).toHaveLength(1);
+      expect(invocations[0]).toMatchObject({ stage: 'spec-seed', attempt: 1 });
+      expect(invocations[0]!.provider.calls).toBe(3);
+      expect((await execa('git', ['rev-parse', 'HEAD'], { cwd: repo })).stdout).toBe(before);
+      expect((await execa('git', ['status', '--porcelain'], { cwd: repo })).stdout).toBe('');
+      const end = (await transcriptEvents(repo)).find((event) => event.type === 'run-end');
+      expect(end?.data.exitPath).toBe('stalled');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('rejects an ERC-green but zero-symbol schematic instead of advancing to layout', async (context) => {
+    if (!(await requireKicad(context))) return;
+    const { repo, briefPath, cleanup } = await makeEmptyRepo();
+    try {
+      await seedCompletedDocStages(repo);
+      await writeBriefHash(repo, 'docs/', {
+        path: 'brief.md',
+        sha256: createHash('sha256').update(await readFile(briefPath, 'utf8')).digest('hex'),
+      });
+      await commitSetup(repo);
+      const invocations: Invocation[] = [];
+      const providerFactory = providerFactoryFor(
+        {
+          schematic: [
+            turn(
+              call('erc', 'run_erc'),
+              call('finish', 'finish', { outcome: 'done', summary: 'ERC is green on the empty scaffold' }),
+            ),
+          ],
+        },
+        invocations,
+      );
+
+      const lines: string[] = [];
+      const result = await runCreate({
+        repoRoot: repo,
+        briefPath,
+        model: 'network-must-not-run',
+        providerFactory,
+        log: (line) => lines.push(line),
+      });
+
+      expect(result).toEqual({ ok: false, completed: ['spec-seed', 'architecture', 'part-selection'] });
+      expect(invocations.map(({ stage, attempt }) => ({ stage, attempt }))).toEqual([{ stage: 'schematic', attempt: 1 }]);
+      const config = JSON.parse(await readFile(path.join(repo, '.copperhead', 'config.json'), 'utf8')) as { schematic: string };
+      expect(await listSymbols(path.join(repo, config.schematic))).toHaveLength(0);
+      const ercEvent = (await transcriptEvents(repo)).find(
+        (event) => event.type === 'tool' && event.data.name === 'run_erc',
+      );
+      expect(ercEvent?.data.result).toContain('ERC: clean');
+      expect(ercEvent?.data.result).toContain('ZERO symbols');
+      expect(ercEvent?.data.result).toContain('NOT a verified design');
+      expect(lines.join('\n')).toContain('stopped at stage 4/8 (schematic)');
+      expect(lines.join('\n')).not.toContain('layout-draft running');
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+});

--- a/test/create-resilience.test.ts
+++ b/test/create-resilience.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'node:path';
-import { mkdir, writeFile, readFile } from 'node:fs/promises';
+import { mkdir, writeFile, readFile, chmod } from 'node:fs/promises';
 import { execa } from 'execa';
 import type { RunOptions, RunResult } from '../src/agent/loop.js';
 import { tempFixtureRepo } from './helpers.js';
@@ -27,7 +27,7 @@ vi.mock('../src/agent/recovery.js', async (importOriginal) => ({
 vi.mock('../src/openspec/cli.js', () => ({ openspecInit: async () => ({ ok: true, output: '' }) }));
 vi.mock('../src/commands/check.js', () => ({ runCheck: async () => ({ ok: true }) }));
 
-import { runCreate } from '../src/commands/create.js';
+import { runCreate, STAGES } from '../src/commands/create.js';
 
 /** A successful mocked run result (one attempt worth of stats). */
 function ok(): RunResult {
@@ -95,6 +95,35 @@ async function seedRepo(repo: string): Promise<string> {
 }
 
 describe('create pipeline resilience (review F3)', () => {
+  it('stops before reporting a resumed stage complete when its commit fails', async () => {
+    const { repo, cleanup } = await tempFixtureRepo();
+    // These doubles isolate orchestration; they do not validate KiCad output.
+    const probes = STAGES.map((stage) => vi.spyOn(stage, 'isComplete').mockResolvedValue(true));
+    try {
+      const briefPath = await seedRepo(repo);
+      await execa('git', ['add', 'brief.md'], { cwd: repo });
+      await execa('git', ['commit', '-q', '-m', 'brief'], { cwd: repo });
+      await mkdir(path.join(repo, 'docs'), { recursive: true });
+      await writeFile(path.join(repo, 'docs', 'SPEC.md'), '# pending work\n');
+      const hook = path.join(repo, '.git', 'hooks', 'pre-commit');
+      await writeFile(hook, '#!/bin/sh\nexit 1\n');
+      await chmod(hook, 0o755);
+      const before = (await execa('git', ['rev-parse', 'HEAD'], { cwd: repo })).stdout;
+      const lines: string[] = [];
+
+      const result = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: (s) => lines.push(s) });
+
+      expect(lines.join('\n')).toContain('could not commit resumed work');
+      expect(result).toEqual({ ok: false, completed: [] });
+      expect((await execa('git', ['rev-parse', 'HEAD'], { cwd: repo })).stdout).toBe(before);
+      expect(await readFile(path.join(repo, 'docs', 'SPEC.md'), 'utf8')).toBe('# pending work\n');
+      expect(mockRunAgentLoop).not.toHaveBeenCalled();
+    } finally {
+      probes.forEach((probe) => probe.mockRestore());
+      await cleanup();
+    }
+  });
+
   it('a retry verdict drives a successful second attempt, prepends the guidance, and accumulates cost across attempts', async () => {
     const { repo, cleanup } = await tempFixtureRepo();
     try {
@@ -197,10 +226,13 @@ describe('create pipeline resilience (review F3)', () => {
       mockRunAgentLoop.mockImplementation(async () => ok());
 
       const lines: string[] = [];
-      await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: (s) => lines.push(s) });
+      const result = await runCreate({ repoRoot: repo, briefPath, model: 'gpt-5', log: (s) => lines.push(s) });
 
       const out = lines.join('\n');
       expect(out).toContain('leaving it uncommitted');
+      expect(result).toEqual({ ok: false, completed: [] });
+      expect(mockRunAgentLoop).not.toHaveBeenCalled();
+      expect(await readFile(path.join(repo, 'my-notes.txt'), 'utf8')).toBe('do not touch\n');
       const { stdout } = await execa('git', ['log', '--oneline'], { cwd: repo });
       expect(stdout).not.toMatch(/resume — commit completed stage/);
     } finally {
@@ -293,6 +325,9 @@ describe('create pipeline resilience (review F3)', () => {
 
     try {
       const briefPath = await seedRepo(repo);
+      // Resume must not proceed with unrelated, uncommitted user input.
+      await execa('git', ['add', 'brief.md'], { cwd: repo });
+      await execa('git', ['commit', '-q', '-m', 'brief'], { cwd: repo });
 
       // Use a non-default docs directory.
       await writeFile(

--- a/test/kicad-cli-resolve.test.ts
+++ b/test/kicad-cli-resolve.test.ts
@@ -33,6 +33,22 @@ async function writeMockExecutable(binPath: string, output = '9.0.1'): Promise<s
   }
 }
 
+function setHermeticWinFallbackRoots(roots: readonly string[]): void {
+  // Keep default candidate generation under test without admitting real macOS bundles.
+  const candidates = defaultFallbackBinaries(roots).filter((candidate) =>
+    roots.some((root) => {
+      const relative = path.relative(root, candidate);
+      return (
+        relative !== '' &&
+        relative !== '..' &&
+        !relative.startsWith(`..${path.sep}`) &&
+        !path.isAbsolute(relative)
+      );
+    }),
+  );
+  setKicadFallbackBinaries(candidates);
+}
+
 describe('kicad-cli binary resolution', () => {
   const saved = process.env.COPPERHEAD_KICAD_CLI;
   let dir: string;
@@ -183,7 +199,7 @@ describe('kicad-cli binary resolution', () => {
     const binBase = path.join(winRoot, '10.0', 'bin', 'kicad-cli');
     const bin = await writeMockExecutable(binBase, '10.0.5');
 
-    setKicadFallbackWinRoots([winRoot]);
+    setHermeticWinFallbackRoots([winRoot]);
     const savedPath = process.env.PATH;
     process.env.PATH = dir;
     try {
@@ -212,7 +228,7 @@ describe('kicad-cli binary resolution', () => {
     await writeMockExecutable(binBase9, '9.0.0');
     await writeMockExecutable(binBase10, '10.0.5');
 
-    setKicadFallbackWinRoots([winRoot]);
+    setHermeticWinFallbackRoots([winRoot]);
     const savedPath = process.env.PATH;
     process.env.PATH = dir; // empty dir: PATH has no kicad-cli
     try {
@@ -228,7 +244,7 @@ describe('kicad-cli binary resolution', () => {
     const binBase = path.join(winRoot, 'bin', 'kicad-cli');
     const bin = await writeMockExecutable(binBase, '8.0.0');
 
-    setKicadFallbackWinRoots([winRoot]);
+    setHermeticWinFallbackRoots([winRoot]);
     const savedPath = process.env.PATH;
     process.env.PATH = dir;
     try {
@@ -279,7 +295,7 @@ describe('kicad-cli binary resolution', () => {
     const binBase = path.join(winRoot, '7.0', 'bin', 'kicad-cli');
     await writeMockExecutable(binBase, '7.0.11');
 
-    setKicadFallbackWinRoots([winRoot]);
+    setHermeticWinFallbackRoots([winRoot]);
     const savedPath = process.env.PATH;
     process.env.PATH = dir; // empty dir: PATH has no kicad-cli
     try {
@@ -314,7 +330,7 @@ describe('kicad-cli binary resolution', () => {
     // Pass both roots: fakeRoot (unlistable) first, then realRoot.
     // The fakeRoot unversioned probe will miss (nothing at fakeRoot/bin/),
     // but realRoot unversioned probe must succeed.
-    setKicadFallbackWinRoots([fakeRoot, realRoot]);
+    setHermeticWinFallbackRoots([fakeRoot, realRoot]);
     const savedPath = process.env.PATH;
     process.env.PATH = dir;
     try {

--- a/test/openai-provider.test.ts
+++ b/test/openai-provider.test.ts
@@ -1,6 +1,7 @@
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { describe, it, expect, afterEach } from 'vitest';
+import { APIUserAbortError } from 'openai';
 import { OpenAIProvider, serializeToolCall, parseToolCall } from '../src/agent/providers/openai.js';
 import type { Msg, ToolSchema } from '../src/agent/types.js';
 
@@ -60,6 +61,20 @@ function completion(message: Record<string, unknown>) {
     choices: [{ index: 0, message, finish_reason: 'stop' }],
     usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
   };
+}
+
+async function withinOneSecond<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), 1000);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 describe('OpenAIProvider — wire contract', () => {
@@ -157,6 +172,63 @@ describe('OpenAIProvider — wire contract', () => {
       const turn = await p.chat([{ role: 'user', content: 'hi' }], []);
       expect(turn).toEqual({ text: null, toolCalls: [], usage: { inputTokens: 0, outputTokens: 0 } });
     });
+  });
+
+  it('close aborts concurrent pending SDK requests and a subsequent retry can succeed', async () => {
+    let requestCount = 0;
+    let pendingStartedCount = 0;
+    let pendingClosedCount = 0;
+    let markPendingStarted!: () => void;
+    let markPendingClosed!: () => void;
+    const pendingStarted = new Promise<void>((resolve) => (markPendingStarted = resolve));
+    const pendingClosed = new Promise<void>((resolve) => (markPendingClosed = resolve));
+    const server = http.createServer((req, res) => {
+      req.resume();
+      requestCount++;
+      if (requestCount <= 2) {
+        if (++pendingStartedCount === 2) markPendingStarted();
+        res.once('close', () => {
+          if (++pendingClosedCount === 2) markPendingClosed();
+        });
+        return; // Hold both SDK requests open until provider.close() aborts them.
+      }
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(completion({ role: 'assistant', content: 'retry-ok' })));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+    process.env.OPENAI_BASE_URL = `http://127.0.0.1:${port}/v1`;
+    const provider = new OpenAIProvider('gpt-5', undefined, { OPENAI_API_KEY: 'sk-test' });
+
+    try {
+      const pending = [
+        provider.chat([{ role: 'user', content: 'first' }], tools),
+        provider.chat([{ role: 'user', content: 'second' }], tools),
+      ];
+      await withinOneSecond(pendingStarted, 'the SDK requests never reached the stub server');
+      await provider.close();
+
+      const cancellations = await withinOneSecond(
+        Promise.allSettled(pending),
+        'provider.close() did not settle the pending SDK requests',
+      );
+      expect(cancellations).toHaveLength(2);
+      for (const cancellation of cancellations) {
+        expect(cancellation.status).toBe('rejected');
+        if (cancellation.status === 'rejected') {
+          expect(cancellation.reason).toBeInstanceOf(APIUserAbortError);
+        }
+      }
+      await withinOneSecond(pendingClosed, 'the stub server did not observe both aborted connections closing');
+
+      const retry = await provider.chat([{ role: 'user', content: 'retry' }], tools);
+      expect(retry.text).toBe('retry-ok');
+      expect(requestCount).toBe(3);
+    } finally {
+      await provider.close();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });
 

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -37,6 +37,27 @@ function fakeTty(): { input: PassThrough; output: PassThrough; lines: string[] }
   return { input, output, lines };
 }
 
+function waitForOutput(output: PassThrough, needle: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let seen = '';
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for REPL output: ${needle}`));
+    }, 5_000);
+    const onData = (chunk: string | Buffer): void => {
+      seen += String(chunk);
+      if (!seen.includes(needle)) return;
+      cleanup();
+      resolve();
+    };
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      output.off('data', onData);
+    };
+    output.on('data', onData);
+  });
+}
+
 function baseOpts(extra: Partial<Parameters<typeof runRepl>[0]> = {}) {
   const { input, output, lines } = fakeTty();
   return {
@@ -471,9 +492,11 @@ describe('session log file', () => {
   it('mirrors session lines to .copperhead/runs/repl-*.log with keys redacted', async () => {
     setColorEnabled(false);
     const repo = await mkdtemp(path.join(tmpdir(), 'copperhead-repl-log-'));
+    const { input, output } = fakeTty();
+    let done: ReturnType<typeof runRepl> | undefined;
     try {
-      const { input, output } = fakeTty();
-      const done = runRepl({
+      const firstPrompt = waitForOutput(output, 'Try "add reverse-polarity protection on VIN"');
+      done = runRepl({
         repoRoot: repo,
         model: 'gpt-5',
         modelSource: 'flag',
@@ -487,9 +510,10 @@ describe('session log file', () => {
           return { outcome: 'success' as const };
         }),
       });
-      await new Promise((r) => setTimeout(r, 30));
+      await firstPrompt;
+      const nextPrompt = waitForOutput(output, 'Try "rename net KEY_DAH to KEY_DASH"');
       input.write('do the thing\n');
-      await new Promise((r) => setTimeout(r, 30));
+      await nextPrompt;
       input.write('/quit\n');
       await done;
 
@@ -504,6 +528,8 @@ describe('session log file', () => {
       expect(text).not.toContain('sk-SECRET_KEY_123');
       expect(text).not.toContain('\x1b[');
     } finally {
+      input.end();
+      await done?.catch(() => undefined);
       await rm(repo, { recursive: true, force: true });
     }
   });
@@ -521,9 +547,11 @@ describe('session log file', () => {
       `ghp_${'b'.repeat(36)}`,
       `github_pat_${'c'.repeat(22)}`,
     ];
+    const { input, output } = fakeTty();
+    let done: ReturnType<typeof runRepl> | undefined;
     try {
-      const { input, output } = fakeTty();
-      const done = runRepl({
+      const firstPrompt = waitForOutput(output, 'Try "add reverse-polarity protection on VIN"');
+      done = runRepl({
         repoRoot: repo,
         model: 'gpt-5',
         modelSource: 'flag',
@@ -537,9 +565,10 @@ describe('session log file', () => {
           return { outcome: 'success' as const };
         }),
       });
-      await new Promise((r) => setTimeout(r, 30));
+      await firstPrompt;
+      const nextPrompt = waitForOutput(output, 'Try "rename net KEY_DAH to KEY_DASH"');
       input.write('publish it\n');
-      await new Promise((r) => setTimeout(r, 30));
+      await nextPrompt;
       input.write('/quit\n');
       await done;
 
@@ -551,6 +580,8 @@ describe('session log file', () => {
       expect(text).toContain('[REDACTED]');
       expect(text).toContain('trailing'); // surrounding context survives
     } finally {
+      input.end();
+      await done?.catch(() => undefined);
       await rm(repo, { recursive: true, force: true });
     }
   });

--- a/test/stage-completion.test.ts
+++ b/test/stage-completion.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import path from 'node:path';
-import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdir, writeFile, rm, symlink } from 'node:fs/promises';
 import os from 'node:os';
 import { STAGES } from '../src/commands/create.js';
 
@@ -36,6 +36,36 @@ async function withTmpDir(fn: (root: string) => Promise<void>): Promise<void> {
 }
 
 const DOCS = 'docs';
+
+describe.each([
+  ['outputs', 'board.gbr'],
+  ['firmware', 'pins.h'],
+])('%s artifact presence', (stage, filename) => {
+  it('does not complete from a zero-byte artifact', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, stage));
+      await writeFile(path.join(root, stage, filename), '');
+      expect(await stageNamed(stage)(root, DOCS)).toBe(false);
+    });
+  });
+
+  it('does not complete from a dangling artifact symlink', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, stage));
+      await symlink('missing-artifact', path.join(root, stage, filename));
+      expect(await stageNamed(stage)(root, DOCS)).toBe(false);
+    });
+  });
+
+  it('continues past an empty artifact to a nonempty nested artifact', async () => {
+    await withTmpDir(async (root) => {
+      await mkdir(path.join(root, stage, 'nested'), { recursive: true });
+      await writeFile(path.join(root, stage, filename), '');
+      await writeFile(path.join(root, stage, 'nested', filename), 'nonempty artifact\n');
+      expect(await stageNamed(stage)(root, DOCS)).toBe(true);
+    });
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Stage 1: spec-seed


### PR DESCRIPTION
## Status: partial investigation, not bounty completion

Related to #66. **Do not close #66 on the basis of this draft.**

AI-assisted contribution. This draft makes verified source fixes and partial
integration coverage reviewable. It does not claim the $50 reward: three local
provider attempts have not produced a complete eight-stage run.

## Changes

- Reject empty files and dangling symlinks in output/firmware completion probes
  (a remaining instance of #23, not full export/firmware validation).
- Stop on a failed protective resume commit instead of falsely advancing.
- Abort compatible-provider SDK requests during watchdog cleanup; retries can
  use the same provider afterward.
- Isolate Windows resolver fixtures from installed macOS bundles and remove
  timing races from REPL log tests without weakening redaction assertions.
- Add a provider-injection seam and offline integration tests for a stalled
  first stage and a zero-symbol schematic whose actual ERC returns clean.

Findings and validation limits: `reports/create-e2e-findings.md`.

## Still required before #66 acceptance

- [ ] Real, non-trivial brief reaches all eight committed stages and exits 0.
- [ ] Successful recorded replay and missing-final-stage regression coverage.
- [x] Complete suite at 431f7cb: 936 passed, zero failed, 21 skipped.
- [ ] Named lint qualification: this checkout has no `npm run lint` script.
- [ ] Final live-run logs and summary attached.

The local model attempts and test fixtures are not interchangeable evidence.
No hand-authored hardware artifacts have been substituted for a real model run.
No paid model calls were used. PayPal settlement remains unconfirmed.

If the source fixes are useful independently, I can split the draft to match
your preferred review scope. No payment or assignment is assumed.
