### PR TITLE
build(nix): add flake packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 node_modules
 dist/
+result
 coverage/
 *.tsbuildinfo
 docs/.astro/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,16 @@ By taking part you agree to our [Code of Conduct](.github/CODE_OF_CONDUCT.md). F
 
 ## Development setup
 
-Requirements: Node.js >= 20 and, for the KiCad integration paths, a local `kicad-cli` on your PATH.
+Requirements: Node.js >= 20 and, for the KiCad integration paths, a local `kicad-cli` on your PATH. The Nix development shell supplies Node.js, git, OpenSpec, and KiCad on Linux. On macOS, install KiCad separately:
 
 ```bash
+nix develop              # optional: enter the pinned tool environment
 npm install
-npm run dev -- --help   # run the CLI from source via tsx
-npm run typecheck       # tsc, no emit
-npm test                # vitest, offline suite
-npm run build           # compile to dist/
+npm run dev -- --help    # run the CLI from source via tsx
+npm run typecheck        # tsc, no emit
+npm test                 # vitest, offline suite
+npm run build            # compile to dist/
+nix flake check          # build and evaluate the Nix package
 ```
 
 The offline test suite runs without any credentials. Integration tests that call an LLM are skipped automatically unless an API key environment variable is present, so `npm test` is safe to run anywhere.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ If you prefer to install manually:
 npm install -g copperhead   # or: npx copperhead check
 ```
 
+With [Nix flakes](https://nixos.wiki/wiki/Flakes), run copperhead with Node.js,
+git, OpenSpec, and (on Linux) KiCad supplied by the pinned environment:
+
+```bash
+nix run github:copperheadhq/copperhead -- --help
+# From a source checkout:
+nix run . -- --help
+```
+
+The flake supports x86-64 Linux, ARM64 Linux, and Apple Silicon macOS. On
+macOS, install the KiCad application separately. Model credentials and
+saved-login provider CLIs remain user configuration.
+
 ### Bootstrap script (macOS and Linux)
 
 Prefer a one-command setup? [`install.sh`](install.sh) checks the prerequisites below, installs copperhead (globally via npm, or built from source when run inside a checkout), and verifies the result with `copperhead doctor`:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/dc5d91f840324650bac8c379428c7037a416959a.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/dc5d91f840324650bac8c379428c7037a416959a.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "Copperhead, an AI agent for KiCad projects";
+
+  inputs = {
+    nixpkgs.url = "https://github.com/NixOS/nixpkgs/archive/dc5d91f840324650bac8c379428c7037a416959a.tar.gz";
+    flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ] (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ self.overlays.default ];
+        };
+      in {
+        packages = {
+          inherit (pkgs) copperhead;
+          default = pkgs.copperhead;
+        };
+
+        checks.default = pkgs.copperhead;
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ pkgs.copperhead ];
+          packages = [
+            pkgs.git
+            pkgs.nodejs_22
+            pkgs.openspec
+          ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.kicad ];
+        };
+      }) // {
+        overlays.default = final: prev: {
+          copperhead = final.callPackage ./pkgs/copperhead.nix { };
+        };
+      };
+}

--- a/pkgs/copperhead.nix
+++ b/pkgs/copperhead.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildNpmPackage,
+  git,
+  kicad,
+  makeWrapper,
+  nodejs_22,
+  openspec,
+  stdenv,
+}:
+
+let
+  runtimePackages = [ git openspec ] ++ lib.optionals stdenv.hostPlatform.isLinux [ kicad ];
+in
+buildNpmPackage {
+  pname = "copperhead";
+  version = (builtins.fromJSON (builtins.readFile ../package.json)).version;
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../LICENSE
+      ../NOTICE
+      ../README.md
+      ../examples
+      ../package-lock.json
+      ../package.json
+      ../src
+      ../tsconfig.json
+    ];
+  };
+
+  nodejs = nodejs_22;
+  npmDepsHash = "sha256-t0hEH/fVsbJFnOLl+LpTdbKqs+j/utyce9t3Ktx4vJU=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    cp -r examples $out/lib/node_modules/copperhead/
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/copperhead \
+      --prefix PATH : ${lib.makeBinPath runtimePackages}
+  '';
+
+  meta = {
+    description = "AI agent that designs, documents, and validates KiCad projects";
+    homepage = "https://copperhead.sh";
+    license = lib.licenses.asl20;
+    mainProgram = "copperhead";
+  };
+}


### PR DESCRIPTION
## What

Adds a pinned Nix flake for running copperhead and entering a complete development environment. The package includes Node.js, git, OpenSpec, and KiCad on Linux, while macOS continues to use the separately installed KiCad application.

## Why

Nix users currently need to install and align each runtime dependency manually. A flake makes the CLI and contributor toolchain reproducible while retaining the existing npm and bootstrap installation paths.

## Design

Build logic lives in [`pkgs/copperhead.nix`](pkgs/copperhead.nix) as a reusable `buildNpmPackage` derivation. [`flake.nix`](flake.nix) only pins inputs, wires the overlay, and exposes package, check, and development-shell outputs.

The installed command wraps its PATH with git and OpenSpec. Linux also receives the pinned KiCad package. KiCad is excluded from the macOS closure because the pinned nixpkgs package is marked broken there, and copperhead already resolves the standard KiCad application path on macOS.

Supported outputs are x86-64 Linux, ARM64 Linux, and Apple Silicon macOS.

## Testing

### Automated test status

| Check | Command | Status |
| --- | --- | --- |
| Typecheck | `npm run typecheck` | pass |
| Build | `npm run build` | pass |
| Markdown | `npm run lint:md` | pass |
| Nix package | `nix build .#copperhead` | pass |
| Nix outputs | `nix flake check --all-systems --no-build` | pass |
| Unit + offline | `npm test` | fail: 937 passed, 1 failed, 21 skipped |
| Live-LLM (opt-in) | API keys not provided | skip |

The remaining unit failure is the timing-sensitive concurrent mutation assertion in `test/mcp-server.test.ts`. This PR does not change application or test code. The KiCad-dependent tests passed after using the stock Nix KiCad footprint table.

### Manual test log (required)

- Sandbox variant used (`create` / `edit`): n/a, packaging-only change with no CLI behavior change.
- Commands run and outcome:

```text
$ nix run . -- --version
0.10.0

$ nix run github:TheCodedKid/copperhead -- --version
0.10.0

$ nix run . -- demo --tour
Tour rendered successfully.

$ nix develop -c sh -c 'node --version; git --version; openspec --version; kicad-cli version'
v22.23.2
git version 2.55.0
1.10.0
10.0.6

$ nix run . -- doctor --json
Node.js, git, OpenSpec, and kicad-cli reported ok. Provider reported the expected failure because no model or API key was configured.
```

## Docs

Updates [`README.md`](README.md) with Nix installation commands and supported platforms. Updates [`CONTRIBUTING.md`](CONTRIBUTING.md) with the Nix development and verification workflow.

---

## Invariant checklist

- [ ] **Spec-gated in**: N/A, packaging only.
- [ ] **Verification-gated out**: N/A, packaging only.
- [ ] **`check`/`verify` stays LLM-free and network-free**: N/A, no application code changed.
- [ ] **No sexp serialization**: N/A, no KiCad code changed.
- [ ] **Sync-obligations ledger**: N/A, no agent code changed.
- [ ] **Secrets**: N/A, no credential or transcript handling changed.
- [ ] **Spec coherence**: N/A, no spec-level behavior changed.
