### PR TITLE
docs(site): make the GitBook theme hold up on a phone

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightLlmsTxt from 'starlight-llms-txt';
+import rehypeTableLabels from './src/plugins/rehype-table-labels.mjs';
 
 const REPO = 'https://github.com/copperheadhq/copperhead';
 
@@ -9,6 +10,7 @@ const REPO = 'https://github.com/copperheadhq/copperhead';
 // so Pages cannot own a path under it.
 export default defineConfig({
   site: 'https://docs.copperhead.sh',
+  markdown: { rehypePlugins: [rehypeTableLabels] },
   integrations: [
     starlight({
       title: 'copperhead',
@@ -37,6 +39,9 @@ export default defineConfig({
         './src/styles/custom.css',
       ],
       expressiveCode: {
+        // Long lines wrap instead of scrolling: sample briefs, prompts, and
+        // commands are prose-like and were being cut off on phones.
+        defaultProps: { wrap: true, preserveIndent: true },
         styleOverrides: {
           borderRadius: '0.75rem',
           codeFontFamily: "'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",

--- a/docs/src/components/JumpLink.astro
+++ b/docs/src/components/JumpLink.astro
@@ -40,6 +40,11 @@ const { href, title, description, icon } = Astro.props;
 			border-color 0.15s,
 			transform 0.15s;
 	}
+	/* Starlight's content-spacing rule skips <a> siblings, so the first link
+	   would otherwise sit flush against the heading above it. */
+	.jump-link {
+		margin-top: 1rem;
+	}
 	.jump-link + .jump-link {
 		margin-top: 0.75rem;
 	}

--- a/docs/src/content/docs/concepts/docs-as-memory.md
+++ b/docs/src/content/docs/concepts/docs-as-memory.md
@@ -41,6 +41,8 @@ Docs that disagree with the schematic are the failure mode this whole tool exist
 
 Hand edits that desync the docs, the constraint registry, or the schematic fail at commit time. See [Verify and sync](/workflows/verify-and-sync/).
 
+<a id="copperheadreadmemd"></a>
+
 ## `README.md` in `.copperhead/`
 
 The config directory describes itself. `init` writes a README into `.copperhead/` documenting every key in `config.json` and what `constraints.json` is for, so someone who clones the repo and has never used copperhead can still tell what these files are.

--- a/docs/src/content/docs/concepts/docs-as-memory.md
+++ b/docs/src/content/docs/concepts/docs-as-memory.md
@@ -41,6 +41,6 @@ Docs that disagree with the schematic are the failure mode this whole tool exist
 
 Hand edits that desync the docs, the constraint registry, or the schematic fail at commit time. See [Verify and sync](/workflows/verify-and-sync/).
 
-## `.copperhead/README.md`
+## `README.md` in `.copperhead/`
 
 The config directory describes itself. `init` writes a README into `.copperhead/` documenting every key in `config.json` and what `constraints.json` is for, so someone who clones the repo and has never used copperhead can still tell what these files are.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -5,9 +5,9 @@ sidebar:
   order: 2
 ---
 
-## `.copperhead/config.json`
+## `config.json`
 
-Written by `copperhead init`. Every key is optional; the defaults below apply when a key is absent or the file does not exist.
+`.copperhead/config.json`, written by `copperhead init`. Every key is optional; the defaults below apply when a key is absent or the file does not exist.
 
 ```json
 {
@@ -52,9 +52,9 @@ Budgets are hard constraints, not hints. A change that would exceed one is refus
 
 The names are yours. copperhead passes them through verbatim and expects the units to be in the key, as in `sleep_current_uA`.
 
-## `.copperhead/constraints.json`
+## `constraints.json`
 
-The constraint registry: machine-readable counterparts to the constraints stated in your design docs. Constraints are dual-written, to the doc and to the registry, and the sync-obligations ledger refuses to let a run commit if one was updated without the other.
+`.copperhead/constraints.json` is the constraint registry: machine-readable counterparts to the constraints stated in your design docs. Constraints are dual-written, to the doc and to the registry, and the sync-obligations ledger refuses to let a run commit if one was updated without the other.
 
 ## Environment variables
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -5,6 +5,8 @@ sidebar:
   order: 2
 ---
 
+<a id="copperheadconfigjson"></a>
+
 ## `config.json`
 
 `.copperhead/config.json`, written by `copperhead init`. Every key is optional; the defaults below apply when a key is absent or the file does not exist.
@@ -51,6 +53,8 @@ Budgets are hard constraints, not hints. A change that would exceed one is refus
 ```
 
 The names are yours. copperhead passes them through verbatim and expects the units to be in the key, as in `sleep_current_uA`.
+
+<a id="copperheadconstraintsjson"></a>
 
 ## `constraints.json`
 

--- a/docs/src/plugins/rehype-table-labels.mjs
+++ b/docs/src/plugins/rehype-table-labels.mjs
@@ -1,0 +1,93 @@
+/**
+ * Build-time HTML tweaks for the markdown content:
+ *
+ * - Every <table> is wrapped in <div class="table-wrap"> so the table itself
+ *   can be a real full-width table while the wrapper takes care of horizontal
+ *   scrolling if it is ever too wide.
+ * - Every body cell gets `data-label="<its column header>"`, so the
+ *   stylesheet can stack rows into cards on narrow screens and still show
+ *   which column each value came from.
+ * - Inline code never breaks inside a token: a short single-token span
+ *   (`--json`, `kicad-cli`) gets class "nowrap", and a multi-word span
+ *   (`--model claude-code`) has each token wrapped in <span class="nowrap">
+ *   so it can only wrap at the spaces. Tokens longer than NOWRAP_MAX_CHARS
+ *   are left alone so nothing can overflow a phone column.
+ *
+ * See the "Tables" and "Inline code" blocks in src/styles/custom.css.
+ */
+const NOWRAP_MAX_CHARS = 30;
+
+function textOf(node) {
+  if (node.type === 'text') return node.value;
+  return (node.children ?? []).map(textOf).join('');
+}
+
+function children(node, tag) {
+  return (node.children ?? []).filter((c) => c.type === 'element' && c.tagName === tag);
+}
+
+function addClass(node, name) {
+  const props = (node.properties ??= {});
+  const existing = Array.isArray(props.className)
+    ? props.className
+    : typeof props.className === 'string'
+      ? props.className.split(/\s+/).filter(Boolean)
+      : [];
+  if (!existing.includes(name)) props.className = [...existing, name];
+}
+
+function visit(node, fn, parent = null, inPre = false) {
+  const replacement = fn(node, parent, inPre);
+  const next = inPre || (node.type === 'element' && node.tagName === 'pre');
+  for (const child of [...(node.children ?? [])]) visit(child, fn, node, next);
+  return replacement;
+}
+
+export default function rehypeTableLabels() {
+  return (tree) => {
+    visit(tree, (node, parent, inPre) => {
+      if (node.type !== 'element') return;
+
+      if (node.tagName === 'code' && !inPre) {
+        const text = textOf(node);
+        if (!/\s/.test(text)) {
+          if (text.length <= NOWRAP_MAX_CHARS) addClass(node, 'nowrap');
+          return;
+        }
+        // Only touch the plain case: one text node, nothing nested.
+        if (node.children.length === 1 && node.children[0].type === 'text') {
+          node.children = text.split(/(\s+)/).map((part) =>
+            /^\s+$/.test(part) || part.length > NOWRAP_MAX_CHARS
+              ? { type: 'text', value: part }
+              : { type: 'element', tagName: 'span', properties: { className: ['nowrap'] }, children: [{ type: 'text', value: part }] },
+          );
+        }
+        return;
+      }
+
+      if (node.tagName !== 'table') return;
+
+      const headerRow = children(node, 'thead').flatMap((t) => children(t, 'tr'))[0];
+      if (headerRow) {
+        const labels = children(headerRow, 'th').map((th) => textOf(th).trim());
+        for (const tbody of children(node, 'tbody')) {
+          for (const tr of children(tbody, 'tr')) {
+            children(tr, 'td').forEach((td, i) => {
+              if (labels[i]) td.properties = { ...td.properties, dataLabel: labels[i] };
+            });
+          }
+        }
+      }
+
+      if (parent && !(parent.type === 'element' && parent.properties?.className?.includes?.('table-wrap'))) {
+        const index = parent.children.indexOf(node);
+        parent.children[index] = {
+          type: 'element',
+          tagName: 'div',
+          properties: { className: ['table-wrap'] },
+          children: [node],
+        };
+      }
+    });
+  };
+}

--- a/docs/src/plugins/rehype-table-labels.mjs
+++ b/docs/src/plugins/rehype-table-labels.mjs
@@ -10,8 +10,9 @@
  * - Inline code never breaks inside a token: a short single-token span
  *   (`--json`, `kicad-cli`) gets class "nowrap", and a multi-word span
  *   (`--model claude-code`) has each token wrapped in <span class="nowrap">
- *   so it can only wrap at the spaces. Tokens longer than NOWRAP_MAX_CHARS
- *   are left alone so nothing can overflow a phone column.
+ *   so it can only wrap at the spaces. A token longer than NOWRAP_MAX_CHARS is
+ *   left unmarked, so the stylesheet's overflow-wrap can break it rather than
+ *   let it overflow a narrow column.
  *
  * See the "Tables" and "Inline code" blocks in src/styles/custom.css.
  */
@@ -37,10 +38,12 @@ function addClass(node, name) {
 }
 
 function visit(node, fn, parent = null, inPre = false) {
-  const replacement = fn(node, parent, inPre);
+  fn(node, parent, inPre);
+  // Children of a <pre> are code-block content: expressive-code owns them, and
+  // wrapping tokens in there would corrupt every sample.
   const next = inPre || (node.type === 'element' && node.tagName === 'pre');
+  // Copied, because fn may replace this node in its parent as it goes.
   for (const child of [...(node.children ?? [])]) visit(child, fn, node, next);
-  return replacement;
 }
 
 export default function rehypeTableLabels() {

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -308,11 +308,19 @@ mobile-starlight-toc .toggle {
 	text-decoration-color: currentColor;
 }
 
+/* Inline code. Short single-token spans are marked "nowrap" at build time
+ * (src/plugins/rehype-table-labels.mjs) so `--json` or `kicad-cli` can never
+ * break at the hyphen. A longer token is left unmarked and break-word lets it
+ * break rather than overflow the column, and when a span does wrap each
+ * fragment keeps its own rounded chip. */
 .sl-markdown-content code:not(:where(.not-content *)) {
 	padding: 0.1em 0.3em;
 	border-radius: 0.375rem;
 	box-shadow: inset 0 0 0 1px var(--sl-color-gray-5);
 	font-size: 0.875em;
+	overflow-wrap: break-word;
+	-webkit-box-decoration-break: clone;
+	box-decoration-break: clone;
 }
 
 .sl-markdown-content blockquote:not(:where(.not-content *)) {
@@ -332,21 +340,14 @@ mobile-starlight-toc .toggle {
 	border-bottom-color: var(--sl-color-gray-5);
 }
 
-/* Inline code. Short single-token spans are marked "nowrap" at build time
- * (src/plugins/rehype-table-labels.mjs) so `--json` or `kicad-cli` can never
- * break at the hyphen; longer spans still wrap so they fit a phone column,
- * and when they do each fragment keeps its own rounded chip. */
-.sl-markdown-content code:not(:where(.not-content *)) {
-	-webkit-box-decoration-break: clone;
-	box-decoration-break: clone;
-}
 .sl-markdown-content :is(code.nowrap, code .nowrap):not(:where(.not-content *)) {
 	white-space: nowrap;
 }
 
-/* Nested lists on phones: a code block inside a list inside a list was
- * being squeezed to about two thirds of the column. */
-@media (max-width: 39.99rem) {
+/* Nested lists in a narrow column: a code block inside a list inside a list
+ * was being squeezed to about two thirds of the column. Keyed off the column
+ * and not the viewport, for the same reason the table rules below are. */
+@container (max-width: 39.99rem) {
 	.sl-markdown-content :is(ul, ol) :is(ul, ol):not(:where(.not-content *)) {
 		padding-inline-start: 1rem;
 	}

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -309,7 +309,7 @@ mobile-starlight-toc .toggle {
 }
 
 .sl-markdown-content code:not(:where(.not-content *)) {
-	padding: 0.1em 0.4em;
+	padding: 0.1em 0.3em;
 	border-radius: 0.375rem;
 	box-shadow: inset 0 0 0 1px var(--sl-color-gray-5);
 	font-size: 0.875em;
@@ -332,6 +332,111 @@ mobile-starlight-toc .toggle {
 	border-bottom-color: var(--sl-color-gray-5);
 }
 
+/* Inline code. Short single-token spans are marked "nowrap" at build time
+ * (src/plugins/rehype-table-labels.mjs) so `--json` or `kicad-cli` can never
+ * break at the hyphen; longer spans still wrap so they fit a phone column,
+ * and when they do each fragment keeps its own rounded chip. */
+.sl-markdown-content code:not(:where(.not-content *)) {
+	-webkit-box-decoration-break: clone;
+	box-decoration-break: clone;
+}
+.sl-markdown-content :is(code.nowrap, code .nowrap):not(:where(.not-content *)) {
+	white-space: nowrap;
+}
+
+/* Nested lists on phones: a code block inside a list inside a list was
+ * being squeezed to about two thirds of the column. */
+@media (max-width: 39.99rem) {
+	.sl-markdown-content :is(ul, ol) :is(ul, ol):not(:where(.not-content *)) {
+		padding-inline-start: 1rem;
+	}
+}
+
+/* ---- Tables --------------------------------------------------------------
+ * Starlight renders a table as a scrolling block sized to its content, which
+ * leaves a ragged right edge next to full-width code blocks. The build wraps
+ * each table in .table-wrap (src/plugins/rehype-table-labels.mjs), so the
+ * table can be a real full-width table and the wrapper handles overflow.
+ *
+ * The content column is a size container, so the table layout follows the
+ * width the table actually has rather than the viewport: with the sidebar
+ * open on a tablet the column is only ~500px wide and a four-column table
+ * was crushed into one-word ribbons. Below 34rem of column width each row
+ * becomes a card, one cell per line, labelled with its column header
+ * (data-label, stamped by the same plugin). The header row stays in the DOM
+ * for assistive tech but leaves the flow.
+ * ---------------------------------------------------------------------- */
+
+.sl-markdown-content {
+	container-type: inline-size;
+}
+.sl-markdown-content .table-wrap:not(:where(.not-content *)) {
+	overflow-x: auto;
+}
+.sl-markdown-content table:not(:where(.not-content *)) {
+	display: table;
+	width: 100%;
+	overflow: visible;
+}
+.sl-markdown-content th:not(:where(.not-content *)) {
+	white-space: nowrap;
+}
+/* Identifiers in the first column (options, keys, commands) stay on one line;
+ * the description column is the one that should give. */
+.sl-markdown-content :is(th, td):first-child code:not(:where(.not-content *)) {
+	white-space: nowrap;
+}
+
+@container (max-width: 33.99rem) {
+	.sl-markdown-content :is(th, td):not(:where(.not-content *)) {
+		font-size: var(--sl-text-sm);
+	}
+	.sl-markdown-content :is(table, tbody, tr, td):not(:where(.not-content *)) {
+		display: block;
+	}
+	.sl-markdown-content thead:not(:where(.not-content *)) {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		overflow: hidden;
+		clip: rect(0 0 0 0);
+		white-space: nowrap;
+	}
+	.sl-markdown-content tr:not(:where(.not-content *)) {
+		padding: 0.25rem 1rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.75rem;
+	}
+	.sl-markdown-content tr:not(:where(.not-content *)) + tr {
+		margin-top: 0.75rem;
+	}
+	.sl-markdown-content td:not(:where(.not-content *)) {
+		padding: 0.625rem 0;
+		border-bottom: 0;
+		overflow-wrap: anywhere;
+	}
+	.sl-markdown-content td:empty:not(:where(.not-content *)) {
+		display: none;
+	}
+	.sl-markdown-content td:not(:where(.not-content *)) + td {
+		border-top: 1px solid var(--sl-color-gray-5);
+	}
+	/* A card is a block now, so first-column code may wrap like any other. */
+	.sl-markdown-content td:first-child code:not(:where(.not-content *)) {
+		white-space: normal;
+	}
+	.sl-markdown-content td[data-label]:not(:where(.not-content *))::before {
+		content: attr(data-label);
+		display: block;
+		margin-bottom: 0.2rem;
+		font-size: 0.6875rem;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--sl-color-gray-3);
+	}
+}
+
 .sl-markdown-content kbd:not(:where(.not-content *)) {
 	padding: 0.1em 0.4em;
 	border: 1px solid var(--sl-color-gray-5);
@@ -339,6 +444,12 @@ mobile-starlight-toc .toggle {
 	background-color: var(--sl-color-gray-6);
 	font-family: var(--__sl-font-mono);
 	font-size: 0.8em;
+}
+
+/* Steps: the guide line ran on below the last step's text (the step keeps
+ * its last paragraph's bottom margin inside it), connecting to nothing. */
+.sl-steps > li:last-child::after {
+	display: none;
 }
 
 /* Asides: rounded, quietly tinted cards instead of a heavy left border. */

--- a/test/docs-rehype-table-labels.test.ts
+++ b/test/docs-rehype-table-labels.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - plain .mjs plugin, no types
+import rehypeTableLabels from '../docs/src/plugins/rehype-table-labels.mjs';
+
+// Minimal hast helpers. The plugin only ever reads and writes plain objects,
+// so the docs site's build dependencies are not needed to exercise it.
+const el = (tagName: string, children: any[] = [], properties: any = {}) => ({
+  type: 'element',
+  tagName,
+  properties,
+  children,
+});
+const text = (value: string) => ({ type: 'text', value });
+const root = (children: any[]) => ({ type: 'root', children });
+
+const run = (tree: any) => {
+  rehypeTableLabels()(tree);
+  return tree;
+};
+
+const find = (node: any, pred: (n: any) => boolean): any => {
+  if (pred(node)) return node;
+  for (const child of node.children ?? []) {
+    const hit = find(child, pred);
+    if (hit) return hit;
+  }
+  return undefined;
+};
+
+const classesOf = (node: any) => {
+  const c = node.properties?.className;
+  return Array.isArray(c) ? c : typeof c === 'string' ? c.split(/\s+/).filter(Boolean) : [];
+};
+
+const table = (headers: string[], rows: string[][]) =>
+  el('table', [
+    el('thead', [el('tr', headers.map((h) => el('th', [text(h)])))]),
+    el('tbody', rows.map((cells) => el('tr', cells.map((c) => el('td', [text(c)]))))),
+  ]);
+
+describe('rehype-table-labels: tables', () => {
+  it('wraps a table in .table-wrap so the wrapper owns the overflow', () => {
+    const tree = run(root([table(['Option'], [['--json']])]));
+
+    const wrap = tree.children[0];
+    expect(wrap.tagName).toBe('div');
+    expect(classesOf(wrap)).toContain('table-wrap');
+    expect(wrap.children[0].tagName).toBe('table');
+  });
+
+  it('labels every body cell with its column header', () => {
+    const tree = run(
+      root([table(['Option', 'Meaning'], [['--json', 'machine output'], ['--quiet', 'no output']])]),
+    );
+
+    const cells = [];
+    find(tree, (n) => {
+      if (n.tagName === 'td') cells.push(n.properties.dataLabel);
+      return false;
+    });
+    expect(cells).toEqual(['Option', 'Meaning', 'Option', 'Meaning']);
+  });
+
+  it('leaves a cell unlabelled when the row is wider than the header', () => {
+    const tree = run(root([table(['Option'], [['--json', 'stray']])]));
+
+    const row = find(tree, (n: any) => n.tagName === 'tr' && n.children[0]?.tagName === 'td');
+    expect(row.children[0].properties.dataLabel).toBe('Option');
+    expect(row.children[1].properties?.dataLabel).toBeUndefined();
+  });
+
+  it('does not wrap a table that is already wrapped', () => {
+    const tree = run(root([el('div', [table(['Option'], [['--json']])], { className: ['table-wrap'] })]));
+
+    expect(tree.children).toHaveLength(1);
+    expect(tree.children[0].children[0].tagName).toBe('table');
+  });
+
+  it('tolerates a table with no header row', () => {
+    const tree = run(root([el('table', [el('tbody', [el('tr', [el('td', [text('x')])])])])]));
+
+    const cell = find(tree, (n: any) => n.tagName === 'td');
+    expect(cell.properties?.dataLabel).toBeUndefined();
+    expect(classesOf(tree.children[0])).toContain('table-wrap');
+  });
+});
+
+describe('rehype-table-labels: inline code', () => {
+  it('marks a short single-token span nowrap, so it cannot break at a hyphen', () => {
+    const tree = run(root([el('p', [el('code', [text('--json')])])]));
+
+    const code = find(tree, (n: any) => n.tagName === 'code');
+    expect(classesOf(code)).toContain('nowrap');
+    expect(code.children).toEqual([text('--json')]);
+  });
+
+  it('splits a multi-word span so it can only break at the spaces', () => {
+    const tree = run(root([el('p', [el('code', [text('copperhead init')])])]));
+
+    const code = find(tree, (n: any) => n.tagName === 'code');
+    expect(classesOf(code)).not.toContain('nowrap');
+    expect(code.children.map((c: any) => (c.type === 'text' ? c.value : c.children[0].value))).toEqual([
+      'copperhead',
+      ' ',
+      'init',
+    ]);
+    const tokens = code.children.filter((c: any) => c.type === 'element');
+    expect(tokens).toHaveLength(2);
+    for (const t of tokens) expect(classesOf(t)).toContain('nowrap');
+  });
+
+  it('leaves a token longer than the cap free to wrap, rather than forcing an overflow', () => {
+    const long = 'a'.repeat(31);
+    const tree = run(root([el('p', [el('code', [text(long)])])]));
+
+    const code = find(tree, (n: any) => n.tagName === 'code');
+    expect(classesOf(code)).not.toContain('nowrap');
+    expect(code.children).toEqual([text(long)]);
+  });
+
+  it('leaves an over-long token inside a multi-word span unmarked', () => {
+    const long = 'b'.repeat(31);
+    const tree = run(root([el('p', [el('code', [text(`run ${long}`)])])]));
+
+    const code = find(tree, (n: any) => n.tagName === 'code');
+    const marked = code.children.filter((c: any) => c.type === 'element');
+    expect(marked).toHaveLength(1);
+    expect(marked[0].children[0].value).toBe('run');
+    expect(code.children.some((c: any) => c.type === 'text' && c.value === long)).toBe(true);
+  });
+
+  it('never touches code inside a <pre>: expressive-code owns code blocks', () => {
+    const tree = run(root([el('pre', [el('code', [el('span', [text('--json')])])])]));
+
+    const code = find(tree, (n: any) => n.tagName === 'code');
+    expect(classesOf(code)).not.toContain('nowrap');
+    const span = find(tree, (n: any) => n.tagName === 'span');
+    expect(classesOf(span)).not.toContain('nowrap');
+  });
+
+  it('preserves an existing class when adding nowrap', () => {
+    const tree = run(root([el('p', [el('code', [text('--json')], { className: ['expressive'] })])]));
+
+    const code = find(tree, (n: any) => n.tagName === 'code');
+    expect(classesOf(code)).toEqual(['expressive', 'nowrap']);
+  });
+
+  it('leaves a span with nested markup structurally alone', () => {
+    const nested = el('code', [text('a '), el('em', [text('b')])]);
+    const tree = run(root([el('p', [nested])]));
+
+    const code = find(tree, (n: any) => n.tagName === 'code');
+    expect(code.children).toHaveLength(2);
+    expect(code.children[1].tagName).toBe('em');
+  });
+});


### PR DESCRIPTION
## What

Makes the docs site readable on a narrow column. Tables stop being content-sized scrolling blocks and become labelled cards below 34rem of column width, inline code stops breaking mid-token, long lines in code blocks wrap instead of being cut off, and a code block nested two lists deep gets its width back. Follow-up to #271.

## Why

#271 restyled the site after GitBook's clean theme, but only the wide case was checked. On a phone, and on a tablet with the sidebar open, five things broke:

- Starlight renders a table as a content-sized scrolling block, which left a ragged right edge next to full-width code blocks. Worse, the binding constraint is the content column, not the viewport: with the sidebar open the column is about 500px, and a four-column table was crushed into one-word ribbons.
- Inline code broke mid-token, so `--json` split at the hyphen and `kicad-cli` at its own.
- Long lines in code blocks were cut off rather than wrapped. Sample briefs and prompts are prose-shaped, so the tail simply vanished.
- A code block nested two lists deep was squeezed to about two thirds of the column.
- Two cosmetic leftovers: the first [JumpLink.astro](docs/src/components/JumpLink.astro) sat flush against its heading, because Starlight's content-spacing rule skips `<a>` siblings, and the Steps guide line ran on past the last step, connecting to nothing.

## Design

[rehype-table-labels.mjs](docs/src/plugins/rehype-table-labels.mjs) is a build-time pass over the content HTML, wired in through `markdown.rehypePlugins` in [astro.config.mjs](docs/astro.config.mjs). It does two things:

- wraps each `<table>` in `.table-wrap`, so the table itself can be a real full-width table while the wrapper owns horizontal overflow, and stamps every body cell with `data-label="<its column header>"`;
- marks a short single-token inline code span `nowrap`, and splits a multi-word span into per-token `<span class="nowrap">`, so a break can only land on a space. Tokens over 30 characters are left free to wrap. An `inPre` guard keeps the pass out of code blocks entirely.

In [custom.css](docs/src/styles/custom.css), `.sl-markdown-content` becomes a size container, so the table rules key off the width the table actually has rather than the viewport. Below 34rem of column width each row becomes a labelled card; the header row is clipped out of the flow but stays in the DOM for assistive tech.

Headings that were a bare path (`.copperhead/config.json`) now name the file and give the path in the prose, so a heading is not the widest thing on the page. That changes their generated slugs, so each renamed heading keeps an explicit `<a id>` carrying its pre-rename slug (`#copperheadconfigjson` and friends) and links published against the old headings still land on their section.

## Spec / OpenSpec

n/a, docs-only and presentational. No spec-level behavior changes, so SPEC.md and the change artifacts correctly stay put.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` (in `docs/`) | pass, clean at 17 pages |
| Unit + offline | `npm test` | 923 pass / 21 skip / 15 fail locally. The 12 new tests all pass; the failures are environment-specific to this machine (create, gating, init, preflight, mcp-server, and the set fluctuates between runs), they are in files this PR does not touch, and CI runs the same suite green. |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY` | n/a |

New tests: [docs-rehype-table-labels.test.ts](test/docs-rehype-table-labels.test.ts), 12 cases. `docs/` has no harness of its own, but the plugin only ever touches plain objects, so the root vitest suite can exercise it with no new dependency. It pins the table wrapping and labelling (including a row wider than its header, and a table with no header row), the nowrap split, the over-long-token case, and that nothing inside a `<pre>` is touched.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a, this is a docs-site style change with no CLI surface.
- Commands run and outcome: built the site and asserted the plugin's output in `dist/`, including that the `inPre` guard holds across all 17 pages, that both slugs (old and new) are present on the renamed headings, and that the nested-list rule ships as a container query. Also rebuilt the stashed baseline to confirm the two build warnings (the `gitignore` language and the `/404.html` entry) are pre-existing and not introduced here.

```text
$ cd docs && npm run build
[build] 17 page(s) built in 2.79s
[build] Complete!

$ # tables wrapped, on the CLI reference
15

$ # data-label stamped from the column headers
data-label="Option"  data-label="Meaning"  data-label="Exit code"  ...

$ # single tokens marked nowrap, multi-word spans split at the space
<code class="nowrap" dir="auto">config.json</code>
<code dir="auto"><span class="nowrap">copperhead</span> <span class="nowrap">init</span></code>

$ # no nowrap markup leaked into any code block, across all pages
code blocks containing nowrap: 0

$ # the pre-rename slugs still resolve, alongside the new ones
legacy anchors present: ['copperheadconfigjson', 'copperheadconstraintsjson']
new slugs still present: True True

$ # the nested-list rule ships as a container query (minified range syntax)
@container (width<=39.99rem){.sl-markdown-content :is(ul,ol) :is(ul,ol)...{padding-inline-start:1rem}

$ npx vitest run test/docs-rehype-table-labels.test.ts
Test Files  1 passed (1)
     Tests  12 passed (12)
```

## Docs

The two content edits are in this PR: [configuration.md](docs/src/content/docs/reference/configuration.md) and [docs-as-memory.md](docs/src/content/docs/concepts/docs-as-memory.md), where a heading that was a bare path now names the file and gives the path in the prose.

---

## Invariant checklist

This diff changes zero lines under `src/` (the only non-docs file is a new test), so every gated path is unreachable from it. Each box is marked N/A on that basis, and the reviewer confirmed it independently.

- [x] **Spec-gated in**: N/A, no change to the agent tool list.
- [x] **Verification-gated out**: N/A, no mutation path touched.
- [x] **`check`/`verify` stays LLM-free and network-free**: N/A, no change to `src/commands/check` or anything it imports.
- [x] **No sexp serialization**: N/A, no change under `src/kicad/`.
- [x] **Sync-obligations ledger**: N/A, no change to the hooks or the commit gate.
- [x] **Secrets**: N/A, no new logging or transcript path.
- [x] **Spec coherence**: N/A, no spec-level behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
