### PR TITLE
docs(site): send docs traffic to the same GA property as the apex

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -4,6 +4,8 @@ import starlightLlmsTxt from 'starlight-llms-txt';
 import rehypeTableLabels from './src/plugins/rehype-table-labels.mjs';
 
 const REPO = 'https://github.com/copperheadhq/copperhead';
+// The same GA property as the apex, copperhead.sh (copperhead-site).
+const GA_MEASUREMENT_ID = 'G-KGEWCR918W';
 
 // Served at the root of its own subdomain, docs.copperhead.sh. The apex,
 // copperhead.sh, is a separate Cloudflare Worker (the copperhead-site repo),
@@ -102,6 +104,21 @@ export default defineConfig({
         { tag: 'meta', attrs: { property: 'og:image', content: 'https://docs.copperhead.sh/og.png' } },
         { tag: 'meta', attrs: { name: 'twitter:card', content: 'summary_large_image' } },
         { tag: 'meta', attrs: { name: 'twitter:image', content: 'https://docs.copperhead.sh/og.png' } },
+        // Google Analytics, the same property the apex serves (copperhead-site,
+        // src/layouts/Base.astro), so docs traffic lands in one place.
+        {
+          tag: 'script',
+          attrs: { async: true, src: `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}` },
+        },
+        {
+          tag: 'script',
+          content: [
+            'window.dataLayer = window.dataLayer || [];',
+            'function gtag(){dataLayer.push(arguments);}',
+            "gtag('js', new Date());",
+            `gtag('config', '${GA_MEASUREMENT_ID}');`,
+          ].join('\n'),
+        },
       ],
       // `data-icon` picks the leading icon for each row; see SidebarSublist.astro.
       sidebar: [


### PR DESCRIPTION
## What

Adds Google Analytics to the docs site, using the same measurement ID the apex already uses, so docs.copperhead.sh and copperhead.sh report into one property.

## Why

The docs site had no analytics at all. copperhead.sh has been measured since it launched ([Base.astro](https://github.com/copperheadhq/copperhead-site) in the `copperhead-site` repo), so every visit to the docs was invisible: there was no way to tell which pages people actually read, or how much traffic the docs get relative to the landing page.

## Design

Wired through Starlight's `head` config in [astro.config.mjs](docs/astro.config.mjs) rather than a component override, so it reaches every page without touching the theme components. The snippet is byte-for-byte the one the apex serves: the async `gtag/js` loader, then the `dataLayer` bootstrap and `gtag('config', ...)` call.

The measurement ID sits in a named constant next to `REPO`, with a comment pointing at the apex as the other place it lives. It is a public identifier that ships in the HTML of every page, so it is a literal here exactly as it is there, not a secret.

## Spec / OpenSpec

n/a, docs-site configuration only. No spec-level behavior changes.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | n/a (zero src lines changed) |
| Build | `npm run build` (in `docs/`) | pass, clean at 17 pages |
| Unit + offline | `npm test` | n/a (no src or test lines changed) |
| Live-LLM (opt-in) | keyed on `ANTHROPIC_API_KEY` | n/a |

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a, docs-site configuration with no CLI surface.
- Commands run and outcome: built the site and confirmed both tags reach every page, and that the inline snippet matches the apex's.

```text
$ cd docs && npm run build
[build] 17 page(s) built in 2.03s
[build] Complete!

$ # both tags present on every generated page
pages total: 17
with loader script: 17
with config call: 17

$ # as emitted, on the home page
<script async src="https://www.googletagmanager.com/gtag/js?id=G-KGEWCR918W"></script>
<script>window.dataLayer = window.dataLayer || [];
function gtag(){dataLayer.push(arguments);}
gtag('js', new Date());
gtag('config', 'G-KGEWCR918W');</script>
```

## Docs

No content changes; this is site configuration only.

---

## Invariant checklist

This diff changes one file, `docs/astro.config.mjs`, and zero lines under `src/`, so every gated path is unreachable from it.

- [x] **Spec-gated in**: N/A, no change to the agent tool list.
- [x] **Verification-gated out**: N/A, no mutation path touched.
- [x] **`check`/`verify` stays LLM-free and network-free**: N/A, no change to `src/commands/check` or anything it imports. The added network call is in the published site's HTML, not in the CLI.
- [x] **No sexp serialization**: N/A, no change under `src/kicad/`.
- [x] **Sync-obligations ledger**: N/A.
- [x] **Secrets**: N/A. A GA measurement ID is a public identifier that ships in every page's HTML, not a credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
